### PR TITLE
fix/trademarks/add-refetch-function

### DIFF
--- a/app/javascript/components/trademark-search.vue
+++ b/app/javascript/components/trademark-search.vue
@@ -32,7 +32,7 @@ const { data: trademarks, refetch, isFetching, isSuccess, isError } = useQuery(
   },
 );
 
-const { data: trademarksComplete } = useQuery(
+const { data: trademarksComplete, refetch: refetchComplete, isFetching: isFetchingComplete } = useQuery(
   ['trademarksComplete', search.name, selectedClassIds.value],
   () => trademarkApi.fullPhoneticSearch(search.name, selectedClassIds.value),
   {
@@ -40,6 +40,11 @@ const { data: trademarksComplete } = useQuery(
     enabled: isSuccess,
   },
 );
+
+function submit() {
+  refetch();
+  refetchComplete();
+}
 
 </script>
 <template>
@@ -64,7 +69,7 @@ const { data: trademarksComplete } = useQuery(
       />
 
       <base-button
-        @click="refetch"
+        @click="submit"
       >
         {{ t('trademarkSearch.search') }}
       </base-button>
@@ -143,7 +148,13 @@ const { data: trademarksComplete } = useQuery(
         </div>
       </div>
       <div
-        v-if="trademarksComplete?.length > 0"
+        v-if="isFetchingComplete"
+        class="text-sm"
+      >
+        <p>{{ t('trademarkSearch.completeLoading') }}</p>
+      </div>
+      <div
+        v-else-if="trademarksComplete?.length > 0"
         class="mt-5"
       >
         <h2 class="mb-2 text-2xl font-bold">

--- a/app/javascript/locales/es.ts
+++ b/app/javascript/locales/es.ts
@@ -14,6 +14,7 @@ export const esLocale = {
   trademarkSearch: {
     error: 'Hubo un error inesperado, inténtalo nuevamente.',
     loading: 'Buscando marcas...',
+    completeLoading: 'Cargando resultados adicionales...',
     results: 'Resultados',
     completeResults: 'Resultados adicionales',
     noResults: 'No se encontraron marcas.',


### PR DESCRIPTION
### Contexto
En Rnovo hay un buscador de marcas que invoca dos búsquedas, una búsqueda base y luego una exhaustiva. En ese contexto, la exhaustiva se ejecuta solo luego de que la base ya esté finalizada.

En caso de realizar una nueva busqueda no se ejecutaban ambos llamados a la API, por lo que se agrega un submit que garantiza que se llamaran siempre ambos. Sin embargo, igualmente esta el parámetro `enabled` para evitar que se realice la segunda llamada sin que la primera este lista. ​


### Qué se esta haciendo
​
#### En particular hay que revisar
​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
