### PR TITLE
feat(nice_class): create model

### DIFF
--- a/app/admin/nice_class.rb
+++ b/app/admin/nice_class.rb
@@ -1,0 +1,5 @@
+ActiveAdmin.register NiceClass do
+  permit_params :short_description, :explanatory_note
+
+  actions :all, except: [:create, :new]
+end

--- a/app/admin/term.rb
+++ b/app/admin/term.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Term do
+  permit_params :name, :nice_class_id, :reference_id
+end

--- a/app/jobs/load_nice_classes_from_csv_job.rb
+++ b/app/jobs/load_nice_classes_from_csv_job.rb
@@ -1,0 +1,20 @@
+class LoadNiceClassesFromCsvJob < ApplicationJob
+  queue_as :default
+
+  def perform(csv_content)
+    return if csv_content.blank?
+
+    NiceClass.transaction do
+      CSV.parse(csv_content, headers: true) do |row|
+        number = row['number'].to_i
+        short_description = row['short_description']
+        explanatory_note = row['explanatory_note']
+
+        NiceClass.find_or_create_by(number: number) do |nice_class|
+          nice_class.short_description = short_description
+          nice_class.explanatory_note = explanatory_note
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/load_terms_from_csv_job.rb
+++ b/app/jobs/load_terms_from_csv_job.rb
@@ -1,0 +1,21 @@
+require 'csv'
+
+class LoadTermsFromCsvJob < ApplicationJob
+  queue_as :default
+
+  def perform(csv_content, nice_class_id)
+    @nice_class = NiceClass.find_by(id: nice_class_id)
+    return unless @nice_class.present? && csv_content.present?
+
+    Term.transaction do
+      CSV.parse(csv_content, headers: true) do |row|
+        reference_id = row['reference_id'].to_i
+        name = row['name']
+
+        @nice_class.terms.find_or_create_by(reference_id: reference_id) do |term|
+          term.name = name
+        end
+      end
+    end
+  end
+end

--- a/app/models/nice_class.rb
+++ b/app/models/nice_class.rb
@@ -1,0 +1,18 @@
+class NiceClass < ApplicationRecord
+end
+
+# == Schema Information
+#
+# Table name: nice_classes
+#
+#  id                :bigint(8)        not null, primary key
+#  number            :integer          not null
+#  short_description :text
+#  explanatory_note  :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_nice_classes_on_number  (number) UNIQUE
+#

--- a/app/models/nice_class.rb
+++ b/app/models/nice_class.rb
@@ -1,4 +1,6 @@
 class NiceClass < ApplicationRecord
+  has_many :terms, dependent: :destroy
+
 end
 
 # == Schema Information

--- a/app/models/nice_class.rb
+++ b/app/models/nice_class.rb
@@ -1,6 +1,5 @@
 class NiceClass < ApplicationRecord
   has_many :terms, dependent: :destroy
-
 end
 
 # == Schema Information

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,0 +1,23 @@
+class Term < ApplicationRecord
+  belongs_to :nice_class
+end
+
+# == Schema Information
+#
+# Table name: terms
+#
+#  id            :bigint(8)        not null, primary key
+#  reference_id  :integer
+#  name          :string
+#  nice_class_id :bigint(8)        not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_terms_on_nice_class_id  (nice_class_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (nice_class_id => nice_classes.id)
+#

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -269,19 +269,17 @@ ActiveAdmin.setup do |config|
   #
   # To disable/customize for the :admin namespace:
   #
-  #   config.namespace :admin do |admin|
+  config.namespace :admin do |admin|
+    admin.download_links = [:csv]
+  end
   #
   #     # Disable the links entirely
   #     admin.download_links = false
-  #
-  #     # Only show XML & PDF options
-  #     admin.download_links = [:xml, :pdf]
   #
   #     # Enable/disable the links based on block
   #     #   (for example, with cancan)
   #     admin.download_links = proc { can?(:view_download_links) }
   #
-  #   end
 
   # == Pagination
   #

--- a/db/migrate/20230201152555_create_nice_classes.rb
+++ b/db/migrate/20230201152555_create_nice_classes.rb
@@ -1,0 +1,11 @@
+class CreateNiceClasses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :nice_classes do |t|
+      t.integer :number, index: { unique: true }, null: false
+      t.text :short_description
+      t.text :explanatory_note
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230201154312_create_terms.rb
+++ b/db/migrate/20230201154312_create_terms.rb
@@ -1,0 +1,11 @@
+class CreateTerms < ActiveRecord::Migration[6.1]
+  def change
+    create_table :terms do |t|
+      t.integer :reference_id
+      t.string :name
+      t.references :nice_class, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_17_151803) do
+ActiveRecord::Schema.define(version: 2023_02_01_152555) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,7 +41,13 @@ ActiveRecord::Schema.define(version: 2023_01_17_151803) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  create_table "nice_classes", force: :cascade do |t|
+    t.integer "number", null: false
+    t.text "short_description"
+    t.text "explanatory_note"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["number"], name: "index_nice_classes_on_number", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_01_152555) do
+ActiveRecord::Schema.define(version: 2023_02_01_154312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,15 @@ ActiveRecord::Schema.define(version: 2023_02_01_152555) do
     t.index ["number"], name: "index_nice_classes_on_number", unique: true
   end
 
+  create_table "terms", force: :cascade do |t|
+    t.integer "reference_id"
+    t.string "name"
+    t.bigint "nice_class_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["nice_class_id"], name: "index_terms_on_nice_class_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -62,4 +71,5 @@ ActiveRecord::Schema.define(version: 2023_02_01_152555) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "terms", "nice_classes"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,18 @@
+
+require 'csv'
+
 # This file should contain all the record creation needed to seed the database
 # with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 # Write the code in a way that can be executed multiple times without duplicating the information.
-#
-# For example:
-#
-# Country.create(name: "Chile") # BAD
-# Country.find_or_create_by(name: "Chile") # GOOD
-#
+
+nice_classes_content = File.read('lib/seeds/nice_classes.csv')
+LoadNiceClassesFromCsvJob.perform_now(nice_classes_content)
+
+terms_filename_format = 'lib/seeds/class_%s_terms.csv'
+
+NiceClass.all.each do |nice_class|
+  terms_content = File.read(terms_filename_format % nice_class.number)
+
+  LoadTermsFromCsvJob.perform_now(terms_content, nice_class.id)
+end

--- a/spec/factories/nice_classes.rb
+++ b/spec/factories/nice_classes.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :nice_class do
+    number { 1 }
+    short_description { "MyText" }
+    explanatory_note { "MyText" }
+  end
+end

--- a/spec/factories/terms.rb
+++ b/spec/factories/terms.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :term do
+    reference_id { 1 }
+    name { "MyString" }
+    nice_class
+  end
+end

--- a/spec/jobs/load_nice_classes_from_csv_job_spec.rb
+++ b/spec/jobs/load_nice_classes_from_csv_job_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe LoadNiceClassesFromCsvJob, type: :job do
+  let(:csv_content) do
+    <<~CSV
+      number,short_description,explanatory_note
+      1,Short description 1,Explanatory note 1
+      2,Short description 2,Explanatory note 2
+    CSV
+  end
+
+  context 'with valid csv file' do
+    def perform
+      described_class.perform_now(csv_content)
+    end
+
+    it 'creates nice classes' do
+      expect { perform }.to change { NiceClass.count }.by(2)
+    end
+
+    it 'creates nice classes with correct attributes' do
+      perform
+
+      expect(NiceClass.first.number).to eq(1)
+      expect(NiceClass.first.short_description).to eq('Short description 1')
+      expect(NiceClass.first.explanatory_note).to eq('Explanatory note 1')
+    end
+  end
+end

--- a/spec/jobs/load_terms_from_csv_job_spec.rb
+++ b/spec/jobs/load_terms_from_csv_job_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe LoadTermsFromCsvJob, type: :job do
+  let(:csv_content) do
+    <<~CSV
+      reference_id,name
+      1,Term 1
+      2,Term 2
+    CSV
+  end
+
+  context 'with valid nice class and csv file' do
+    let(:nice_class) { create(:nice_class) }
+
+    def perform
+      described_class.perform_now(csv_content, nice_class.id)
+    end
+
+    it 'creates terms' do
+      expect { perform }.to change { nice_class.terms.count }.by(2)
+    end
+
+    it 'creates terms with correct attributes' do
+      perform
+
+      expect(nice_class.terms.first.reference_id).to eq(1)
+      expect(nice_class.terms.first.name).to eq('Term 1')
+    end
+
+    describe 'when term already exists' do
+      let!(:term) { create(:term, nice_class: nice_class, reference_id: 1) }
+
+      it 'does not create term' do
+        expect { perform }.to change { nice_class.terms.count }.by(1)
+      end
+    end
+  end
+
+  context 'with invalid nice class' do
+    let(:csv_file) { Tempfile.new('terms.csv') }
+
+    before do
+      csv_file.write(csv_content)
+    end
+
+    after do
+      csv_file.close!
+    end
+
+    it 'does not create terms' do
+      expect { described_class.perform_now(csv_file, 0) }.not_to (change { Term.count })
+    end
+  end
+end

--- a/spec/models/nice_class_spec.rb
+++ b/spec/models/nice_class_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe NiceClass, type: :model do
+  it 'has a valid factory' do
+    expect(build(:nice_class)).to be_valid
+  end
+end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Term, type: :model do
+  it 'has a valid factory' do
+    expect(build(:term)).to be_valid
+  end
+end


### PR DESCRIPTION
### Contexto
La clasificación de Niza es un sistema que estandariza el registro de marcas. Existen 45 categorías y cuando una persona quiere registrar su marca, debe determinar en qué categorías la quiere registrar. Registrar una marca en menos categorías de las necesarias puede resultar en que la marca no esté suficientemente protegida, mientras que registrarla en más categorías de las necesarias resulta en un costo más alto.
Rnovo es una plataforma para que un usuario pueda obtener asesoría, entre otras cosas, respecto a qué categorías debería registrar su marca. Para ello, debemos tener acceso a la información de la clasificación de niza, la cual es mas o menos constante (se actualiza cada 5 años y la última vez que se actualizó fue el 1 de enero de este año.  

### Qué se esta haciendo
- Se añaden los modelos y relaciones para las clases de niza y sus terminos (subcategorias)
- Se añaden seeds que cargan los CSV añadidos en el PR #1. Estos seeds involucran jobs para prevenir la duplicación de términos y clases ya añadidas.
​
#### En particular hay que revisar
Revisar que el evitar duplicación haga sentido
​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
