### PR TITLE
Feat/trademarks/integrate-full-search

### DIFF
--- a/app/controllers/api/internal/trademarks_controller.rb
+++ b/app/controllers/api/internal/trademarks_controller.rb
@@ -1,13 +1,16 @@
 class Api::Internal::TrademarksController < Api::Internal::BaseController
   def phonetic_search
-    respond_with tmview_client.phonetic_search(trademark_search_params[:trademark_name])
+    respond_with PhoneticTrademarkSearchJob.perform_now(
+      brand_name,
+      nice_classes
+    ), each_serializer: Api::Internal::TrademarkSerializer
   end
 
   def full_phonetic_search
     respond_with FullPhoneticTrademarkSearchJob.perform_now(
-      trademark_search_params[:trademark_name],
+      brand_name,
       nice_classes
-    )
+    ), each_serializer: Api::Internal::TrademarkSerializer
   end
 
   private
@@ -16,11 +19,11 @@ class Api::Internal::TrademarksController < Api::Internal::BaseController
     params.permit(:format, :trademark_name, nice_class_ids: [])
   end
 
-  def nice_classes
-    @nice_classes ||= NiceClass.where(id: trademark_search_params[:nice_class_ids])
+  def brand_name
+    @brand_name ||= trademark_search_params[:trademark_name]
   end
 
-  def tmview_client
-    @tmview_client ||= TmviewClient.new(nice_classes: nice_classes)
+  def nice_classes
+    @nice_classes ||= NiceClass.where(id: trademark_search_params[:nice_class_ids])
   end
 end

--- a/app/javascript/components/trademark-search.vue
+++ b/app/javascript/components/trademark-search.vue
@@ -23,12 +23,21 @@ const search = reactive({
 
 const selectedClassIds = computed(() => search.niceClassIds.map((niceClass) => niceClass.id.toString()));
 
-const { data: trademarks, refetch, isFetching, isError } = useQuery(
+const { data: trademarks, refetch, isFetching, isSuccess, isError } = useQuery(
   ['trademarks', search.name, selectedClassIds.value],
   () => trademarkApi.phoneticSearch(search.name, selectedClassIds.value),
   {
     refetchOnWindowFocus: false,
     enabled: false,
+  },
+);
+
+const { data: trademarksComplete } = useQuery(
+  ['trademarksComplete', search.name, selectedClassIds.value],
+  () => trademarkApi.fullPhoneticSearch(search.name, selectedClassIds.value),
+  {
+    refetchOnWindowFocus: false,
+    enabled: isSuccess,
   },
 );
 
@@ -132,6 +141,48 @@ const { data: trademarks, refetch, isFetching, isError } = useQuery(
             </div>
           </div>
         </div>
+      </div>
+      <div
+        v-if="trademarksComplete?.length > 0"
+        class="mt-5"
+      >
+        <h2 class="mb-2 text-2xl font-bold">
+          {{ t('trademarkSearch.completeResults') }}
+        </h2>
+
+        <div
+          v-for="trademark in trademarksComplete"
+          :key="trademark.applicationNumber"
+          class="my-2 flex flex-col gap-5"
+        >
+          <div class="flex w-full flex-col justify-between rounded-lg border bg-slate-200 p-2">
+            <div class="flex justify-between">
+              <div class="flex flex-col gap-1">
+                <h3 class="text-base">
+                  {{ trademark.trademarkName }}
+                </h3>
+                <p class="text-xs">
+                  {{ t('trademarkSearch.score') }}: {{ trademark.score }}%
+                </p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <div class="flex gap-1">
+                  <span class="text-xs font-bold">
+                    {{ t('trademarkSearch.applicationNumber') }}
+                  </span>
+                  <span class="text-xs">
+                    {{ trademark.applicationNumber }}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        v-else-if="trademarks?.length === 0"
+      >
+        <p>{{ t('trademarkSearch.noResults') }}</p>
       </div>
     </div>
   </div>

--- a/app/javascript/locales/es.ts
+++ b/app/javascript/locales/es.ts
@@ -15,6 +15,8 @@ export const esLocale = {
     error: 'Hubo un error inesperado, inténtalo nuevamente.',
     loading: 'Buscando marcas...',
     results: 'Resultados',
+    completeResults: 'Resultados adicionales',
+    noResults: 'No se encontraron marcas.',
     search: 'Buscar',
     searchLabel: 'Buscar marca',
     niceClassHint: 'Seleccionar Clases de Niza',

--- a/app/jobs/full_phonetic_trademark_search_job.rb
+++ b/app/jobs/full_phonetic_trademark_search_job.rb
@@ -5,11 +5,13 @@ class FullPhoneticTrademarkSearchJob < ApplicationJob
     @brand_name = brand_name
     @nice_classes = nice_classes
 
+    return [] if @brand_name.blank?
+
     results = brand_name_variations.map do |variation|
       tmview_client.phonetic_search(variation)
     end
 
-    results.flatten.uniq
+    results.flatten.sort_by(&:score).reverse.uniq(&:application_number)
   end
 
   private

--- a/app/jobs/phonetic_trademark_search_job.rb
+++ b/app/jobs/phonetic_trademark_search_job.rb
@@ -1,0 +1,22 @@
+class PhoneticTrademarkSearchJob < ApplicationJob
+  queue_as :default
+
+  def perform(brand_name, nice_classes)
+    @brand_name = brand_name
+    @nice_classes = nice_classes
+
+    return [] if @brand_name.blank?
+
+    phonetic_search_results.sort_by(&:score).reverse
+  end
+
+  private
+
+  def phonetic_search_results
+    @phonetic_search_results ||= tmview_client.phonetic_search(@brand_name)
+  end
+
+  def tmview_client
+    @tmview_client ||= TmviewClient.new(nice_classes: @nice_classes)
+  end
+end

--- a/spec/jobs/phonetic_trademark_search_job_spec.rb
+++ b/spec/jobs/phonetic_trademark_search_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe PhoneticTrademarkSearchJob, type: :job do
+  let(:tmview_client) { instance_double(TmviewClient, phonetic_search: []) }
+
+  before do
+    allow(TmviewClient).to receive(:new).and_return(tmview_client)
+  end
+
+  describe '#perform' do
+    let(:brand_name) { 'brand_name' }
+    let(:nice_classes) { [create(:nice_class)] }
+
+    it 'calls TmviewClient#phonetic_search' do
+      described_class.perform_now(brand_name, nice_classes)
+      expect(tmview_client).to have_received(:phonetic_search)
+    end
+
+    it 'returns an array' do
+      expect(described_class.perform_now(brand_name, nice_classes)).to be_a(Array)
+    end
+  end
+end


### PR DESCRIPTION
### Contexto

Rnovo es una plataforma que permite realizar búsquedas marcarías con el objetivo de ofrecer un flujo de registro de marcas y propiedad intelectual. En dicho contexto, una de las funcionalidades clave es el poder buscar marcas en el registro marcario internacional y para comparar fonéticamente.

Como proveedor de búsqueda fonética sobre base de datos marcaría se seleccionó a la NGO tmdn.org. Donde se utiliza su buscador `TmView`

​
### Qué se esta haciendo

Este PR incluye mejoras a la funcionalidad ya implementada. Añadiendo un job para abstraer la logica de la busqueda, agregando el ordenar y resultados uniq. Y finalmente integrando la busqueda completa

En orden de commits

1. Se crea job para abstraer la busqueda
2. Se ordenan los resultados y se filtran
3. Se agrega la busqueda completa al frontend
#### En particular hay que revisar
​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
