### PR TITLE
feat/trademarks-search/add-api

### DIFF
--- a/app/controllers/api/internal/trademarks_controller.rb
+++ b/app/controllers/api/internal/trademarks_controller.rb
@@ -1,0 +1,26 @@
+class Api::Internal::TrademarksController < Api::Internal::BaseController
+  def phonetic_search
+    respond_with tmview_client.phonetic_search(trademark_search_params[:trademark_name])
+  end
+
+  def full_phonetic_search
+    respond_with FullPhoneticTrademarkSearchJob.perform_now(
+      trademark_search_params[:trademark_name],
+      nice_classes
+    )
+  end
+
+  private
+
+  def trademark_search_params
+    params.permit(:format, :trademark_name, nice_class_ids: [])
+  end
+
+  def nice_classes
+    @nice_classes ||= NiceClass.where(id: trademark_search_params[:nice_class_ids])
+  end
+
+  def tmview_client
+    @tmview_client ||= TmviewClient.new(nice_classes: nice_classes)
+  end
+end

--- a/app/jobs/full_phonetic_trademark_search_job.rb
+++ b/app/jobs/full_phonetic_trademark_search_job.rb
@@ -1,0 +1,24 @@
+class FullPhoneticTrademarkSearchJob < ApplicationJob
+  queue_as :default
+
+  def perform(brand_name, nice_classes)
+    @brand_name = brand_name
+    @nice_classes = nice_classes
+
+    results = brand_name_variations.map do |variation|
+      tmview_client.phonetic_search(variation)
+    end
+
+    results.flatten.uniq
+  end
+
+  private
+
+  def brand_name_variations
+    GenerateTrademarkVariationsJob.perform_now(@brand_name)
+  end
+
+  def tmview_client
+    @tmview_client ||= TmviewClient.new(nice_classes: @nice_classes)
+  end
+end

--- a/app/jobs/generate_trademark_variations_job.rb
+++ b/app/jobs/generate_trademark_variations_job.rb
@@ -1,0 +1,72 @@
+class GenerateTrademarkVariationsJob < ApplicationJob
+  queue_as :default
+
+  def perform(trademark_name)
+    @trademark_name = trademark_name.downcase
+
+    if @trademark_name.length < 3
+      [@trademark_name]
+    elsif splitted_name.length == 1
+      variations_for_one_word
+    elsif splitted_name.length.between?(2, 4)
+      variations_for_two_to_four_words
+    else
+      variations_for_more_than_four_words
+    end
+  end
+
+  private
+
+  def variations_for_one_word
+    word = @trademark_name
+    [
+      word,
+      word_without_first_letter(word),
+      word_without_last_letter(word),
+      word_without_vowels(word),
+      word_without_consonants(word)
+    ]
+  end
+
+  def variations_for_two_to_four_words
+    words = splitted_name
+
+    variations = [@trademark_name, *words.dup]
+
+    words.combination(2).each do |combination|
+      variations << combination.join(' ')
+    end
+
+    variations.uniq
+  end
+
+  def variations_for_more_than_four_words
+    words = splitted_name
+    [
+      @trademark_name,
+      words.first,
+      words.last,
+      "#{words.first} #{words.last}"
+    ]
+  end
+
+  def word_without_first_letter(word)
+    word[1..]
+  end
+
+  def word_without_last_letter(word)
+    word[..-2]
+  end
+
+  def word_without_vowels(word)
+    word.gsub(/[aeiou]/, '')
+  end
+
+  def word_without_consonants(word)
+    word.gsub(/[^aeiou]/, '')
+  end
+
+  def splitted_name
+    @splitted_name ||= @trademark_name.split(' ')
+  end
+end

--- a/app/serializers/api/internal/trademark_serializer.rb
+++ b/app/serializers/api/internal/trademark_serializer.rb
@@ -1,0 +1,20 @@
+class Api::Internal::TrademarkSerializer < ActiveModel::Serializer
+  type :trademark
+
+  attributes(
+    :trademark_name,
+    :trademark_office,
+    :application_number,
+    :application_date,
+    :trademark_status,
+    :mark_image_uri,
+    :detail_image_uri,
+    :trademark_standard_code,
+    :score,
+    :nice_classes
+  )
+
+  def read_attribute_for_serialization(attr)
+    object.send(attr)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,12 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :internal do
       resources :terms, only: :index
+      resources :trademarks, only: [] do
+        collection do
+          get :phonetic_search
+          get :full_phonetic_search
+        end
+      end
     end
   end
   resources :terms, only: :index

--- a/spec/jobs/full_phonetic_trademark_search_job_spec.rb
+++ b/spec/jobs/full_phonetic_trademark_search_job_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe FullPhoneticTrademarkSearchJob, type: :job do
+  let(:tmview_client) { instance_double(TmviewClient, phonetic_search: []) }
+
+  before do
+    allow(TmviewClient).to receive(:new).and_return(tmview_client)
+    allow(GenerateTrademarkVariationsJob)
+      .to receive(:perform_now)
+      .and_return(['variation1', 'variation2'])
+  end
+
+  describe '#perform' do
+    let(:brand_name) { 'brand_name' }
+    let(:nice_classes) { [create(:nice_class)] }
+
+    it 'calls GenerateTrademarkVariationsJob' do
+      described_class.perform_now(brand_name, nice_classes)
+      expect(GenerateTrademarkVariationsJob).to have_received(:perform_now).with(brand_name)
+    end
+
+    it 'calls TmviewClient#phonetic_search' do
+      described_class.perform_now(brand_name, nice_classes)
+      expect(tmview_client).to have_received(:phonetic_search).twice
+    end
+
+    it 'returns an array' do
+      expect(described_class.perform_now(brand_name, nice_classes)).to be_a(Array)
+    end
+  end
+end

--- a/spec/jobs/generate_trademark_variations_job_spec.rb
+++ b/spec/jobs/generate_trademark_variations_job_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe GenerateTrademarkVariationsJob, type: :job do
+  describe '#perform' do
+    def perform
+      described_class.perform_now(trademark_name)
+    end
+
+    context 'when the trademark has less than 3 characters' do
+      let(:trademark_name) { 'ab' }
+
+      it { expect(perform).to eq(['ab']) }
+    end
+
+    context 'when the trademark has 3 characters or more' do
+      let(:trademark_name) { 'abcde' }
+
+      it 'Generates 4 variations' do
+        expect(perform).to eq(['abcde', 'bcde', 'abcd', 'bcd', 'ae'])
+      end
+    end
+
+    context 'when the trademark has between 2 and 4 words' do
+      let(:trademark_name) { 'abc def ghi' }
+
+      it 'Generates n words, and their combinations' do
+        expect(perform).to eq(['abc def ghi', 'abc', 'def', 'ghi', 'abc def', 'abc ghi', 'def ghi'])
+      end
+    end
+
+    context 'when the trademark has more than 4 words' do
+      let(:trademark_name) { 'abc def ghi jkl mno' }
+
+      it 'Generates the first, last, and first and last words' do
+        expect(perform).to eq(["abc def ghi jkl mno", "abc", "mno", "abc mno"])
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/trademarks_spec.rb
+++ b/spec/requests/api/internal/trademarks_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Internal::TrademarkController', type: :request do
+  describe 'GET /phonetic_search' do
+    let(:tmview_client) { instance_double(TmviewClient, phonetic_search: []) }
+    let(:params) { { trademark_name: 'MyString', nice_class_ids: [1, 2, 3] } }
+
+    def perform
+      get '/api/internal/trademarks/phonetic_search', params: params
+    end
+
+    before do
+      allow(TmviewClient).to receive(:new).and_return(tmview_client)
+      allow(tmview_client).to receive(:phonetic_search).and_return(['response'])
+      perform
+    end
+
+    it 'calls TmviewClient#phonetic_search' do
+      expect(tmview_client).to have_received(:phonetic_search)
+    end
+
+    it 'returns 200' do
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe 'GET /full_phonetic_search' do
+    let(:params) { { trademark_name: 'MyString', nice_class_ids: [1, 2, 3] } }
+
+    def perform
+      get '/api/internal/trademarks/full_phonetic_search', params: params
+    end
+
+    before do
+      allow(FullPhoneticTrademarkSearchJob).to receive(:perform_now).and_return(['response'])
+      perform
+    end
+
+    it 'calls FullPhoneticTrademarkSearchJob#perform_now' do
+      expect(FullPhoneticTrademarkSearchJob).to have_received(:perform_now)
+    end
+
+    it 'returns 200' do
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
### Contexto

Rnovo es una plataforma que permite realizar búsquedas marcarías con el objetivo de ofrecer un flujo de registro de marcas y propiedad intelectual. En dicho contexto, una de las funcionalidades clave es el poder buscar marcas en el registro marcario internacional y para comparar fonéticamente.

Como proveedor de búsqueda fonética sobre base de datos marcaría se seleccionó a la NGO tmdn.org. Donde se utiliza su buscador `TmView`

​
### Qué se esta haciendo

Este PR incluye el MVP de api para buscador marcario. Con principal foco en minimizar los tiempos de respuesta se realizan dos tipos de busqueda. La busqueda fonetica base y la completa. Donde la completa genera derivaciones de la marca a buscar. 


En orden de commits

1. Se crea un job que genera variaciones de una marca
2. Se crea un job que realiza la busqueda para estas variaciones
3. Se crea un controller para buscar mediante api interna
#### En particular hay que revisar
​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
