### PR TITLE
Feat/inapi terms

### DIFF
--- a/app/admin/term.rb
+++ b/app/admin/term.rb
@@ -1,3 +1,3 @@
 ActiveAdmin.register Term do
-  permit_params :name, :nice_class_id, :reference_id
+  permit_params :name, :nice_class_id
 end

--- a/app/jobs/load_terms_from_csv_job.rb
+++ b/app/jobs/load_terms_from_csv_job.rb
@@ -8,13 +8,10 @@ class LoadTermsFromCsvJob < ApplicationJob
     return unless @nice_class.present? && csv_content.present?
 
     Term.transaction do
-      CSV.parse(csv_content, headers: true) do |row|
-        reference_id = row['reference_id'].to_i
+      CSV.parse(csv_content, headers: true, col_sep: '|') do |row|
         name = row['name']
 
-        @nice_class.terms.find_or_create_by(reference_id: reference_id) do |term|
-          term.name = name
-        end
+        @nice_class.terms.find_or_create_by(name: name)
       end
     end
   end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -11,7 +11,6 @@ end
 # Table name: terms
 #
 #  id            :bigint(8)        not null, primary key
-#  reference_id  :integer
 #  name          :string
 #  nice_class_id :bigint(8)        not null
 #  created_at    :datetime         not null

--- a/app/serializers/api/internal/term_serializer.rb
+++ b/app/serializers/api/internal/term_serializer.rb
@@ -3,7 +3,6 @@ class Api::Internal::TermSerializer < ActiveModel::Serializer
 
   attributes(
     :id,
-    :reference_id,
     :name,
     :nice_class_id
   )

--- a/db/migrate/20230222185149_remove_reference_id_from_terms.rb
+++ b/db/migrate/20230222185149_remove_reference_id_from_terms.rb
@@ -1,0 +1,5 @@
+class RemoveReferenceIdFromTerms < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :terms, :reference_id, :integer }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_09_131014) do
+ActiveRecord::Schema.define(version: 2023_02_22_185149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -53,7 +53,6 @@ ActiveRecord::Schema.define(version: 2023_02_09_131014) do
   end
 
   create_table "terms", force: :cascade do |t|
-    t.integer "reference_id"
     t.string "name"
     t.bigint "nice_class_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/lib/seeds/class_10_terms.csv
+++ b/lib/seeds/class_10_terms.csv
@@ -1,317 +1,449 @@
-class,reference_id,name
-10,100001,cinturones abdominales
-10,100002,cinturones hipogástricos
-10,100003,fajas abdominales
-10,100004,colchones para el parto
-10,100005,dispositivos de ayuda auditiva
-10,100005,audífonos de corrección auditiva
-10,100006,trompetillas acústicas
-10,100007,grapas quirúrgicas
-10,100008,agujas para uso médico
-10,100009,agujas de sutura
-10,100010,pesarios
-10,100011,aparatos terapéuticos de aire caliente
-10,100012,vibradores de aire caliente para uso médico
-10,100013,protectores de colchón [salvacamas]
-10,100013,salvacamas
-10,100014,sábanas para la incontinencia [empapadores]
-10,100015,catéteres
-10,100017,bombillas radiógenas para uso médico
-10,100017,tubos de material radioactivo para uso médico
-10,100018,anillos de dentición [mordedores]
-10,100020,vendas ortopédicas para las articulaciones
-10,100021,férulas para uso quirúrgico
-10,100022,vendas elásticas
-10,100023,bandas galvánicas para uso médico
-10,100024,aparatos de rayos X para uso médico
-10,100025,cuñas [orinales]
-10,100025,cómodos [orinales]
-10,100026,palanganas para uso médico
-10,100027,aparatos obstétricos para el ganado
-10,100028,biberones*
-10,100029,bisturís
-10,100029,incisores [tenazas incisorias] para uso quirúrgico
-10,100030,escalpelos
-10,100031,botas para uso médico
-10,100033,tientas quirúrgicas
-10,100034,escupideras para uso médico
-10,100034,salivaderas para uso médico
-10,100035,catgut [material de sutura]
-10,100036,camillas con ruedas
-10,100037,camillas para enfermos
-10,100037,angarillas
-10,100037,camillas de ambulancia
-10,100038,artículos ortopédicos
-10,100039,bragueros [vendas para hernias]
-10,100039,vendas para hernias [bragueros]
-10,100040,soportes del arco del pie para el calzado
-10,100041,camisas de fuerza
-10,100042,cánulas
-10,100043,guantes para uso médico
-10,100044,aparatos para limpiar las cavidades del cuerpo
-10,100045,cinturones médicos
-10,100046,fajas de embarazo
-10,100047,fajas ortopédicas
-10,100048,sillones de dentista
-10,100049,pinzas para castrar
-10,100050,almohadillas electrotérmicas para uso médico
-10,100051,calzado ortopédico
-10,100052,dientes artificiales
-10,100053,esponjas quirúrgicas
-10,100054,aparatos e instrumentos quirúrgicos
-10,100055,estuches de médico
-10,100056,hilo quirúrgico
-10,100057,aparatos de anestesia
-10,100058,tijeras quirúrgicas
-10,100059,compresas electrotérmicas [cirugía]
-10,100060,compresores [cirugía]
-10,100061,cuentagotas para uso médico
-10,100061,goteros para uso médico
-10,100062,cortacallos
-10,100063,aparatos para masajes estéticos
-10,100064,cojines para uso médico
-10,100064,almohadones para uso médico
-10,100065,instrumentos cortantes para uso quirúrgico
-10,100067,incubadoras para uso médico
-10,100069,cucharas para medicamentos
-10,100070,limpiadores linguales [raspadores de lengua]
-10,100070,raspadores de lengua
-10,100071,limpiadores de oídos
-10,100072,fresas para uso odontológico
-10,100073,aparatos e instrumentos odontológicos
-10,100074,pivotes para dientes artificiales
-10,100076,dentaduras postizas
-10,100077,lancetas
-10,100078,espejos de dentista
-10,100079,dediles para uso médico
-10,100080,jeringas para inyecciones
-10,100081,drenajes para uso médico
-10,100081,tubos de drenaje para uso médico
-10,100082,bolsas de agua para uso médico
-10,100083,pantallas radiológicas para uso médico
-10,100084,electrocardiógrafos
-10,100085,sondas para uso médico
-10,100086,bombas para uso médico
-10,100087,aparatos para análisis de sangre
-10,100088,sillones para uso médico u odontológico
-10,100089,frascos cuentagotas para uso médico
-10,100090,fórceps
-10,100091,aparatos galvánicos para uso terapéutico
-10,100092,guantes para masajes
-10,100093,gastroscopios
-10,100094,bolsas de hielo para uso médico
-10,100095,hemocitómetros
-10,100096,camas de agua para uso médico
-10,100097,jeringas hipodérmicas
-10,100098,almohadillas abdominales
-10,100098,almohadillas hipogástricas
-10,100099,inhaladores
-10,100100,inyectores para uso médico
-10,100101,almohadas contra el insomnio
-10,100102,aparatos e instrumentos urológicos
-10,100103,insufladores
-10,100104,enemas para uso médico
-10,100105,lámparas de rayos ultravioleta para uso médico
-10,100106,láseres para uso médico
-10,100107,sacaleches
-10,100107,tiraleches
-10,100108,lámparas para uso médico
-10,100109,vaporizadores para uso médico
-10,100110,orinales
-10,100111,mandíbulas artificiales
-10,100112,mascarillas de anestesia
-10,100113,aparatos de masaje
-10,100114,aparatos e instrumentos médicos
-10,100115,recipientes para aplicar medicamentos
-10,100116,maletines especiales para instrumental médico
-10,100117,prótesis
-10,100117,miembros artificiales
-10,100118,espejos para cirujanos
-10,100119,mobiliario especial para uso médico
-10,100120,aparatos obstétricos
-10,100121,fajas umbilicales
-10,100122,oftalmómetros
-10,100123,oftalmoscopios
-10,100124,aparatos para proteger el oído
-10,100125,piel artificial para uso quirúrgico
-10,100126,conteras de muletas
-10,100127,pistolas de bolos para uso veterinario
-10,100127,aplicadores de bolos para uso veterinario
-10,100128,preservativos
-10,100128,condones
-10,100129,esfigmomanómetros
-10,100129,aparatos para medir la tensión arterial
-10,100129,tensiómetros
-10,100130,lámparas de cuarzo para uso médico
-10,100131,aparatos e instrumentos generadores de rayos X para uso médico
-10,100132,radiografías para uso médico
-10,100133,aparatos de radiología para uso médico
-10,100134,aparatos de radioterapia
-10,100135,aparatos de reanimación
-10,100136,tubos de rayos X para uso médico
-10,100137,dispositivos de protección contra los rayos X para uso médico
-10,100138,respiradores
-10,100139,aparatos para la respiración artificial
-10,100140,sierras quirúrgicas
-10,100141,prótesis mamarias
-10,100142,jeringas uterinas
-10,100143,jeringas vaginales
-10,100144,estetoscopios
-10,100145,chupetes para bebés
-10,100146,soportes para los pies planos
-10,100147,aparatos para tratar la sordera
-10,100148,suspensorios [vendas]
-10,100149,material de sutura
-10,100150,mesas de operaciones
-10,100151,trocares
-10,100153,sondas uretrales
-10,100154,jeringas uretrales
-10,100155,ventosas para uso médico
-10,100156,aparatos e instrumentos veterinarios
-10,100157,aparatos vibratorios para camas
-10,100158,vibradores
-10,100159,ojos artificiales
-10,100160,pulverizadores de aerosol para uso médico
-10,100161,almohadas de aire para uso médico
-10,100162,cojines de aire para uso médico
-10,100162,almohadones de aire para uso médico
-10,100163,colchones de aire para uso médico
-10,100164,jeringas para uso médico
-10,100165,medias elásticas para uso quirúrgico
-10,100166,medias para varices
-10,100166,medias para várices
-10,100168,muletas
-10,100169,cierres de biberones
-10,100170,tetinas de biberones
-10,100171,plantillas ortopédicas
-10,100172,campos quirúrgicos [sábanas estériles]
-10,100173,camas especiales para cuidados médicos
-10,100174,electrodos para uso médico
-10,100175,cinturones eléctricos para uso médico
-10,100176,aparatos de ejercicio físico para uso médico
-10,100177,incubadoras para recién nacidos
-10,100178,cepillos quirúrgicos para limpiar las cavidades corporales
-10,100179,aparatos dentales eléctricos
-10,100180,aparatos de análisis para uso médico
-10,100181,filtros de rayos ultravioleta para uso médico
-10,100182,aparatos de fumigación para uso médico
-10,100183,corsés para uso médico
-10,100184,contraceptivos que no sean químicos
-10,100184,anticonceptivos que no sean químicos
-10,100191,mantas eléctricas para uso médico
-10,100191,cobertores eléctricos para uso médico
-10,100191,cobijas eléctricas para uso médico
-10,100192,prótesis capilares
-10,100193,rodilleras ortopédicas
-10,100194,lentes de contacto [prótesis intraoculares] para implantación quirúrgica
-10,100194,prótesis intraoculares [lentes de contacto] para implantación quirúrgica
-10,100195,almohadillas antiescaras
-10,100195,almohadillas antillagas
-10,100196,aparatos de fisioterapia
-10,100197,espirómetros [aparatos médicos]
-10,100198,termómetros para uso médico
-10,100199,agujas de acupuntura
-10,100200,ropa especial para quirófano
-10,100201,aparatos de diagnóstico para uso médico
-10,100202,instrumentos eléctricos de acupuntura
-10,100203,estimuladores cardíacos [marcapasos]
-10,100203,marcapasos [estimuladores cardíacos]
-10,100204,grúas para pacientes
-10,100204,grúas de elevación para pacientes
-10,100205,mascarillas para personal médico
-10,100206,vendas de escayola para uso ortopédico
-10,100206,vendas de yeso para uso ortopédico
-10,100207,sábanas quirúrgicas
-10,100208,implantes quirúrgicos compuestos de materiales artificiales
-10,100209,almohadillas térmicas para primeros auxilios
-10,100210,sillas orinal
-10,100210,sillas cómodo
-10,100211,desfibriladores
-10,100212,dializadores
-10,100213,hilos de guía para uso médico
-10,100214,aparatos de ortodoncia
-10,100215,aparatos de tracción para uso médico
-10,100216,recipientes especiales para desechos médicos
-10,100217,cabestrillos [vendas de soporte]
-10,100218,bolsas para lavados internos
-10,100219,muñecas eróticas [muñecas sexuales]
-10,100219,muñecas sexuales
-10,100220,aparatos de microdermoabrasión
-10,100221,aparatos de rehabilitación física para uso médico
-10,100222,pulsímetros
-10,100222,esfigmómetros
-10,100223,estents
-10,100223,endoprótesis vasculares [estents]
-10,100224,tapones auditivos
-10,100224,tapones para los oídos
-10,100225,etiquetas indicadoras de la temperatura para uso médico
-10,100226,andadores para personas discapacitadas
-10,100227,tomógrafos para uso médico
-10,100228,aparatos para el tratamiento del acné
-10,100229,peines antipiojos
-10,100230,bastones de cuatro patas para uso médico
-10,100231,cámaras endoscópicas para uso médico
-10,100232,aparatos de monitorizacion de la frecuencia cardíaca
-10,100233,prendas de compresión
-10,100234,juguetes sexuales
-10,100235,estimuladores cerebrales
-10,100236,dispositivos implantables para la administración subcutánea de fármacos
-10,100237,implantes biodegradables de fijación ósea
-10,100238,depresores linguales para uso médico
-10,100238,bajalenguas para uso médico
-10,100239,aspiradores nasales
-10,100240,protectores bucales para uso odontológico
-10,100241,copas menstruales
-10,100242,mascarillas respiratorias para la respiración artificial
-10,100243,elásticos de ortodoncia
-10,100243,ligas de ortodoncia
-10,100244,dispositivos de análisis para la identificación de bacterias para uso médico
-10,100245,aparatos de tests de ADN y ARN para uso médico
-10,100246,aparatos para la regeneración de células madre para uso médico
-10,100247,monitores de grasa corporal
-10,100248,monitores de composición corporal
-10,100249,separadores interdigitales para uso ortopédico
-10,100250,pulseras antirreumáticas
-10,100250,pulseras para el reumatismo
-10,100251,anillos antirreumáticos
-10,100251,anillos para el reumatismo
-10,100252,pulseras para uso médico
-10,100253,robots quirúrgicos
-10,100254,chupetes alimentadores para bebés
-10,100255,pulseras antináuseas
-10,100256,andadores con ruedas
-10,100257,inhaladores de hidrógeno
-10,100258,aparatos de imagenología por resonancia magnética [IRM] para uso médico
-10,100259,camas de aire para uso médico
-10,100260,parches de enfriamiento para uso médico
-10,100261,almohadillas de enfriamiento para primeros auxilios
-10,100262,dispositivos urinarios portátiles
-10,100263,bastones para uso médico
-10,100264,trajes robóticos de exoesqueleto para uso médico
-10,100265,bandas de acupresión
-10,100266,clips sujetachupetes
-10,100266,clips sujetatetinas
-10,100267,analizadores de colesterol
-10,100268,batas de reconocimiento para pacientes
-10,100269,anillos biomagnéticos para uso terapéutico o médico
-10,100270,antifaces terapéuticos
-10,100271,masajeadores de encías para bebés
-10,100272,trituradores de pastillas
-10,100273,medidores de glucosa en sangre
-10,100273,glucómetros
-10,100274,lámparas de curado para uso médico
-10,100275,rellenos óseos compuestos de materiales artificiales
-10,100276,cámaras de inhalación
-10,100276,espaciadores para inhaladores
-10,100277,mesas de reconocimiento médico
-10,100278,nanorrobots para uso médico
-10,100278,robots nanométricos para uso médico
-10,100279,vendajes neuromusculares 
-10,100280,aparatos médicos de enfriamiento para tratar golpes de calor
-10,100281,aparatos médicos de enfriamiento para la hipotermia terapéutica
-10,100282,cortadores de comprimidos
-10,100283,mascarillas higiénicas para uso médico
-10,100284,máscaras de LED para uso terapéutico
-10,100285,concentradores de oxígeno para uso médico
-10,100286,vendas de sujeción
-10,100287,cascos para el tratamiento con láser de la alopecia
+class|name
+10|Abrazaderas para uso quirúrgico
+10|Abrazaderas pélvicas de emergencia
+10|Agujas de extracción de sangre
+10|Agujas de inyección
+10|Agujas de inyección para uso médico
+10|Agujas de sutura
+10|Agujas Luer lock para uso médico
+10|Agujas para biopsia
+10|Agujas para fístulas
+10|Agujas para inyecciones
+10|Agujas para uso médico
+10|Alambres de cerclaje
+10|Alambres de guía para uso médico y piezas y acoples para ellos
+10|Alicates quirúrgicos
+10|Alineadores dentales
+10|Almohadas cervicales para uso médico
+10|Almohadillas abdominales para uso médico
+10|Almohadillas dorsales para uso médico
+10|Almohadillas enfriantes para uso en primeros auxilios
+10|Amputadores quirúrgicos
+10|Analizadores de composición corporal para uso médico
+10|Analizadores de humedad de la piel para uso médico
+10|Anoscopios
+10|Anticonceptivos (aparatos)
+10|Aparato de enemas
+10|Aparatos automáticos de vacunación
+10|Aparatos de cromatografía de gas para uso médico
+10|Aparatos de diagnóstico médico para analizar virus
+10|Aparatos de ejercicio físico para uso médico
+10|Aparatos de entrenamiento físico para uso médico
+10|Aparatos de infusión de uso terapéutico
+10|Aparatos de lavado de uso terapéutico
+10|Aparatos de masaje
+10|Aparatos de masaje para cuello y hombros
+10|Aparatos de masaje para los ojos
+10|Aparatos de masaje para los pies
+10|Aparatos de masaje para uso médico
+10|Aparatos de masaje para uso personal
+10|Aparatos de medida del ritmo cardiaco
+10|Aparatos de polimerización con una finalidad dental
+10|Aparatos de radioterapia
+10|Aparatos de rayos X para imágenes odontológicas
+10|Aparatos de rayos X para uso dental y médico
+10|Aparatos de rayos X para uso médico
+10|Aparatos de taladrado para aplicaciones quirúrgicas y dentales
+10|Aparatos de terapia eléctrica y estática
+10|Aparatos de termoterapia para uso médico
+10|Aparatos de ultrasonido para diagnóstico médico
+10|Aparatos de ultrasonido para uso médico
+10|Aparatos dentales para el tratamiento de la apnea obstructiva del sueño
+10|Aparatos e instrumentos médicos relacionados con la reactividad neurovegetativa
+10|Aparatos e instrumentos quirúrgicos
+10|Aparatos e instrumentos quirúrgicos para uso médico, odontológico o veterinario
+10|Aparatos e instrumentos utilizados en cirugías de pies
+10|Aparatos eléctricos de masajes para uso doméstico
+10|Aparatos eléctricos terapéuticos de baja frecuencia
+10|Aparatos médicos de radiación
+10|Aparatos médicos para introducir preparados farmacéuticos en el cuerpo humano
+10|Aparatos ortopédicos para pies zambos
+10|Aparatos ortopédicos vertebrales
+10|Aparatos para análisis de sangre
+10|Aparatos para desfibrilación cardiaca
+10|Aparatos para diagnóstico clínico
+10|Aparatos para extracción de sangre
+10|Aparatos para facilitar la inhalación de preparaciones farmacéuticas para uso médico
+10|Aparatos para la extracción de muestras sangre
+10|Aparatos para la moxibustión
+10|Aparatos para la terapia de acupresión
+10|Aparatos para limpiar las cavidades del cuerpo
+10|Aparatos para magnetoterapia
+10|Aparatos para medir la tensión arterial
+10|Aparatos para transfusión de sangre
+10|Aparatos terapéuticos electromagnéticos de alta frecuencia
+10|Aparatos ultrasónicos para uso veterinario
+10|Aparatos utilizados en la implementación de exámenes de diagnóstico para detectar la proteína anormal prion
+10|Apoyos acústicos para discapacitados auditivos
+10|Articulaciones artificiales
+10|Artroscopios
+10|Aspiradores eléctricos de esputo
+10|Aspiradores manuales de esputo
+10|Atomizadores para uso médico
+10|Audífonos de funcionamiento eléctrico
+10|Audífonos digitales
+10|Audífonos eléctricos
+10|Audífonos para discapacitados auditivos (apoyos acústicos)
+10|Autorefractores optométricos (de uso oftalmológico)
+10|Ayudas para caminar para uso médico
+10|Bandejas para la impresión dental
+10|Batas médicas de aislamiento
+10|Bateas de emesis
+10|Biberones para bebé
+10|Biómetros para lentes intraoculares
+10|Bisturíes eléctricos para uso quirúrgico
+10|Bisturíes para uso médico
+10|Bisturíes quirúrgicos
+10|Bolsas para duchas vaginales
+10|Bombas de insulina
+10|Botellas de lactancia para bebes
+10|Botellas para guardar leche materna
+10|Broncoscopios
+10|Broncoscopios flexibles
+10|Broncoscopios rígidos
+10|Cabestrillos
+10|Cabestrillos (vendas de soporte)
+10|Cabestrillos para hombros (para rehabilitación)
+10|Calcetines para diabéticos
+10|Calibres cutáneos para uso médico
+10|Cámaras de oxígeno hiperbárico con una finalidad médica
+10|Cámaras de rayos gamma para uso médico
+10|Cámaras endoscópicas
+10|Cámaras oftálmicas para uso médico
+10|Camas de agua para uso médico
+10|Camas de masaje para uso médico
+10|Camillas
+10|Camillas de emergencias
+10|Camillas de hospital
+10|Camillas para enfermos
+10|Camillas para pacientes
+10|Camillas para pacientes bariátricos
+10|Camillas para transporte de pacientes
+10|Camisas de fuerza
+10|Cánulas
+10|Cánulas para anestésicos con recipientes
+10|Cartílago artificial
+10|Catéter intracardiaco
+10|Catéteres
+10|Catéteres de balón
+10|Catéteres eléctricos de uso quirúrgico
+10|Catéteres médicos
+10|Catéteres para uso médico y quirúrgico
+10|Catéteres urinarios
+10|Catéteres venosos centrales
+10|Catgut quirúrgico
+10|Cauterios de platino para uso quirúrgico
+10|Chupetes (tetinas)
+10|Cintas de kinesiología
+10|Cinturones abdominales para uso médico
+10|Citoscopios
+10|Clavos intramedulares
+10|Coderas para epicondilitis
+10|Cojines de hielo para uso medico
+10|Cojines inflables para uso médico
+10|Cojines ortopédicos
+10|Colchones de apoyo para uso médico
+10|Collares cervicales
+10|Collarines cónicos (collares isabelinos) para uso veterinario
+10|Colposcopios
+10|Conexiones de tornillos médicos
+10|Conexiones Luer para uso médico
+10|Contenedores de muestras médicas
+10|Contenedores especialmente adaptados para la eliminación de instrumentos médicos, jeringas y otros desechos médicos contaminados
+10|Contrafuertes de implantes para fines dentales
+10|Copas menstruales
+10|Corazones artificiales y sus partes
+10|Coronas dentales
+10|Correctores dentales (frenillos)
+10|Cortadores de píldoras
+10|Cortadores médicos y quirúrgicos para cortar tejido y órganos humano y animal
+10|Cucharas para administrar medicamentos
+10|Cuchillos médicos y quirúrgicos para cortar tejido y órganos humano y animal
+10|Cuchillos y cortadores médicos y quirúrgicos para cortar tejido y órganos humanos
+10|Curetas afiladas
+10|Dediles para uso médico
+10|Dentaduras postizas
+10|Desfibriladores
+10|Desfibriladores externos
+10|Diafragmas para la contracepción
+10|Dientes artificiales y fundas protectoras
+10|Dientes y tapaduras artificiales
+10|Dilatadores ginecológicos
+10|Dilatadores nasales
+10|Dilatadores rectales
+10|Dilatadores uretrales
+10|Dispositivos de anastomosis
+10|Dispositivos de corte para uso médico
+10|Dispositivos de inyección para productos farmacéuticos
+10|Dispositivos de medida del pulso
+10|Dispositivos de telemetría para aplicaciones médicas
+10|Dispositivos de vibromasaje
+10|Dispositivos e instrumentos quirúrgicos
+10|Dispositivos médicos con una finalidad de dosimetría en el ámbito de la radioterapia
+10|Dispositivos médicos, en concreto, implantes intravasculares compuestos de material artificial
+10|Dispositivos para medir el azúcar en la sangre
+10|Dispositivos para medir la presión intracraneal
+10|Electrocardiógrafos
+10|Electrodos de desfibrilación cardíaca
+10|Electrodos para desfibriladores externos
+10|Electrodos para electrocirugía
+10|Electrodos para uso médico
+10|Electroencefalógrafos
+10|Electroestimuladores musculares para uso médico
+10|Elevadores de fórceps
+10|Elevadores periosteales
+10|Encajes protésicos usados para sujetar prótesis a las extremidades del cuerpo
+10|Endoprótesis
+10|Endoscopios de cápsula
+10|Endoscopios médicos rígidos y flexibles
+10|Equipo de acupuntura
+10|Equipo endoscópico
+10|Escalpelos de láser para uso médico
+10|Escáneres de tomografía computarizada
+10|Escariadores dentales
+10|Esfigmomanómetros electrónicos
+10|Esfinterótomos
+10|Esofagoscopios
+10|Esofagoscopios flexibles
+10|Esofagoscopios rígidos
+10|Espátulas médicas
+10|Espéculos
+10|Espéculos oculares
+10|Espejos de dentista
+10|Espejos quirúrgicos
+10|Esquiascopios
+10|Estents de uréter implantables
+10|Estimuladores cardíacos (marcapasos)
+10|Estuches adaptados para instrumentos de disección para uso o investigación científicos
+10|Etiquetas indicadoras de la temperatura para uso médico
+10|Excavadores dentales
+10|Extractores de mucosidades
+10|Extremidades, ojos y dientes artificiales
+10|Fajas de embarazo para uso médico
+10|Fajas umbilicales
+10|Férulas para dedos
+10|Férulas para uso médico
+10|Fibroscopios para uso médico
+10|Filtros de sangre
+10|Filtros nasales para uso médico
+10|Fórceps de pulmón
+10|Fórceps obstétricos
+10|Fórceps para huesos
+10|Fórceps para uso quirúrgico
+10|Fórceps para uso técnico-dental
+10|Fórceps quirúrgicos
+10|Fresas para aplicaciones dentales
+10|Fundas de dedo para diagnóstico
+10|Fundas dentales
+10|Ganchos para espondilólisis
+10|Goniómetros para uso ortopédico
+10|Grapas quirúrgicas
+10|Guantes para uso en hospitales
+10|Guantes para uso médico
+10|Hemoglobinómetros
+10|Hilo guía hidrófilo para rastrear catéteres
+10|Hilo para uso médico
+10|Histeroscopios
+10|Huesos artificiales para implantación
+10|Humidificadores para uso médico
+10|Implantes compuestos por materiales artificiales
+10|Implantes de cóclea
+10|Implantes dentales
+10|Implantes espinales compuestos por materiales artificiales
+10|Implantes médicos, quirúrgicos y ortopédicos hechos de materiales artificiales
+10|Incubadoras para recién nacidos
+10|Indicadores de dióxido de carbono para uso médico
+10|Inhaladores para anestésicos vacíos
+10|Inhaladores vacíos para uso médico
+10|Instrumentos de audición médicos y partes de los mismos
+10|Instrumentos de castración para uso veterinario
+10|Instrumentos de disección para fines médicos
+10|Instrumentos de imagen por resonancia magnética para uso médico
+10|Instrumentos de inyección sin agujas
+10|Instrumentos de otorrinolaringología
+10|Instrumentos de relleno de uso dental
+10|Instrumentos de sutura hemostáticos
+10|Instrumentos litotómicos
+10|Instrumentos médicos ginecológicos para el examen de los órganos reproductivos femeninos
+10|Instrumentos médicos para cortar tejidos
+10|Instrumentos médicos para termoterapia intersticial de tejidos biológicos
+10|Instrumentos para aplicar rellenos dentales
+10|Instrumentos para la acupuntura
+10|Instrumentos para traqueotomía percutánea para uso médico
+10|Instrumentos protésicos para uso dental
+10|Instrumentos quirúrgicos para su uso en cirugía ortopédica y de columna vertebral
+10|Interpupilómetros
+10|Irrigadores nasales eléctricos
+10|Irrigadores nasales no eléctricos
+10|Irrigadores para uso médico
+10|Jeringas de inseminación
+10|Jeringas de inyección (tubos de jeringa)
+10|Jeringas dentales
+10|Jeringas desechables
+10|Jeringas para punción espinal
+10|Jeringas para uso médico y para inyecciones
+10|Jeringuillas hipodérmicas desechables para uso médico
+10|Lámparas de arco de carbono con una finalidad terapéutica
+10|Lámparas de calor para uso médico
+10|Lámparas medicas para operar
+10|Lámparas UV para uso médico
+10|Laparoscopios para uso médico y quirúrgico
+10|Laparoscopios y catéteres para uso médico y quirúrgico
+10|Laringes artificiales
+10|Laringes artificiales alimentadas por batería
+10|Laringoscopios
+10|Láseres para uso médico
+10|Lentes intraoculares
+10|Ligamentos protésicos
+10|Limpiadores de cavidades/caries bucales
+10|Limpiadores de oídos
+10|Litotritores
+10|Luces de curado dentales (aparatos odontológicos)
+10|Mantas terapéuticas con peso
+10|Máquinas de terapia de onda corta
+10|Máquinas e instrumentos ortodóncicos para uso dental
+10|Máquinas e instrumentos para operar hueso
+10|Máquinas eléctricas para operar huesos
+10|Máquinas y aparatos de terapia ultrasónica
+10|Máquinas y aparatos para pruebas de ojos
+10|Marcapasos cardíacos
+10|Martillos de reflejo para uso diagnóstico
+10|Martillos percutores pectorales
+10|Masajeadores de cuero cabelludo eléctrico para uso comercial
+10|Masajeadores de cuero cabelludo eléctrico para uso doméstico
+10|Máscaras de reanimación cardiopulmonares
+10|Mascarillas de anestesia
+10|Mascarillas de oxígeno para uso médico
+10|Mascarillas respiratorias para uso médico
+10|Material de incrustación para uso técnico dental
+10|Material de sutura
+10|Materiales de fijado para uso dental
+10|Medias elásticas para uso médico
+10|Medias y pantis de compresión para uso médico
+10|Medidores de flujo espiratorio máximo (de uso médico)
+10|Medidores de glucosa sanguínea
+10|Medidores electrónicos de presión sanguínea (para uso médico)
+10|Mesas de disección
+10|Mesas de examinación de uso en hospitales
+10|Metales base y aleaciones para uso dental
+10|Mitones para uso médico
+10|Monitores de composición corporal
+10|Monitores de grasa corporal
+10|Monitores de presión sanguínea
+10|Monitores de pulso fetal
+10|Monitores de ritmo cardíaco fetal
+10|Monitores de señal cardiaca
+10|Monitores de temperatura electrónicos para uso médico
+10|Monitores para electrocardiógrafos
+10|Monitores portátiles utilizados para medir datos biométricos para uso médico
+10|Muestrarios de tonalidad de dientes para uso odontológico
+10|Nebulizadores para uso médico
+10|Obturadores intramedulares (de uso quirúrgico)
+10|Ojos artificiales
+10|Orinales para uso médico
+10|Otoscopios
+10|Oxímetro de pulso
+10|Papilotomas
+10|Partes de huesos artificiales para implante en huesos naturales
+10|Pegamento quirúrgico
+10|Peines antipiojos para mascotas
+10|Pelotas de masaje de uso terapéutico
+10|Pelvímetros
+10|Perforadoras quirúrgicas
+10|Pesarios
+10|Pinzas de reposición
+10|Pinzas hemostáticas
+10|Plantillas ortopédicas
+10|Plantillas ortopédicas que incorporan sujeciones de arco
+10|Plantillas para uso ortopédico
+10|Portadores de amalgama
+10|Prendas de compresión postoperatorias
+10|Preservativos
+10|Preservativos espermicidas
+10|Protectores bucales para uso médico
+10|Protectores de colchón (salvacamas)
+10|Protectores de colchón para incontinentes
+10|Protectores de pezón para la lactancia materna
+10|Protectores de plástico para el pulgar para evitar la succión del pulgar
+10|Prótesis
+10|Prótesis capilares
+10|Prótesis de articulaciones
+10|Prótesis de cadera ortopédicas
+10|Prótesis dentales
+10|Prótesis óseas
+10|Puentes de implante con una finalidad dental
+10|Puertos de acceso vascular de uso médico
+10|Pulsímetros
+10|Queratoscopio
+10|Quitagrapas quirúrgicos
+10|Radiadores por infrarrojos con una finalidad terapéutica
+10|Radiadores ultravioleta para uso terapéutico
+10|Rascadores óseos
+10|Recipientes especiales para desechos médicos
+10|Refuerzos ortopédicos para insertar en el calzado
+10|Resonancia magnética (aparatos de tomografía computarizada)
+10|Retinoscopios
+10|Retractores de mastoides
+10|Retractores labiales
+10|Retractores para huesos
+10|Retractores quirúrgicos
+10|Robots médicos para uso en terapia cognitiva para niños
+10|Robots para uso médico o quirúrgico
+10|Rodilleras ortopédicas
+10|Sábanas para personas incontinentes
+10|Sacaleches
+10|Saquitos de ostomía
+10|Sensores y alarmas para monitorización de pacientes
+10|Separadores de vértebras
+10|Sillas de dentista
+10|Sillas de masajes
+10|Sillas eléctricas de masaje
+10|Sondas para uso médico
+10|Soportes de cimentación dental
+10|Soportes para bolsas de hielo médicas
+10|Stents
+10|Stents médicos
+10|Stents recubiertos biocompatibles
+10|Sucedáneos de huesos para uso quirúrgico
+10|Sucedáneos para huesos, cartílago, ligamentos y tendones
+10|Suturas
+10|Suturas quirúrgicas
+10|Taladros dentales
+10|Tapones de diáfisis
+10|Tazas de alimentación para uso médico
+10|Tensiómetros electrónicos de muñeca
+10|Termómetros clínicos
+10|Termómetros de oído para uso médico
+10|Termómetros para la fiebre
+10|Tetinas de biberón para bebé
+10|Tetinas desechables
+10|Tijeras médicas
+10|Tijeras quirúrgicas
+10|Tonómetros
+10|Tornillos para huesos
+10|Tracoscopios
+10|Trajes quirúrgicos
+10|Trocares
+10|Tubos bucales
+10|Tubos capilares para la sangre
+10|Tubos capilares para muestras
+10|Tubos de alimentación enteral
+10|Tubos de drenaje capilares
+10|Tubos de rayos X para uso médico
+10|Tubos de timpanostomía
+10|Tubos endobronquiales
+10|Tubos endotraqueales
+10|Tubos para cánulas
+10|Tubos para catéteres
+10|Tubos para la alimentación endovenosa
+10|Unidades de lámpara de arco de mercurio con una finalidad terapéutica
+10|Válvulas cardíacas artificiales
+10|Válvulas cardiacas para prótesis quirúrgicas
+10|Válvulas para el tratamiento de la hidrocefalia
+10|Válvulas subcutáneas para implantación
+10|Vaporizadores para uso médico
+10|Vendas de soporte
+10|Vendas elásticas
+10|Ventiladores médicos
+10|Ventosas para terapia de moxibustión
+10|Yeso médico y quirúrgico

--- a/lib/seeds/class_11_terms.csv
+++ b/lib/seeds/class_11_terms.csv
@@ -1,394 +1,431 @@
-class,reference_id,name
-11,110001,instalaciones automáticas para abrevar
-11,110002,acumuladores de calor
-11,110003,mecheros de acetileno
-11,110003,quemadores de acetileno
-11,110004,generadores de acetileno
-11,110005,faros de acetileno
-11,110006,campanas de ventilación
-11,110007,instalaciones de alumbrado para vehículos aéreos
-11,110008,aerotermos
-11,110008,hornos de aire caliente
-11,110009,aparatos para desodorizar el aire
-11,110010,dispositivos para el enfriar el aire
-11,110011,filtros de aire para sistemas de climatización
-11,110011,filtros para sistemas de aire acondicionado
-11,110012,recalentadores de aire
-11,110013,secadores de aire
-11,110014,instalaciones de aire acondicionado
-11,110015,instalaciones de filtrado de aire
-11,110016,aparatos de aire caliente
-11,110017,aparatos para baños de aire caliente
-11,110018,encendedores de fricción para encender el gas
-11,110019,encendedores de gas
-11,110020,encendedores*
-11,110021,bombillas de iluminación
-11,110022,bombillas eléctricas
-11,110023,lámparas de arco
-11,110024,lámparas eléctricas
-11,110025,armazones de horno
-11,110026,armarios frigoríficos
-11,110027,luces para vehículos
-11,110031,faros para automóviles
-11,110032,recipientes refrigerantes para hornos
-11,110033,bañeras
-11,110035,bañeras para baños de asiento
-11,110036,cabinas transportables para baños turcos
-11,110037,aparatos para baños
-11,110038,calentadores de baño
-11,110038,calientabaños
-11,110039,instalaciones de baño
-11,110040,lámparas [aparatos de iluminación]
-11,110041,faroles de alumbrado
-11,110042,manguitos de lámparas
-11,110043,mecheros de incandescencia
-11,110043,quemadores de incandescencia
-11,110044,mecheros de lámparas
-11,110044,quemadores de lámparas
-11,110045,luces para bicicletas
-11,110046,bidés
-11,110047,calderas que no sean partes de máquinas
-11,110048,cocederos
-11,110049,bocas de riego
-11,110050,tapones de radiador
-11,110051,linternas eléctricas
-11,110052,calentadores de agua*
-11,110053,hornos de panadería
-11,110055,rompechorros
-11,110055,aireadores para grifos
-11,110056,asadores giratorios
-11,110057,espetones para asadores
-11,110058,quemadores de laboratorio
-11,110059,antorchas para la industria petrolera
-11,110060,quemadores*
-11,110061,quemadores germicidas
-11,110063,calderas de lavandería
-11,110064,retretes transportables
-11,110065,ventiladores [climatización]
-11,110066,torrefactores de café
-11,110067,caloríferos
-11,110068,grifos para tuberías y canalizaciones
-11,110068,llaves de paso para tuberías y canalizaciones
-11,110069,recuperadores de calor
-11,110069,regeneradores de calor
-11,110070,piezas accesorias de arcilla refractaria [chamota] para hornos
-11,110071,bombillas de indicadores de dirección para vehículos
-11,110071,bombillas de intermitentes para vehículos
-11,110072,carbón para lámparas de arco
-11,110073,instalaciones de calefacción
-11,110074,aparatos de carga para hornos
-11,110075,depósitos de descarga de agua
-11,110075,cisternas [depósitos de agua] de inodoro
-11,110076,instalaciones de calefacción por agua caliente
-11,110077,calderas de calefacción
-11,110078,tubos de calderas de calefacción
-11,110079,instalaciones de climatización para vehículos
-11,110079,instalaciones de aire acondicionado para vehículos
-11,110080,aparatos de calefacción por combustible sólido, líquido o gaseoso
-11,110081,instalaciones de calefacción para vehículos
-11,110082,aparatos de calefacción eléctricos
-11,110083,radiadores de calefacción central
-11,110084,humidificadores para radiadores de calefacción central
-11,110085,elementos calefactores
-11,110086,calienta-hierros
-11,110086,calentadores de tenacillas
-11,110087,calientapiés eléctricos o no
-11,110088,folgos calentados eléctricamente
-11,110089,calientaplatos
-11,110090,calentadores de inmersión
-11,110091,cristales de lámparas
-11,110092,tubos de lámparas
-11,110093,humeros de chimenea
-11,110093,conductos de humo [conductos de chimenea]
-11,110094,tiros de chimenea
-11,110095,secadores de pelo
-11,110095,secadores de cabello
-11,110096,instalaciones de distribución de agua
-11,110097,secadores [aparatos]
-11,110099,aparatos de aire acondicionado
-11,110100,aparatos para calentar cola [pegamento]
-11,110101,columnas de destilación
-11,110103,tuberías [partes de instalaciones sanitarias]
-11,110103,cañerías [partes de instalaciones sanitarias]
-11,110104,instalaciones de conductos de agua
-11,110105,inodoros
-11,110105,váteres [inodoros]
-11,110106,congeladores
-11,110107,utensilios de cocción eléctricos
-11,110108,cocinas [aparatos]
-11,110109,aparatos e instalaciones de cocción
-11,110110,luces de motocicleta
-11,110111,tubos de descarga eléctrica para la iluminación
-11,110112,dispositivos antihielo para vehículos
-11,110112,descarchadores para vehículos
-11,110114,distribuidores de desinfectante para baños
-11,110115,aparatos de desinfección
-11,110116,plantas desalinizadoras de agua de mar
-11,110116,instalaciones de desalinización del agua de mar
-11,110117,aparatos de desecación
-11,110118,difusores de luz
-11,110119,aparatos para enfriar bebidas
-11,110120,aparatos de destilación*
-11,110121,duchas*
-11,110122,casquillos [portalámparas] de lámparas eléctricas
-11,110122,casquillos de lámparas eléctricas [portalámparas]
-11,110123,instalaciones de depuración de agua
-11,110123,instalaciones depuradoras de agua
-11,110124,aparatos para filtrar el agua
-11,110125,instalaciones para enfriar el agua
-11,110126,fuentes de agua
-11,110127,depósitos de agua a presión
-11,110128,esterilizadores de agua
-11,110129,intercambiadores térmicos que no sean partes de máquinas
-11,110130,aparatos e instalaciones de alumbrado
-11,110133,arañas de luces
-11,110135,instalaciones de depuración de aguas residuales
-11,110135,instalaciones depuradoras de aguas residuales
-11,110136,plafones [lámparas]
-11,110137,radiadores eléctricos
-11,110138,aparatos de depuración de gases
-11,110138,aparatos depuradores de gases
-11,110141,aparatos para secar el forraje
-11,110142,evaporadores
-11,110143,estufas [aparatos de calefacción]
-11,110145,filamentos de lámparas eléctricas
-11,110147,filtros para agua potable
-11,110148,antorchas
-11,110149,forjas portátiles
-11,110150,hornos que no sean de laboratorio
-11,110151,piezas accesorias conformadas para hornos
-11,110152,rejillas de incinerador
-11,110153,hogares
-11,110153,chimeneas [hogares]
-11,110154,ceniceros para hogares de chimenea
-11,110155,aparatos y máquinas frigoríficos
-11,110156,cámaras frigoríficas
-11,110157,recipientes frigoríficos
-11,110158,lámparas para rizar
-11,110159,tostadores de frutos
-11,110160,lavadores de gas [partes de instalaciones de gas]
-11,110161,mecheros de gas
-11,110161,quemadores de gas
-11,110162,calderas de gas
-11,110163,lámparas de gas
-11,110165,generadores de vapor que no sean partes de máquinas
-11,110166,lámparas germicidas para purificar el aire
-11,110167,aparatos y máquinas de hielo
-11,110168,neveras portátiles eléctricas
-11,110168,heladeras portátiles eléctricas
-11,110169,globos de lámparas
-11,110170,placas calentadoras
-11,110171,tostadores de pan
-11,110172,parrillas [utensilios de cocción]
-11,110172,aparatos para tostar
-11,110173,incineradores
-11,110174,aparatos de ionización para el tratamiento del aire o del agua
-11,110175,fuentes de agua ornamentales
-11,110176,lámparas de laboratorio
-11,110177,instalaciones para enfriar la leche
-11,110178,pasteurizadores
-11,110179,lámparas de aceite
-11,110180,lámparas de rayos ultravioleta que no sean para uso médico
-11,110182,lámparas de seguridad
-11,110183,reflectores de lámparas
-11,110185,farolillos
-11,110185,lampiones
-11,110186,lavabos
-11,110186,lavamanos
-11,110188,instalaciones para enfriar líquidos
-11,110189,tubos luminosos de alumbrado
-11,110190,filamentos de magnesio [iluminación]
-11,110191,torrefactores de malta
-11,110192,lámparas de minero
-11,110193,instalaciones para el tratamiento de combustibles nucleares y moderadores nucleares
-11,110194,válvulas reguladoras de nivel para depósitos
-11,110194,válvulas reguladoras de nivel para tanques [depósitos]
-11,110195,luces eléctricas para árboles de Navidad
-11,110196,números luminosos para casas
-11,110197,quemadores oxhídricos
-11,110198,radiadores [calefacción]
-11,110199,quemadores de aceite
-11,110199,quemadores de fueloil
-11,110200,faros para vehículos
-11,110201,placas de calefacción
-11,110202,proyectores de luz
-11,110203,instalaciones de polimerización
-11,110204,cocinas profesionales [aparatos]
-11,110205,purgadores de aire no automáticos para instalaciones de calefacción de vapor
-11,110206,aparatos y máquinas para purificar el agua
-11,110207,aparatos y máquinas para purificar el aire
-11,110208,torres de refinado para la destilación
-11,110209,instalaciones y máquinas de enfriamiento
-11,110210,hornillos
-11,110210,anafes
-11,110212,reflectores para vehículos
-11,110213,aparatos e instalaciones de refrigeración
-11,110214,aparatos e instalaciones de enfriamiento
-11,110215,registros de tiro [calefacción]
-11,110215,reguladores de tiro [calefacción]
-11,110216,accesorios de regulación para aparatos y conducciones de agua o gas
-11,110217,accesorios de seguridad para aparatos y conducciones de agua o gas
-11,110218,grifos*
-11,110219,arandelas para grifos de agua
-11,110220,asadores
-11,110221,aparatos e instalaciones sanitarias
-11,110222,aparatos e instalaciones de secado
-11,110223,secamanos para lavabos
-11,110224,serpentines [partes de instalaciones de destilación, calefacción o enfriamiento]
-11,110225,ventiladores [partes de instalaciones de aire acondicionado]
-11,110226,esterilizadores
-11,110227,instalaciones enfriadoras de tabaco
-11,110228,tostadores de tabaco
-11,110229,aparatos de iluminación para vehículos
-11,110230,aparatos de torrefacción
-11,110230,tostadores
-11,110231,instalaciones automáticas para transportar ceniza
-11,110232,instalaciones de producción de vapor
-11,110233,aparatos e instalaciones de ventilación [aire acondicionado]
-11,110234,instalaciones de ventilación [climatización] para vehículos
-11,110235,tazas de inodoro
-11,110235,tazas de váter
-11,110236,asientos de inodoro
-11,110236,asientos de váter [inodoro]
-11,110237,pantallas de lámpara
-11,110238,portapantallas para lámparas
-11,110239,grifos mezcladores para tuberías de agua
-11,110240,accesorios de regulación y seguridad para conductos de gas
-11,110241,accesorios de regulación y seguridad para aparatos de agua
-11,110242,acumuladores de vapor
-11,110243,aparatos e instalaciones para ablandar el agua
-11,110244,campanas de ventilación para laboratorios
-11,110245,esterilizadores de aire
-11,110246,alambiques*
-11,110247,mecheros de alcohol
-11,110247,quemadores de alcohol
-11,110249,dispositivos antideslumbrantes para vehículos [accesorios para lámparas]
-11,110249,dispositivos antiencandilantes para vehículos [accesorios para lámparas]
-11,110250,dispositivos calentadores antiescarcha para vehículos
-11,110251,apliques para mecheros de gas
-11,110251,apliques para quemadores de gas
-11,110252,instalaciones de suministro de agua
-11,110253,reactores nucleares
-11,110254,ollas a presión eléctricas
-11,110254,ollas exprés eléctricas
-11,110256,luces para automóviles
-11,110257,calientabiberones eléctricos
-11,110258,gofreras eléctricas
-11,110258,barquilleros [moldes para hacer barquillos] eléctricos
-11,110258,moldes de hierro eléctricos para pastelería
-11,110259,accesorios de regulación y seguridad para aparatos de gas
-11,110261,cafeteras de filtro eléctricas
-11,110262,cafeteras eléctricas
-11,110263,farolas
-11,110264,humeros para calderas de calefacción
-11,110265,barbacoas
-11,110266,freidoras eléctricas
-11,110267,chimeneas para viviendas
-11,110268,bombas de calor
-11,110269,colectores solares térmicos [calefacción]
-11,110270,hornos solares
-11,110271,aparatos de bronceado
-11,110271,camas solares
-11,110272,aparatos o instalaciones de descarga de agua
-11,110273,alimentadores de calderas de calefacción
-11,110274,refrigeradores
-11,110274,frigoríficos
-11,110275,aparatos de desodorización que no sean para uso personal
-11,110276,aparatos de toma de agua
-11,110277,aparatos para depurar el aceite
-11,110278,aparatos de fumigación que no sean para uso médico
-11,110279,soportes de carga de hornos
-11,110280,calentadores de bolsillo
-11,110291,bañeras de hidromasaje
-11,110292,aparatos de cromatografía para uso industrial
-11,110293,filamentos eléctricos calentadores
-11,110294,condensadores de gas que no sean partes de máquinas
-11,110296,almohadillas electrotérmicas que no sean para uso médico
-11,110297,instalaciones de sauna
-11,110298,cabinas de ducha
-11,110299,fregaderos
-11,110300,vaporizadores faciales [saunas]
-11,110301,urinarios
-11,110302,bolsas de agua caliente
-11,110303,hervidores eléctricos
-11,110304,calientacamas
-11,110305,mantas eléctricas que no sean para uso médico
-11,110305,cobertores eléctricos que no sean para uso médico
-11,110305,cobijas eléctricas que no sean para uso médico
-11,110306,calentadores de cama
-11,110307,aparatos de filtración para acuarios
-11,110308,aparatos de calefacción para acuarios
-11,110309,luces para iluminar acuarios
-11,110310,alfombras electrotérmicas
-11,110311,hornos dentales
-11,110312,yogurteras eléctricas
-11,110312,aparatos eléctricos para hacer yogur
-11,110313,depósitos de expansión para instalaciones de calefacción central
-11,110314,campanas extractoras para cocinas
-11,110315,ventiladores eléctricos para uso personal
-11,110316,secadoras de ropa eléctricas
-11,110317,hornos de microondas [aparatos de cocina]
-11,110318,aparatos de cloración para piscinas
-11,110318,aparatos de cloración para albercas de natación
-11,110318,aparatos de cloración para piletas de natación
-11,110319,válvulas termostáticas [partes de instalaciones de calefacción]
-11,110320,aparatos para producir chorros de hidromasaje
-11,110321,aparatos de deshidratación de residuos alimenticios
-11,110322,lámparas de buceo
-11,110322,lámparas de submarinismo
-11,110323,aspersores de riego por goteo [accesorios de riego]
-11,110325,cámaras blancas [instalaciones sanitarias]
-11,110326,piedras de lava para barbacoas
-11,110327,máquinas de riego para uso agrícola
-11,110328,hornos de microondas para uso industrial
-11,110329,hornos de pan
-11,110330,vitrinas frigoríficas
-11,110331,aparatos vaporizadores para planchar tejidos
-11,110332,máquinas para hacer pan
-11,110333,aparatos de iluminación con diodos electroluminiscentes [ledes]
-11,110333,aparatos de alumbrado con diodos electroluminiscentes [ledes]
-11,110334,aparatos para bañeras de hidromasaje
-11,110335,vitrinas calentadoras
-11,110336,ollas eléctricas multifuncionales
-11,110337,vaporeras eléctricas
-11,110338,prensas eléctricas para tortillas
-11,110339,aparatos para esterilizar libros
-11,110340,pistolas de aire caliente
-11,110341,fuentes de chocolate eléctricas
-11,110342,aparatos de desinfección para uso médico
-11,110343,armarios refrigeradores eléctricos para vino
-11,110344,guirnaldas de luces decorativas para fiestas
-11,110345,calcetines electrotérmicos
-11,110346,linternas frontales
-11,110346,linternas de cabeza
-11,110347,lámparas de manicura
-11,110348,máquinas de cocción al vacío eléctricas
-11,110349,generadores de microburbujas para bañeras
-11,110350,aparatos de calentamiento y refrigeración para la distribución de bebidas calientes y frías
-11,110351,prendas de vestir electrotérmicas
-11,110352,máquinas eléctricas de uso doméstico para la preparación de pasteles de arroz molido
-11,110353,mechas especiales para estufas de petróleo
-11,110354,placas de cocción eléctricas
-11,110355,faroles de vela
-11,110356,freidoras de aire caliente
-11,110357,máquinas para preparar helados cremosos
-11,110358,luces indicadoras de dirección para bicicletas
-11,110359,refrigeradores, aparatos de enfriamiento y congeladores para almacenamiento médico
-11,110360,lámparas de curado que no sean para uso médico
-11,110361,sistemas de cultivo hidropónico
-11,110362,recipientes calorífugos eléctricos
-11,110363,deshidratadores eléctricos de alimentos
-11,110364,calentadores de manos alimentados por USB
-11,110365,calentadores de tazas alimentados por USB
-11,110366,cuscuseras eléctricas
-11,110367,lámparas de pie
-11,110368,cazuelas de tajín eléctricas
-11,110369,proyectores de luces
-11,110370,máquinas de niebla
-11,110371,aparatos e instalaciones de calefacción por suelo radiante
-11,110371,aparatos e instalaciones de calefacción por piso radiante
-11,110372,humidificadores
-11,110373,máquinas eléctricas para elaborar leche de soja
-11,110374,cápsulas de café, vacías, para cafeteras eléctricas
-11,110375,dispensadores de bebidas calientes eléctricos
-11,110376,deshumidificadores
+class|name
+11|Accesorios de regulación para aparatos y conducciones de agua o gas
+11|Ahumadores de barbacoa
+11|Aires acondicionados de ventana para uso industrial
+11|Alcachofas de ducha
+11|Alfombras electrotérmicas
+11|Almohadillas de calefacción eléctricas, que no sean para tratamiento médico
+11|Altos hornos para uso industrial
+11|Antorchas eléctricas de iluminación
+11|Aparatos de aire acondicionado para sellado de ventilación
+11|Aparatos de aire acondicionado por inducción local para uso industrial
+11|Aparatos de alumbrado eléctricos
+11|Aparatos de calefacción de aire caliente para uso industrial
+11|Aparatos de calefacción de pavimentos
+11|Aparatos de calefacción para acuarios
+11|Aparatos de calefacción por agua caliente para uso industrial
+11|Aparatos de calefacción por vapor para uso industrial
+11|Aparatos de climatización para uso industrial
+11|Aparatos de cromatografía para uso industrial
+11|Aparatos de descongelación para vehículos
+11|Aparatos de desinfección para billetes de banco
+11|Aparatos de destilación
+11|Aparatos de filtración para acuarios
+11|Aparatos de iluminación de pantalla plana
+11|Aparatos de iluminación para vehículos
+11|Aparatos de ionización para tratar el aire
+11|Aparatos de purificación de agua
+11|Aparatos de purificación de aire instalados en vehículos
+11|Aparatos de purificación y filtración de agua
+11|Aparatos de secado de manos eléctricos para baños
+11|Aparatos de secado de uñas mediante led
+11|Aparatos desalinizadores de agua
+11|Aparatos desinfectantes de lavavajillas para uso industrial
+11|Aparatos e instalaciones de aire acondicionado
+11|Aparatos e instalaciones de refrigeración
+11|Aparatos e instalaciones para ablandar el agua
+11|Aparatos e instrumentos de aire acondicionado, refrigeración del aire y ventilación
+11|Aparatos eléctricos de calor para baños de cera de parafina, que no sean para uso médico
+11|Aparatos eléctricos japoneses para calentar las piernas para fines domésticos (kotatsu eléctricos)
+11|Aparatos eléctricos para cocer huevos
+11|Aparatos eléctricos para purificar el agua de bañeras para uso doméstico
+11|Aparatos para calentar espacios
+11|Aparatos para enfriar bebidas
+11|Aparatos para filtrar el agua
+11|Aparatos para filtrar el agua potable
+11|Aparatos para la generación de vapor
+11|Aparatos para la purificación de agua para uso industrial
+11|Aparatos para purificar el agua del grifo
+11|Aparatos para purificar el aire
+11|Aparatos para secar de manos libres
+11|Aparatos para secar el forraje
+11|Aparatos purificadores de aguas residuales
+11|Aparatos y máquinas de hielo
+11|Aparatos y máquinas para purificar el aire
+11|Apliques de luces por infrarrojos
+11|Arañas de luces
+11|Arandelas para grifos de agua
+11|Armarios frigoríficos
+11|Arroceras eléctricas
+11|Arroceras para uso industrial
+11|Asadores de carbón para uso doméstico
+11|Asadores de pescado
+11|Asadores giratorios eléctricos
+11|Asadores para hornos de cocina
+11|Asadores y parrillas de asador
+11|Asientos de inodoro para uso con fuentes de baño estilo japonés
+11|Asientos de retrete para niños
+11|Aspersores de riego
+11|Autoclaves eléctricas
+11|Bandejas de ducha
+11|Bañeras
+11|Bañeras de ducha
+11|Bañeras de entrada lateral para personas con discapacidad física
+11|Bañeras de hidromasaje
+11|Bañeras y bandejas de ducha
+11|Baños de asiento
+11|Baños de pies eléctricos
+11|Baños eléctricos portátiles para los pies
+11|Barras quimioluminiscentes (luces)
+11|Bases de ducha
+11|Bases para lámparas
+11|Bidés
+11|Bolas de cisternas de baño
+11|Bolas luminosas para discotecas
+11|Bolsas de agua caliente eléctricas
+11|Bolsas de agua para calentar camas
+11|Bombillas de iluminación
+11|Bombillas de iluminación en miniatura
+11|Bombillas de iluminación halógena
+11|Bombillas de iluminación LED
+11|Bombillas fluorescentes
+11|Cafeteras eléctricas
+11|Cafeteras eléctricas para uso doméstico
+11|Calderas de baño
+11|Calderas de calefacción
+11|Calderas para instalaciones de calefacción
+11|Calefactores halógenos
+11|Calefactores radiantes eléctricos (para uso doméstico)
+11|Calentadores continuos
+11|Calentadores de agua
+11|Calentadores de agua por bombeo eólico
+11|Calentadores de agua por inducción
+11|Calentadores de bebidas eléctricos
+11|Calentadores de cama,
+11|Calentadores de cocina no eléctricos de uso doméstico
+11|Calentadores de gas para agua de uso doméstico
+11|Calentadores de inmersión
+11|Calentadores de pies eléctricos
+11|Calentadores de tazas eléctricos
+11|Calentadores eléctricos de bolsillo para calentar las manos
+11|Calentadores eléctricos para toallitas húmedas para bebés
+11|Calentadores para agua de alimentación para uso industrial
+11|Calentadores para piscinas
+11|Calentadores para platos
+11|Calentadores por convección
+11|Calentadores solares para agua
+11|Calienta biberones eléctricos
+11|Calientapiés eléctricos para uso personal
+11|Calientaplatos
+11|Calientaplatos eléctricos
+11|Camas de bronceado
+11|Campanas extractoras de humos para uso doméstico
+11|Campanas extractoras para cocinas
+11|Candelabros eléctricos
+11|Cazuelas eléctricas
+11|Chorros para bañeras de hidromasaje
+11|Cocinas a gas (calefactores para uso doméstico)
+11|Cocinas a leña
+11|Cocinas de combustión lenta (de uso doméstico)
+11|Cocinas de fideos ramen eléctricas
+11|Cocinas de gas
+11|Cocinas eléctricas
+11|Colectores solares para calefacción
+11|Congeladores
+11|Congeladores criogénicos
+11|Congeladores eléctricos (para uso doméstico)
+11|Congeladores eléctricos (para uso industrial)
+11|Contenedores frigoríficos para el transporte
+11|Convectores de calor
+11|Cubículos de ducha y baño
+11|Cubiertas protectoras de grifos de bañera para prevención de accidentes de niños
+11|Cúpulas de refrigeración
+11|Depósitos de descarga de agua
+11|Depuradores de aire para automóviles
+11|Desempañadores para vehículos
+11|Deshumidificadores para uso doméstico
+11|Deshumidificadores para uso industrial
+11|Destiladoras para procesamiento químico
+11|Dispositivos de iluminación
+11|Dispositivos de iluminación para vitrinas
+11|Dispositivos de riego agrícola
+11|Dispositivos para el enfriar el aire
+11|Duchas
+11|Duchas de emergencia
+11|Duchas de mano
+11|Duchas y cabinas de ducha
+11|Elementos calefactores
+11|Enfriadores de aire portátiles por evaporación
+11|Enfriadores de espacio eléctricos (para uso doméstico)
+11|Estaciones de lavado de ojos de emergencia
+11|Esterilizadores de agua
+11|Esterilizadores de aire
+11|Esterilizadores de inodoros mediante rayos uva para uso doméstico
+11|Esterilizadores de leche
+11|Esterilizadores de platos
+11|Esterilizadores de zapatos con fines domésticos
+11|Esterilizadores para cepillos de dientes
+11|Esterilizadores ultrasónicos de uso doméstico
+11|Estufas de aceite (calefactores de uso doméstico)
+11|Estufas de carbón para calefacción de ambientes para uso doméstico
+11|Estufas de cocina de aceite para uso doméstico
+11|Estufas de cocina eléctricas para uso doméstico
+11|Estufas de gas
+11|Estufas de queroseno
+11|Estufas japonesas de carbón para uso doméstico (hibachi)
+11|Evaporadores de refrigeración
+11|Evaporadores para aires acondicionados
+11|Evaporadores para procesamiento químico
+11|Extractores de aire
+11|Extractores de humo
+11|Farolas
+11|Faroles de alumbrado
+11|Faroles de vela
+11|Farolillos chinos eléctricos
+11|Faros para automóviles
+11|Faros para vehículos
+11|Filtros de agua
+11|Filtros de agua del grifo de uso doméstico
+11|Filtros de aire para campanas extractoras
+11|Filtros de aire para sistemas de climatización
+11|Filtros de aire para unidades de aire acondicionado
+11|Filtros para agua potable
+11|Filtros para aparatos de iluminación
+11|Focos delanteros para automóviles
+11|Focos para su uso en vehículos
+11|Fogones portátiles
+11|Fosas sépticas
+11|Fregaderos de cocina
+11|Freidoras eléctricas
+11|Freidoras eléctricas sin aceite
+11|Freidoras industriales
+11|Fuentes de agua
+11|Fuentes de agua ornamentales
+11|Generadores nucleares
+11|Grifos
+11|Grifos automáticos
+11|Grifos de agua
+11|Grifos economizadores de agua
+11|Grifos monomando para fregaderos
+11|Grifos para lavabos
+11|Hervidores de huevo eléctricos
+11|Hervidores eléctricos
+11|Hervidores plegables, eléctricos
+11|Hornos calentadores para uso industrial
+11|Hornos de calcinación para uso industrial
+11|Hornos de carbonización para uso industrial
+11|Hornos de cocina de gas para uso doméstico
+11|Hornos de cocina de inducción
+11|Hornos de cocina eléctricos para uso doméstico
+11|Hornos de cocina japoneses (kamado)
+11|Hornos de cocina para uso doméstico
+11|Hornos de cocina para uso industrial
+11|Hornos de convección
+11|Hornos de foso para uso industrial
+11|Hornos de fundición para uso industrial
+11|Hornos de microondas
+11|Hornos de microondas (aparatos de cocina)
+11|Hornos de microondas para uso doméstico
+11|Hornos de microondas para uso industrial
+11|Hornos de pan
+11|Hornos de recalentamiento
+11|Hornos dentales
+11|Hornos generadores de gas (para uso industrial)
+11|Hornos japoneses de carbón para cocinar con fines domésticos (shichirin)
+11|Hornos para fundir metales
+11|Hornos para la industria química y de fabricación de vidrios
+11|Hornos para recuperar chatarra de metales
+11|Hornos para uso industrial
+11|Hornos refractarios
+11|Hornos rotatorios para uso industrial
+11|Humeros de chimenea
+11|Humidificadores
+11|Humidificadores con generador de aniones
+11|Humidificadores con USB para uso doméstico
+11|Humidificadores para uso industrial
+11|Iluminadores infrarrojos
+11|Incineradores de basura
+11|Incineradores de basura para uso doméstico
+11|Incineradores de basura para uso industrial
+11|Incineradores de residuos
+11|Inodoros
+11|Inodoros ahorradores de agua
+11|Inodoros con sistema de chorro de agua
+11|Instalaciones de aire acondicionado
+11|Instalaciones de aire acondicionado central para uso industrial
+11|Instalaciones de aire acondicionado para automóviles
+11|Instalaciones de aire acondicionado para vehículos
+11|Instalaciones de calefacción
+11|Instalaciones de calefacción para vehículos
+11|Instalaciones de climatización para vehículos
+11|Instalaciones de depuración de agua
+11|Instalaciones de depuración de aguas residuales
+11|Instalaciones de filtrado de aire
+11|Instalaciones de humectación ambiental
+11|Instalaciones de iluminación para vehículos
+11|Instalaciones de producción de vapor
+11|Instalaciones de sauna
+11|Instalaciones purificadoras de aguas residuales
+11|Intercambiadores de calor para procesamiento químico
+11|Ionizadores de agua para uso doméstico
+11|Jarras calentadas eléctricamente
+11|Lámparas (aparatos de iluminación)
+11|Lámparas de bicicleta
+11|Lámparas de buceo
+11|Lámparas de descarga y sus partes
+11|Lámparas de dínamo para vehículos
+11|Lámparas de escritorio
+11|Lámparas de gas
+11|Lámparas de lectura
+11|Lámparas de mercurio
+11|Lámparas de papel portátiles (chochin)
+11|Lámparas de pie de papel (andon)
+11|Lámparas de rayos solares
+11|Lámparas de rayos ultravioleta que no sean para uso médico
+11|Lámparas de seguridad LED
+11|Lámparas de seguridad para uso subterráneo
+11|Lámparas de suelo
+11|Lámparas de techo
+11|Lámparas de vapor de metal halógenas de rayos ultravioletas
+11|Lámparas descendentes
+11|Lámparas eléctricas
+11|Lámparas estroboscópicas (para efectos de iluminación)
+11|Lámparas fluorescentes
+11|Lámparas germicidas para purificar el aire
+11|Lámparas halógenas
+11|Lámparas incandescentes
+11|Lámparas infrarrojas
+11|Lámparas LED
+11|Lámparas para tiendas de campaña
+11|Lámparas para uso en exteriores
+11|Lámparas ultravioletas utilizadas para acuarios
+11|Lavacabezas para su uso en peluquerías
+11|Limpiadores de vapor de uso doméstico
+11|Linternas (lámparas de mano)
+11|Linternas de bolsillo
+11|Linternas eléctricas
+11|Luces de arco de carbono (klieg)
+11|Luces de freno de vehículos
+11|Luces decorativas para su uso en interiores
+11|Luces eléctricas nocturnas
+11|Luces indicadoras de dirección para automóviles
+11|Luces LED de paisajismo
+11|Luces LED subacuáticas
+11|Luces para iluminar acuarios
+11|Luces para la decoración festiva
+11|Luces para leer
+11|Luces para vehículos
+11|Luces traseras para vehículos
+11|Luminarias
+11|Luminarias de LED
+11|Mandos para grifos
+11|Mantas eléctricas para uso doméstico
+11|Mantas eléctricas que no sean para uso médico
+11|Máquinas de café expreso eléctricas
+11|Máquinas de enfriado de bebidas y dispensadores de hielo
+11|Máquinas de filtrado de aire industriales
+11|Máquinas de hielo
+11|Máquinas de para uso agrícola
+11|Máquinas de secado para la agricultura
+11|Máquinas frigoríficas
+11|Máquinas para hacer cubitos de hielo
+11|Máquinas para hacer pan
+11|Máquinas para la purificación del agua
+11|Máquinas para purificar gas
+11|Máquinas productoras de vapor
+11|Mecanismos de suspensión para lámparas
+11|Mecheros de gas
+11|Mecheros de lámparas
+11|Neveras de bebidas para su uso en automóviles
+11|Olla arrocera eléctrica
+11|Ollas de cocina eléctricas
+11|Ollas de inducción electromagnética para uso doméstico
+11|Ollas de inducción electromagnética para uso industrial
+11|Palancas (pulsadores) de cisterna de inodoros
+11|Paneles para duchas
+11|Panificadoras eléctricas
+11|Pantallas de lámparas
+11|Parrillas de asador
+11|Parrillas de gas
+11|Parrillas eléctricas
+11|Parrillas eléctricas de exterior
+11|Percoladores de café eléctricos
+11|Placas calentadoras
+11|Placas calentadoras para uso doméstico
+11|Placas de cocción eléctricas
+11|Plafones (lámparas)
+11|Planchas eléctricas (aparatos de cocina)
+11|Planchas sandwicheras eléctricas
+11|Plataformas de ducha
+11|Proyectores de luz
+11|Purificadores de agua de uso doméstico
+11|Purificadores de aire
+11|Purificadores de aire de uso doméstico
+11|Purificadores de aire para cochecitos
+11|Purificadores de aire para uso doméstico
+11|Purificadores de aire para uso industrial
+11|Purificadores de aire robóticos para uso doméstico
+11|Purificadores eléctricos de agua de uso doméstico
+11|Radiadores (calefacción)
+11|Radiadores de calefacción central
+11|Radiadores eléctricos
+11|Radiadores eléctricos para calefaccionar edificios
+11|Radiadores para aires acondicionados industriales
+11|Reactores nucleares (pilas atómicas)
+11|Reflectores de bicicleta
+11|Reflectores para vehículos
+11|Refrigeradores de gas
+11|Refrigeradores eléctricos para uso doméstico
+11|Refrigeradores para congelar de uso doméstico
+11|Refrigeradores para cosméticos
+11|Refrigeradores-congeladores
+11|Reguladores de temperatura automáticos para radiadores de calefacción central
+11|Rociadores de ducha
+11|Salamandras (aparatos de calefacción)
+11|Samovares eléctricos
+11|Sandwicheras eléctricas
+11|Sartenes eléctricas
+11|Secador de aire caliente eléctrico portátil
+11|Secadoras de cabello para uso doméstico
+11|Secadoras de cabello para uso en salón de belleza
+11|Secadoras de zapatos eléctricas para uso doméstico
+11|Secadoras eléctricas de ropa
+11|Secadores de lavandería, eléctricos o de uso doméstico
+11|Secadores de pelo eléctricos
+11|Sistemas de iluminación con focos sobre rieles
+11|Surtidores de agua para bañeras de hidromasaje
+11|Tapones de radiador
+11|Tazas de inodoro
+11|Teteras (eléctricas)
+11|Teteras eléctricas inalámbricas
+11|Toalleros de calefacción eléctrica
+11|Torrefactores de café
+11|Torres de iluminación móviles
+11|Tostadoras de sándwiches eléctricas
+11|Tostadores eléctricos para uso doméstico
+11|Tubos de calderas de calefacción
+11|Tubos de descarga eléctrica para la iluminación
+11|Tubos de lámparas
+11|Tubos de lámparas fluorescentes
+11|Tubos fluorescentes para iluminación
+11|Unidades de destilación de agua
+11|Urinarios
+11|Válvulas termostáticas como partes de instalaciones de calefacción
+11|Vaporeras de alimentos eléctricas
+11|Vaporizador eléctrico para verduras
+11|Vaporizadores para prendas de vestir
+11|Velas para iluminación
+11|Velas sin flama
+11|Ventiladores de cielo
+11|Ventiladores de techo con luces integradas
+11|Ventiladores de ventana eléctricos
+11|Ventiladores eléctricos
+11|Ventiladores eléctricos con dispositivos de enfriamiento por evaporación
+11|Ventiladores eléctricos de uso personal
+11|Ventiladores eléctricos para uso doméstico
+11|Ventiladores eléctricos sin aspas
+11|Ventiladores para aparatos de aire acondicionado
+11|Ventiladores para uso industrial
+11|Vitrinas frigoríficas
+11|Woks eléctricos
+11|Yogurteras eléctricas

--- a/lib/seeds/class_12_terms.csv
+++ b/lib/seeds/class_12_terms.csv
@@ -1,366 +1,468 @@
-class,reference_id,name
-12,120001,carretillas elevadoras
-12,120002,enganches de vagón o ferrocarril
-12,120002,enganches de ferrocarril
-12,120002,enganches de vagón
-12,120003,acoplamientos para vehículos terrestres
-12,120004,transportadores aéreos
-12,120005,vehículos aéreos
-12,120006,globos aerostáticos
-12,120007,cámaras de aire para neumáticos
-12,120008,equipos para reparar cámaras de aire
-12,120009,bombas de aire [accesorios para vehículos]
-12,120010,amortiguadores de suspensión para vehículos
-12,120011,muelles amortiguadores para vehículos
-12,120011,resortes amortiguadores para vehículos
-12,120012,aviones anfibios
-12,120013,dispositivos antiderrapantes para neumáticos de vehículos
-12,120014,cadenas antiderrapantes
-12,120015,reposacabezas para asientos de vehículos
-12,120015,apoyacabezas para asientos de vehículos
-12,120016,camiones de riego
-12,120017,enganches de remolque para vehículos
-12,120018,autobuses
-12,120019,autocares
-12,120021,barcos*
-12,120022,camiones
-12,120023,capós de automóviles
-12,120024,cadenas para automóviles
-12,120025,chasis de automóviles
-12,120026,avisadores acústicos de marcha atrás para vehículos
-12,120026,alarmas acústicas de reversa para vehículos
-12,120027,aviones
-12,120028,transbordadores [ferris]
-12,120029,portaequipajes para vehículos
-12,120029,bacas para vehículos
-12,120030,globos dirigibles
-12,120031,cubiertas de neumáticos para vehículos
-12,120032,válvulas de neumáticos para vehículos
-12,120033,pestañas de cubiertas de ruedas de ferrocarril
-12,120034,barras de torsión para vehículos
-12,120035,cascos de buque
-12,120036,bicheros
-12,120037,dispositivos de mando para buques
-12,120038,dispositivos para desatracar barcos
-12,120039,planos inclinados para barcos
-12,120040,propulsores de hélice para barcos
-12,120041,remos
-12,120042,cajas basculantes para camiones
-12,120043,ruedas de vagoneta [minería]
-12,120044,bicicletas*
-12,120046,pies de apoyo para bicicletas
-12,120046,patas de cabra para bicicletas
-12,120047,bogies para vagones de ferrocarril
-12,120048,pescantes para barcos
-12,120049,guardabarros
-12,120049,guardafangos
-12,120049,salpicaderas
-12,120050,carretillas de dos ruedas
-12,120050,carretillas de equipaje
-12,120050,carretillas de transporte
-12,120051,cabinas para instalaciones de transporte por cable
-12,120052,furgones de artillería [vehículos]
-12,120053,ruedas de vehículos
-12,120054,capós de motor para vehículos
-12,120055,capotas para vehículos
-12,120056,caravanas
-12,120057,remolques [vehículos]
-12,120058,cárteres para órganos de vehículos terrestres que no sean para motores
-12,120059,cinturones de seguridad para asientos de vehículos
-12,120060,cubos de ruedas de vehículos
-12,120061,cadenas de bicicleta
-12,120062,sillas de ruedas
-12,120063,chalanas
-12,120064,chalupas
-12,120065,carretillas para manipular mercancías
-12,120065,carretillas de manipulación de mercancías
-12,120066,carros portamangueras
-12,120067,vagonetas de colada
-12,120068,coches de golf
-12,120068,carros de golf [vehículos]
-12,120069,chasis de vehículos
-12,120070,timones
-12,120071,material rodante de funicular
-12,120072,material rodante de ferrocarril
-12,120073,chimeneas de buque
-12,120074,orugas para vehículos
-12,120075,tractores
-12,120076,vagonetas de mina
-12,120077,parachoques de vehículos
-12,120077,defensas de vehículos
-12,120078,topes antichoque para material rodante ferroviario
-12,120079,circuitos hidráulicos para vehículos
-12,120080,manillares de bicicleta
-12,120080,manubrios de bicicleta
-12,120081,literas para vehículos
-12,120082,cuadernas de buque
-12,120084,neumáticos de bicicleta
-12,120085,engranajes para bicicletas
-12,120086,frenos de bicicleta
-12,120087,guardabarros de bicicleta
-12,120087,guardafangos de bicicleta 
-12,120087,salpicaderas de bicicleta
-12,120088,llantas para ruedas de bicicleta
-12,120088,rines para ruedas de bicicleta
-12,120089,manivelas de bicicleta
-12,120090,motores de bicicleta
-12,120091,cubos para ruedas de bicicleta
-12,120092,pedales de bicicleta
-12,120093,infladores para neumáticos de bicicleta
-12,120094,radios para ruedas de bicicleta
-12,120094,rayos para ruedas de bicicleta
-12,120095,ruedas de bicicleta
-12,120096,sillines de bicicleta
-12,120097,pies de apoyo para motocicletas
-12,120097,patas de cabra de motocicletas
-12,120103,engranajes para vehículos terrestres
-12,120105,dragas [barcos]
-12,120106,dresinas
-12,120106,cigüeñas ferroviarias
-12,120109,motores eléctricos para vehículos terrestres
-12,120110,vehículos eléctricos
-12,120111,embragues para vehículos terrestres
-12,120112,asientos infantiles de seguridad para vehículos
-12,120113,paracaídas
-12,120114,cubiertas para neumáticos
-12,120116,contrapesos para equilibrar ruedas de vehículos
-12,120116,contrapesos para balancear ruedas de vehículos
-12,120117,vehículos espaciales
-12,120118,palos para buques
-12,120119,ejes de vehículos
-12,120120,cojinetes de eje
-12,120121,limpiaparabrisas
-12,120122,guardafaldas para bicicletas
-12,120123,redes portaequipajes para vehículos
-12,120124,tapacubos
-12,120125,furgones [vehículos]
-12,120125,camionetas
-12,120125,furgonetas
-12,120126,frenos de vehículos
-12,120127,sujeciones para cubos de ruedas
-12,120128,vehículos frigoríficos
-12,120129,vagones frigoríficos
-12,120130,motores para vehículos terrestres
-12,120131,espadillas [remos]
-12,120132,fundas para asientos de vehículos
-12,120133,portillas [ojos de buey]
-12,120134,hidroaviones
-12,120135,hidroplanos [barcos]
-12,120136,coches cama
-12,120138,locomotoras
-12,120139,máquinas motrices para vehículos terrestres
-12,120140,vagones
-12,120141,escalones para vehículos
-12,120141,estribos para vehículos
-12,120142,mecanismos de transmisión para vehículos terrestres
-12,120143,mecanismos de propulsión para vehículos terrestres
-12,120144,vehículos militares de transporte
-12,120145,reactores para vehículos terrestres
-12,120147,motocicletas
-12,120148,ruedas libres para vehículos terrestres
-12,120149,vehículos náuticos
-12,120150,buques
-12,120151,hélices de buque
-12,120153,remos para canoas
-12,120154,parabrisas
-12,120155,clavos para neumáticos
-12,120156,bandas de rodadura para recauchutar neumáticos
-12,120157,neumáticos
-12,120159,pontones
-12,120160,puertas de vehículos
-12,120161,portaesquís para automóviles
-12,120162,motocarros
-12,120162,triciclos de reparto
-12,120163,sillas de paseo
-12,120163,sillitas de paseo
-12,120164,toldos para sillas de paseo
-12,120164,toldos para sillitas de paseo
-12,120165,capotas para sillas de paseo
-12,120165,capotas para sillitas de paseo
-12,120166,propulsores de hélice
-12,120168,rayos para ruedas de vehículos
-12,120168,radios para ruedas de vehículos
-12,120169,tensores de rayos de ruedas
-12,120169,tensores de radios de ruedas
-12,120170,telesquís
-12,120171,muelles de suspensión para vehículos
-12,120171,resortes de suspensión para vehículos
-12,120172,vagones restaurante
-12,120172,coches restaurante
-12,120173,retrovisores
-12,120174,llantas [rines] para ruedas de vehículos
-12,120174,rines [llantas] para ruedas de vehículos
-12,120175,sillines de motocicleta
-12,120176,sidecares
-12,120177,asientos de vehículos
-12,120178,coches deportivos
-12,120178,autos deportivos
-12,120179,cornamusas [marina]
-12,120180,telesillas
-12,120182,toletes
-12,120182,escálamos
-12,120183,volquetes
-12,120183,camiones de volteo
-12,120184,aeronaves
-12,120185,bastidores de vehículos
-12,120186,trineos [vehículos]
-12,120187,tranvías
-12,120188,aparatos e instalaciones de transporte por cable
-12,120189,funiculares
-12,120190,teleféricos
-12,120191,triciclos
-12,120192,turbinas para vehículos terrestres
-12,120193,vehículos de
-locomoción terrestre,
-aérea, acuática o ferroviaria
-12,120194,parches adhesivos de caucho para reparar cámaras de aire
-12,120195,tapizados para interiores de vehículos
-12,120196,ciclomotores
-12,120196,velomotores
-12,120198,cristales de vehículos
-12,120198,ventanillas de vehículos
-12,120199,coches
-12,120199,automóviles
-12,120200,dispositivos antirrobo para vehículos
-12,120201,basculadores de vagones [partes de vagones]
-12,120202,yates
-12,120203,aparatos, máquinas y dispositivos para la aeronáutica
-12,120204,dispositivos antideslumbrantes para vehículos*
-12,120204,dispositivos antirreflejo para vehículos
-12,120206,neumáticos para automóviles
-12,120207,carrocerías de automóviles
-12,120209,parachoques para automóviles
-12,120210,amortiguadores para automóviles
-12,120211,alarmas antirrobo para vehículos
-12,120212,bocinas para vehículos
-12,120212,avisadores acústicos para vehículos
-12,120213,hormigoneras [vehículos]
-12,120213,revolvedoras de concreto [vehículos]
-12,120214,cámaras de aire para neumáticos de bicicleta
-12,120215,forros de freno para vehículos
-12,120216,zapatas de freno para vehículos
-12,120217,cajas de cambios para vehículos terrestres
-12,120218,carretillas
-12,120219,carretas
-12,120221,cuadros de bicicleta
-12,120222,carrocerías
-12,120223,asientos eyectables para aeronaves
-12,120224,fundas para vehículos
-12,120225,cadenas de accionamiento para vehículos terrestres
-12,120226,cadenas de transmisión para vehículos terrestres
-12,120226,cadenas motrices para vehículos terrestres
-12,120227,convertidores de par motor para vehículos terrestres
-12,120228,brazos de señal para vehículos
-12,120229,chimeneas de locomotora
-12,120230,volantes para vehículos
-12,120232,fundas de sillín para bicicletas
-12,120233,ambulancias
-12,120234,neumáticos sin cámara para bicicletas
-12,120235,desmultiplicadores para vehículos terrestres
-12,120235,engranajes reductores para vehículos terrestres
-12,120236,segmentos de freno para vehículos
-12,120237,aerodeslizadores
-12,120241,tapones para depósitos de carburante de vehículos
-12,120242,bielas para vehículos terrestres que no sean partes de motores
-12,120243,plataformas elevadoras [partes de vehículos terrestres]
-12,120244,arneses de seguridad para asientos de vehículos
-12,120245,parasoles para automóviles
-12,120246,árboles de transmisión para vehículos terrestres
-12,120247,bolsas de aire [dispositivos de seguridad para automóviles]
-12,120247,airbags [dispositivos de seguridad para automóviles]
-12,120248,cestas especiales para bicicletas
-12,120249,autocaravanas
-12,120249,casas rodantes
-12,120250,ruedecillas para carritos [vehículos]
-12,120251,carritos de limpieza
-12,120252,defensas para buques
-12,120253,trineos de pie
-12,120254,cofres especiales para bicicletas
-12,120255,carritos para la compra
-12,120256,vehículos a motor para la nieve
-12,120256,vehículos de motor para la nieve
-12,120257,vehículos teledirigidos que no sean juguetes
-12,120257,vehículos de control remoto que no sean de juguete
-12,120258,patinetes [vehículos]
-12,120259,mástiles de barco
-12,120260,fundas para volantes de automóviles
-12,120261,alerones para vehículos
-12,120262,limpiafaros
-12,120262,limpiafocos
-12,120263,pastillas de freno para automóviles
-12,120264,fundas para ruedas de recambio
-12,120264,fundas para ruedas de auxilio
-12,120264,fundas para neumáticos de refacción
-12,120265,carros basculantes
-12,120266,encendedores de cigarrillos para automóviles
-12,120267,discos de freno para vehículos
-12,120268,alforjas especiales para bicicletas
-12,120269,timbres para bicicletas
-12,120271,vehículos blindados
-12,120272,bancadas de motor para vehículos terrestres
-12,120272,soportes de motor para vehículos terrestres
-12,120273,drones militares
-12,120274,canoas
-12,120275,drones civiles
-12,120276,retrovisores laterales para vehículos
-12,120277,mosquiteras para sillas de paseo
-12,120277,mosquiteras para sillitas de paseo
-12,120278,palancas de mando para vehículos
-12,120279,vehículos sin conductor [vehículos autónomos]
-12,120279,vehículos autónomos
-12,120280,scooters
-12,120281,scooters para personas con movilidad reducida
-12,120282,ceniceros para automóviles
-12,120283,cadenas de motocicleta
-12,120284,cuadros de motocicleta
-12,120285,manillares de motocicleta
-12,120285,manubrios de motocicleta
-12,120286,motores de motocicleta
-12,120287,cofres especiales para motocicletas
-12,120288,bandajes macizos para ruedas de vehículos
-12,120289,coches de niño
-12,120289,carriolas [coches de niño]
-12,120290,cubrepiés especiales para coches de niño
-12,120291,cubrepiés especiales para sillas de paseo
-12,120291,cubrepiés especiales para sillitas de paseo
-12,120292,inserciones de espuma para neumáticos
-12,120293,bolsas especiales para sillas de paseo
-12,120294,vehículos teledirigidos para inspección submarina
-12,120295,vehículos submarinos autónomos para la inspección del fondo marino
-12,120296,fuelles para autobuses articulados
-12,120297,bicicletas eléctricas
-12,120298,fundas de sillín para motocicletas
-12,120299,coches de carreras
-12,120300,coches robóticos
-12,120301,drones con cámara
-12,120301,drones fotográficos
-12,120302,carros de pesca
-12,120303,carros jaula
-12,120304,tuercas de seguridad para ruedas de vehículos
-12,120305,clips especiales para fijar piezas de automóviles a las carrocerías
-12,120306,trineos de rescate
-12,120307,grúas remolque
-12,120307,camiones-grúa
-12,120308,camiones de basura
-12,120309,remolques para transportar bicicletas
-12,120310,remolques para bicicletas
-12,120311,sillitas de paseo para animales de compañía
-12,120312,camiones con función de grúa integrada
-12,120313,drones de reparto
-12,120314,helicópteros teledirigidos con cámara a bordo
-12,120315,autogiros
-12,120315,girocópteros
-12,120316,helicópteros
-12,120317,transportadores personales
-12,120317,giropodos
-12,120318,tablas de dos ruedas autoequilibradas
-12,120319,monociclos autoequilibrados
-12,120320,pasadores de capó para vehículos
-12,120321,neumáticos para quitanieves
-12,120322,campanas de buceo
-12,120323,portavasos para vehículos
-12,120324,carros*
-12,120325,coches de caballos 
-12,120325,carruajes tirados por caballos
-12,120326,vehículos anfibios
-12,120327,vehículos todoterreno
+class|name
+12|Accionamientos eléctricos para vehículos
+12|Acoplamientos de ejes para vehículos terrestres
+12|Aeronaves
+12|Aeronaves de rotor basculante
+12|Aeronaves eléctricas
+12|Aeronaves ligeras
+12|Alarmas antirrobo para vehículos
+12|Alarmas de seguridad para vehículos
+12|Aletas anti-salpicaduras para vehículos
+12|Amortiguadores de aire para componentes de suspensión de vehículos para el amortiguamiento de asientos y cabinas de conductor
+12|Amortiguadores para automóviles
+12|Amortiguadores para bicicletas
+12|Amortiguadores para motocicletas
+12|Aparatos antirrobo de vehículos
+12|Aparatos de advertencia antirrobo para vehículos automóviles
+12|Arneses de paracaídas
+12|Arneses de seguridad para niños en asientos de vehículos
+12|Arneses para asientos de seguridad para vehículos automóviles
+12|Asientos de automóvil para niños
+12|Asientos de seguridad de animales de compañía para vehículos
+12|Asientos de seguridad para coches
+12|Asientos de vehículos automóviles
+12|Asientos elevadores de vehículos para niños
+12|Asientos infantiles de seguridad para coches
+12|Asientos infantiles de seguridad para vehículos
+12|Asientos infantiles de seguridad para vehículos automóviles
+12|Asientos para autos ferroviarios
+12|Aspas de rotores para helicópteros
+12|Autobuses
+12|Autogiros
+12|Automotores de combustión interna
+12|Automóviles
+12|Automóviles alimentados con hidrógeno
+12|Automóviles eléctricos enchufables
+12|Automóviles híbridos
+12|Automóviles híbridos enchufables
+12|Avión a reacción
+12|Aviones
+12|Aviones de turbopropulsor
+12|Aviones de turborreactor
+12|Aviones eléctricos
+12|Aviones propulsados por hélice
+12|Aviones ultra ligeros
+12|Avisadores acústicos para motocicletas
+12|Bacas
+12|Bandas de rodadura para recauchutar neumáticos
+12|Bandas de rodadura para recauchutar neumáticos de vehículos forestales
+12|Bandas de rodadura para recauchutar neumáticos de vehículos utilizados en la industria de la ingeniería civil
+12|Bandas de rodamiento para el recauchutado de neumáticos para vehículos de ingeniería civil
+12|Barcas de remos japonesas de fondo plano (tenmasen)
+12|Barcos
+12|Barcos de pasajeros
+12|Barcos de pesca
+12|Barcos jon
+12|Barras de torsión para vehículos automóviles
+12|Barras de tracción
+12|Barras de tracción para remolques
+12|Bastidores de motocicletas
+12|Bicicletas
+12|Bicicletas de agua
+12|Bicicletas de carreras
+12|Bicicletas de carreras en carretera
+12|Bicicletas de montaña
+12|Bicicletas de paseo
+12|Bicicletas de reparto
+12|Bicicletas eléctricas
+12|Bicicletas eléctricas plegables
+12|Bicicletas motorizadas.
+12|Bicicletas plegables
+12|Bicicletas tándem
+12|Bocinas de advertencia
+12|Bocinas de bicicleta
+12|Bocinas para vehículos
+12|Bocinas para vehículos automóviles
+12|Bolsas de aire (dispositivos de seguridad para automóviles)
+12|Bolsas de aire para vehículos
+12|Bombas de aire para automóviles
+12|Bombas de aire para hinchar neumáticos de bicicleta
+12|Bombas de aire para motocicletas
+12|Bombas de aire para vehículos a motor de dos ruedas o bicicletas
+12|Bombas para inflar neumáticos de vehículos
+12|Botavaras para barcos
+12|Botes automóviles
+12|Botes de remos
+12|Botes inflables
+12|Brazos de suspensión para teleféricos
+12|Brazos oscilantes para motocicletas
+12|Bujes de ruedas de automóviles
+12|Bujes para ruedas de vehículos
+12|Buques de cableado
+12|Buques de carga
+12|Buses eléctricos
+12|Cables de freno para vehículos
+12|Cadenas antideslizantes para neumáticos de vehículos
+12|Cadenas de accionamiento para vehículos terrestres
+12|Cadenas de bicicleta
+12|Cadenas de rotación para vehículos terrestres
+12|Cadenas de transmisión para motocicletas
+12|Cadenas de transmisión para vehículos terrestres
+12|Cadenas para bicicletas
+12|Cadenas para vehículos automóviles
+12|Cajas de cambios automáticas para vehículos terrestres
+12|Cajas de cambios para vehículos automóviles
+12|Cajas de cambios para vehículos terrestres
+12|Cajas de techo (portaequipajes) para vehículos
+12|Cámaras de aire para bicicletas
+12|Cámaras de aire para ciclos
+12|Cámaras de aire para neumáticos de aeronaves
+12|Cámaras de aire para neumáticos de automóviles
+12|Cámaras de aire para neumáticos de motocicletas
+12|Cámaras de aire para neumáticos de ruedas de vehículos
+12|Cámaras de aire para neumáticos de vehículos
+12|Cámaras de aire para vehículos automóviles de dos ruedas o bicicletas
+12|Cámaras de neumático para ruedas de vehículos
+12|Cambios de velocidad para vehículos terrestres
+12|Camiones
+12|Camiones cisterna
+12|Camiones de riego
+12|Camiones ligeros
+12|Camiones para minas
+12|Camionetas pickup
+12|Cámpers (vehículos recreativos)
+12|Candados antirrobo para uso en volantes de automóviles
+12|Capós de automóviles
+12|Capós de vehículos
+12|Caravanas (remolques)
+12|Carretas
+12|Carretillas
+12|Carretillas con ruedas
+12|Carretillas elevadoras
+12|Carretillas para manipular productos
+12|Carriolas
+12|Carritos (carros móviles)
+12|Carritos de hospital para administrar medicación
+12|Carritos de plataforma
+12|Carritos manuales para vías férreas
+12|Carrocería para vehículos de motor
+12|Carrocerías
+12|Carrocerías blindadas para vehículos
+12|Carrocerías de automóviles
+12|Carrocerías de vehículos
+12|Carrocerías para aeronaves
+12|Carrocerías para autos ferroviarios
+12|Carrocerías para remolques
+12|Carrocerías para vehículos a motor
+12|Carros de golf motorizados
+12|Carros de hospital
+12|Carros de supermercado
+12|Carros y carretillas de tracción humana
+12|Carruajes tirados por caballo
+12|Cárteres para componentes de vehículos automóviles que no sean para motores
+12|Casas flotantes
+12|Cestas adaptadas para bicicletas
+12|Chalupas
+12|Chasis para vagones de ferrocarril
+12|Chasises para vehículos automóviles
+12|Ciclomotores
+12|Ciclomotores eléctricos
+12|Cigüeñales para motocicletas
+12|Cilindros de freno
+12|Cilindros de freno principal
+12|Cinta de agarre para motocicletas
+12|Cinturones de seguridad de vehículo para niños
+12|Cinturones de seguridad para asientos de vehículos
+12|Cinturones de seguridad para vehículos
+12|Circuitos hidráulicos para vehículos
+12|Circuitos hidráulicos para vehículos automóviles
+12|Coches
+12|Coches blindados
+12|Coches de carreras
+12|Coches de ferrocarril eléctrico
+12|Coches de niño
+12|Coches eléctricos
+12|Coches fúnebres
+12|Coches para bebé
+12|Cofres especiales para vehículos de dos ruedas
+12|Cojines para sillas de ruedas para enfermos
+12|Cojinetes antifricción para barcos
+12|Controles de manubrio para ciclomotores
+12|Convertidor de par hidráulico para vehículos terrestres
+12|Convertidores de par motor para vehículos automóviles
+12|Correas de transmisión para vehículos terrestres
+12|Cuadros de ciclo
+12|Cubiertas (neumáticos) para ciclos y bicicletas
+12|Cubiertas convertibles de automóviles
+12|Cubiertas de neumáticos para vehículos
+12|Cubiertas para coches de paseo
+12|Cubos para ruedas de vehículo (motocicletas)
+12|Defensas para barcos (para-golpes)
+12|Desviadores traseros
+12|Dientes de rueda
+12|Discos de freno
+12|Discos de freno para vehículos
+12|Dispositivos antirrobo para vehículos
+12|Dispositivos antirrobo para vehículos automóviles
+12|Dispositivos de conducción y timones para embarcaciones
+12|Ejes para bicicletas
+12|Ejes para sistemas de suspensión neumática en vehículos
+12|Ejes para vehículos terrestres
+12|Ejes y ejes de cardán para vehículos automóviles
+12|Embarcaciones (barcas y barcos)
+12|Embragues para vehículos terrestres
+12|Empujadores de vagonetas de minas
+12|Empuñaduras de freno de mano para vehículos
+12|Empuñaduras de manillares (partes de motocicletas)
+12|Empuñaduras de palanca de cambios para vehículos
+12|Empuñaduras para manillares de bicicletas
+12|Encendedores de cigarrillos para automóviles
+12|Enganches de vagón o ferrocarril
+12|Engranajes de inversión para vehículos terrestres
+12|Engranajes para vehículos
+12|Entremiches para barcos
+12|Equipos de arrastre de vagonetas
+12|Espejos retrovisores para automóviles
+12|Esquife (skiff)
+12|Estabilizadores de bicicletas
+12|Estructuras portaequipajes para bicicletas
+12|Forros de freno
+12|Forros de freno para vehículos automóviles
+12|Forros de freno para vehículos terrestres
+12|Forros de frenos para vehículos
+12|Frenos de bicicleta
+12|Frenos de cinta para vehículos terrestres
+12|Frenos de cono para vehículos terrestres
+12|Frenos de dirección
+12|Frenos de disco hidráulicos
+12|Frenos de disco para vehículos terrestres
+12|Frenos de mano para vehículos terrestres
+12|Frenos de vehículos
+12|Frenos hidráulicos de llanta
+12|Frenos para vehículos automóviles
+12|Fundas adaptadas para carrocerías de vehículos
+12|Fundas ajustables para embarcaciones y vehículos marítimos
+12|Fundas ajustables para motocicletas
+12|Fundas ajustables para volantes de vehículos
+12|Fundas de asiento para vehículos (con forma o a medida)
+12|Fundas para asientos de vehículos
+12|Fundas para volantes de conducir
+12|Fuselajes de aviones
+12|Garfios de barcos (bicheros)
+12|Globos aerostáticos
+12|Globos dirigibles
+12|Guardabarros para automóviles
+12|Guardabarros para bicicletas o automóviles de dos ruedas
+12|Guardabarros para ciclos
+12|Guardabarros para motocicletas
+12|Hélices de avión
+12|Hélices de barco
+12|Helicópteros
+12|Hidroalas
+12|Hidroalas para embarcaciones
+12|Hidroplanos
+12|Hormigoneras (vehículos)
+12|Impulsores de automotores móviles
+12|Infladores de neumáticos
+12|Instalaciones eléctricas antirrobo para vehículos
+12|Intermitentes para vehículos terrestres
+12|Lanchas (botes)
+12|Lanchas de recreo con propulsión a chorro
+12|Limpiafaros
+12|Limpiaparabrisas
+12|Limpiaparabrisas para automóviles
+12|Limpiaparabrisas para vehículos automóviles
+12|Llantas (rines) de ciclo
+12|Llantas de rueda para motocicletas
+12|Llantas para aterrizaje de aeronave
+12|Llantas para bicicletas o vehículos a motor de dos ruedas
+12|Llantas para ruedas de automóviles
+12|Locomotoras de auto generación eléctrica (locomotoras diésel-eléctricas)
+12|Locomotoras de combustión interna
+12|Locomotoras de vapor
+12|Locomotoras eléctricas
+12|Mandos de caja de cambios
+12|Manijas de puerta para vehículos
+12|Manillares de ciclo
+12|Manivelas de ciclo
+12|Manubrios
+12|Manubrios de automóviles
+12|Máquinas de navegación de largo alcance (LORAN)
+12|Marcos de bicicleta y sujeciones de manubrio
+12|Mástiles de barco
+12|Material rodante ferroviario
+12|Mecanismos de embrague para vehículos automóviles
+12|Mecanismos de propulsión para vehículos acuáticos y sus partes
+12|Mecanismos de transmisión para vehículos terrestres
+12|Monociclos
+12|Monociclos autoequilibrantes
+12|Monociclos eléctricos
+12|Motocicletas
+12|Motocicletas de motocross
+12|Motonieves
+12|Motores de gasolina para vehículos terrestres
+12|Motores diésel para vehículos terrestres
+12|Motores para vehículos terrestres
+12|Motores turborreactores para vehículos terrestres
+12|Motos acuáticas
+12|Motos para motocross
+12|Neumáticos macizos
+12|Neumáticos macizos para vehículos
+12|Neumáticos para aeronaves
+12|Neumáticos para automóviles
+12|Neumáticos para bicicletas de niños
+12|Neumáticos para motocicletas
+12|Neumáticos tubulares
+12|Neumáticos y cámaras de aire para bicicletas
+12|Neumáticos y cámaras de aire para ruedas de vehículos forestales
+12|Palancas de freno para bicicletas
+12|Parabrisas de vehículos
+12|Parabrisas para automóviles
+12|Parabrisas para vehículos automóviles
+12|Paracaídas
+12|Parachoques de barcos
+12|Parachoques para automóviles
+12|Parasoles de automóviles
+12|Parasoles de parabrisas de automóvil
+12|Parasoles de parabrisas para automóviles
+12|Parasoles de vehículo automóvil
+12|Parches de caucho adhesivos para reparar cámaras de aire y neumáticos
+12|Parches para cámaras de neumático
+12|Parches para neumáticos
+12|Parches para reparación de neumáticos de vehículos
+12|Parches para reparar neumáticos
+12|Pastillas de frenos para vehículos terrestres
+12|Patinetes
+12|Patinetes (vehículos)
+12|Patinetes automóviles
+12|Pedales de bicicleta
+12|Pedales de motocicleta
+12|Perillas para volantes de automóviles
+12|Pescantes para barcos (pescantes de carga para embarcaciones)
+12|Pesos de aletas guardabarros
+12|Piñones (ruedas dentadas) para vehículos terrestres
+12|Piñones de ruedas traseras
+12|Planeador
+12|Platos de cadena para bicicletas
+12|Platos de cadena para motocicletas
+12|Portaaviones
+12|Portaequipajes ajustados al capó
+12|Portaequipajes para automóviles
+12|Portaequipajes para bicicletas
+12|Portaequipajes para ciclos
+12|Portaequipajes para coches
+12|Portaequipajes para motocicletas
+12|Portaequipajes para vehículos automóviles
+12|Portaesquís para automóviles
+12|Portaesquís para vehículos
+12|Portaesquís para vehículos automóviles
+12|Portallanta de refacción para automóviles
+12|Portavasos adaptados para automóviles
+12|Portillas (ojos de buey) para embarcaciones
+12|Propulsores de hélice para barcos
+12|Propulsores de hélice para vehículos
+12|Protectores de cadena para bicicletas
+12|Protectores de lluvia para ventanas de automóviles
+12|Púas antiderrapantes para neumáticos de vehículos
+12|Puertas de vehículos automóviles
+12|Puertas para autos ferroviarios
+12|Radios de rueda para automóviles
+12|Radios de rueda para motocicletas
+12|Rayos para ruedas de vehículos
+12|Reactores para vehículos terrestres
+12|Recipientes de almacenamiento para bacas de vehículos terrestres
+12|Redes portaequipajes para vehículos
+12|Remolques
+12|Remolques de bicicleta (riyakah)
+12|Remolques de caballos
+12|Remolques para botar barcos
+12|Remolques para transporte de karts
+12|Remos de canoa
+12|Remos de kayak
+12|Reposabrazos para asientos de automóvil
+12|Reposabrazos para sillas de ruedas
+12|Reposabrazos para vehículos
+12|Reposacabezas para asientos de vehículos
+12|Reposacabezas para asientos de vehículos automóviles
+12|Resortes amortiguadores para vehículos automóviles
+12|Respaldos adaptados para su uso en vehículos
+12|Retrovisores
+12|Rines (llantas) para ruedas de vehículos
+12|Rines para ruedas de automóviles
+12|Rines para ruedas de vehículos automóviles
+12|Rotores de frenos para vehículos terrestres
+12|Ruedas de bicicletas
+12|Ruedas de repuesto para bicicletas
+12|Ruedas de repuesto para motocicletas
+12|Ruedas de tren de aterrizaje para aeronaves
+12|Ruedas de vehículos
+12|Ruedas dentadas para vehículos terrestres
+12|Ruedas para automóviles
+12|Ruedas para ciclos y bicicletas
+12|Scooters accionados por medios eléctricos
+12|Scooters eléctricos autoequilibrantes
+12|Sidecares de motocicleta
+12|Sillas de ruedas
+12|Sillas de ruedas eléctricas
+12|Sillas de ruedas manuales
+12|Sillas de ruedas motorizadas para personas discapacitadas y con dificultades de movilidad
+12|Sillines de bicicleta
+12|Sistemas de timón
+12|Soportes de botellas de agua para bicicletas
+12|Soportes de tazas para su uso en vehículos
+12|Submarinos
+12|Suspensión de ruedas
+12|Tablas de escotillas
+12|Tableros para automóviles
+12|Tableros para automóviles
+12|Tambores de freno
+12|Tanques de combustible para aeronaves
+12|Tapacubos para rines
+12|Tapones para depósitos de gasolina de vehículos automóviles
+12|Techos convertibles para vehículos
+12|Techos corredizos (sunroof)de automóviles
+12|Telesillas
+12|Timones para barcos
+12|Tractores
+12|Tractores agrícolas
+12|Tractores guiados automáticamente (sin conductor) para el manejo de materiales
+12|Transportadores aéreos
+12|Trenes alimentados con hidrógeno
+12|Trenes de aterrizaje de aeronaves
+12|Trenes de carga
+12|Triciclos
+12|Trolebuses
+12|Turbinas de aire para vehículos terrestres
+12|Turbinas de gas para vehículos terrestres
+12|Turbinas de vapor para vehículos terrestres
+12|Turbinas hidráulicas para vehículos terrestres
+12|Turbinas para vehículos terrestres
+12|Vagones de ferrocarril
+12|Vagones de ferrocarril de pasajeros
+12|Vagones frigoríficos (coches de ferrocarril)
+12|Vagones para transporte de carga
+12|Vagones pequeños para niños
+12|Válvulas para neumáticos de vehículos
+12|Vehículo de uso recreativo combinado con remolque para caballos
+12|Vehículos a motor para la nieve
+12|Vehículos aéreos no tripulados (drones) con cámara
+12|Vehículos aerodeslizadores
+12|Vehículos anfibios
+12|Vehículos automóviles de carreras
+12|Vehículos automóviles de dos ruedas
+12|Vehículos automóviles para transportación terrestre
+12|Vehículos blindados
+12|Vehículos de celda de combustible
+12|Vehículos de doble tracción
+12|Vehículos de motor accionados eléctricamente
+12|Vehículos eléctricos autopropulsados
+12|Vehículos eléctricos de pilas de combustible
+12|Vehículos espaciales
+12|Vehículos frigoríficos
+12|Vehículos guiados automáticamente
+12|Vehículos para discapacitados físicos o con movilidad reducida
+12|Vehículos para remolque de aviones
+12|Vehículos recolectores de basura
+12|Vehículos sobre raíles
+12|Vehículos submarinos operados remotamente para transporte (ROVs)
+12|Vehículos sumergibles tripulados
+12|Vehículos terrestres
+12|Vehículos terrestres blindados
+12|Vehículos todo terreno
+12|Veleros
+12|Ventanas de vehículos
+12|Ventanas de vehículos automóviles
+12|Viseras para automóviles
+12|Yates
+12|Zapatas de freno para vehículos automóviles
+12|Zapatas de freno para vehículos terrestres

--- a/lib/seeds/class_13_terms.csv
+++ b/lib/seeds/class_13_terms.csv
@@ -1,94 +1,98 @@
-class,reference_id,name
-13,130001,acetilnitrocelulosa
-13,130002,cureñas de cañones
-13,130003,cartuchos explosivos
-13,130005,explosivos de nitrato de amonio
-13,130006,detonadores
-13,130007,armas motorizadas
-13,130008,armas de protección con gas lacrimógeno
-13,130009,armas de fuego
-13,130010,escobillones para limpiar armas de fuego
-13,130013,fuegos artificiales
-13,130014,piezas de artillería
-13,130015,misiles balísticos
-13,130015,armas balísticas
-13,130016,aparatos para llenar cartucheras
-13,130017,luces de Bengala
-13,130018,tapones detonantes
-13,130019,casquillos de cartuchos
-13,130020,cañones
-13,130021,cañones de fusil
-13,130022,carabinas
-13,130022,rifles
-13,130023,cartuchos*
-13,130024,aparatos para cargar cartuchos
-13,130025,cartucheras
-13,130026,armas de fuego para cazar
-13,130026,armas de fuego de deporte
-13,130027,municiones
-13,130028,percutores de fusil
-13,130029,cuernos de pólvora
-13,130030,pólvora de algodón
-13,130030,algodón pólvora [pólvora de algodón]
-13,130030,piroxilina
-13,130031,culatas de armas de fuego
-13,130032,dinamita
-13,130033,estuches para fusiles
-13,130034,explosivos
-13,130034,productos fulminantes
-13,130035,cohetes de señales
-13,130036,fusiles [armas]
-13,130037,cajas de fusil
-13,130037,culatas de fusil
-13,130038,miras de espejo para fusiles
-13,130040,guardamontes de fusiles
-13,130040,protectores de gatillo para fusiles
-13,130041,granalla de plomo [perdigones]
-13,130041,perdigones
-13,130042,municiones para armas de fuego
-13,130043,lanzacohetes
-13,130044,mechas para explosivos de minería
-13,130045,minas [explosivos]
-13,130046,ametralladoras
-13,130046,metralletas
-13,130047,morteros [armas de fuego]
-13,130048,obuses
-13,130049,pistolas [armas]
-13,130050,pólvora de cañón
-13,130051,pólvoras explosivas
-13,130052,proyectiles [armas]
-13,130053,sustancias pirofóricas
-13,130054,productos pirotécnicos
-13,130055,revólveres
-13,130056,muñones de armas pesadas
-13,130057,plataformas de tiro
-13,130058,dispositivos de puntería para armas de fuego que no sean miras telescópicas
-13,130058,miras para armas de fuego que no sean miras telescópicas
-13,130059,pistolas de aire comprimido [armas]
-13,130060,mechas para explosivos
-13,130061,cebos explosivos
-13,130062,cordones detonantes para explosivos
-13,130063,bandoleras para armas
-13,130064,señales de niebla explosivas
-13,130064,señales de bruma explosivas
-13,130065,miras para piezas de artillería que no sean miras telescópicas
-13,130066,cebos fulminantes que no sean de juguete
-13,130066,cápsulas detonantes*
-13,130066,cápsulas fulminantes que no sean de juguete
-13,130066,casquillos fulminantes que no sean de juguete
-13,130068,cohetes [proyectiles]
-13,130069,fusiles lanzaarpones [armas]
-13,130070,silenciadores para armas
-13,130071,carros de combate
-13,130071,tanques [carros de combate]
-13,130072,petardos
-13,130073,aerosoles de defensa personal
-13,130074,cananas
-13,130075,cintas de cartuchos para armas de fuego automáticas
-13,130075,cintas de municiones para armas de fuego
-13,130076,torpedos
-13,130077,armas cortas [armas de fuego]
-13,130077,armas de cinto [armas de fuego]
-13,130078,granadas de mano
-13,130079,pistolas de bengalas
-13,130080,luces de bengala de emergencia explosivas o pirotécnicas
+class|name
+13|Aerosoles de defensa personal
+13|Ametralladoras
+13|Aparatos de detonación para volar minas submarinas
+13|Armas automáticas
+13|Armas de fuego
+13|Armas de fuego automáticas
+13|Armas de protección con gas lacrimógeno
+13|Armas eléctricas dirigidas
+13|Armas pesadas
+13|Balas para pistolas de aire comprimido
+13|Bípodes para armas de fuego
+13|Bolsos especialmente adaptados para transportar rifles
+13|Bombas (armamento)
+13|Bombas aéreas
+13|Bombas de gas (armas)
+13|Cabezas explosivas de infrarrojos para cohetes de defensa
+13|Cajas de fusil
+13|Cananas
+13|Cañones (piezas de artillería)
+13|Cañones antiaéreos
+13|Carabinas
+13|Carcasas de fuegos artificiales
+13|Carga explosivas de profundidad
+13|Cargadores para armas pequeñas
+13|Cargas pirotécnicas
+13|Cartuchos cebo
+13|Cartuchos de escopeta
+13|Cartuchos explosivos
+13|Cartuchos incendiarios
+13|Cartuchos para ametralladoras
+13|Cartuchos para pólvora
+13|Cartuchos para productos pirotécnicos
+13|Cartuchos para rifle
+13|Cartuchos para rifles para la caza
+13|Cebos para explosivos
+13|Cohetes (proyectiles)
+13|Cohetes de observación
+13|Correas para fusiles
+13|Culatas de fusil
+13|Cureñas de cañones
+13|Dinamitas
+13|Dispositivos de explosión
+13|Elevadores de carga para municiones
+13|Estuches para armas de fuego
+13|Estuches para pistolas y rifles
+13|Explosivos líquidos
+13|Fuegos artificiales
+13|Fuegos artificiales en formas de cartucho
+13|Fuegos de señalización
+13|Fundas combinadas para armas de fuego y municiones
+13|Fundas para fusiles
+13|Granadas de mano
+13|Iniciadores (detonadores cebo)
+13|Lanzadores para bombas
+13|Mechas para explosivos
+13|Mezclas pirotécnicas de propulsión para municiones y motores de cohetes
+13|Minas (explosivos)
+13|Minas antitanque
+13|Minas marinas
+13|Minas submarinas
+13|Miras de armas de fuego
+13|Miras de espejo para rifles
+13|Misiles aire-superficie
+13|Misiles balísticos propulsados por cohete
+13|Misiles productores de humo para tanques y vehículos acorazados
+13|Morteros (armas de fuego)
+13|Municiones para armas de fuego
+13|Municiones para rifles
+13|Nitrocelulosa
+13|Obuses
+13|Petardos
+13|Piezas de artillería de largo alcance
+13|Pistolas
+13|Pistolas de aire comprimido
+13|Pistolas de bengalas
+13|Pistolas paralizantes
+13|Pistolas sin retroceso
+13|Placas de culata para escopetas
+13|Plataformas de tiro
+13|Pólvora negra
+13|Pólvora para pistolas
+13|Polvos explosivos
+13|Proyectiles de artillería guiados
+13|Proyectiles perforantes
+13|Proyectiles pirotécnicos
+13|Proyectiles productores de humo
+13|Proyectiles productores de humo para cohetes
+13|Receptores de cartuchos para armas de fuego automáticas
+13|Revólveres
+13|Revólveres automáticos
+13|Rifles militares
+13|Rifles para la caza (rifles de deporte)
+13|Señales de humo explosivas luminosas
+13|Silenciadores para armas
+13|Sistemas de recarga automática de armas de fuego
+13|Tapones detonantes
+13|Torpedos

--- a/lib/seeds/class_14_terms.csv
+++ b/lib/seeds/class_14_terms.csv
@@ -1,118 +1,227 @@
-class,reference_id,name
-14,140001,ágatas
-14,140002,manecillas de reloj
-14,140002,agujas de reloj
-14,140003,lingotes de metales preciosos
-14,140004,joyas de ámbar amarillo
-14,140005,perlas de ámbar prensado
-14,140006,amuletos [joyería]
-14,140008,plata hilada
-14,140009,hilos de plata [joyería]
-14,140009,hilados de plata [joyería]
-14,140011,relojes que no sean de uso personal
-14,140013,péndulos [piezas de reloj]
-14,140014,tambores de reloj
-14,140015,pulseras [joyería]
-14,140016,relojes de pulsera
-14,140017,pulseras de reloj
-14,140017,extensibles de reloj
-14,140018,dijes [joyería]
-14,140019,broches [joyería]
-14,140021,esferas [piezas de reloj]
-14,140022,relojes de sol
-14,140023,maquinarias de reloj
-14,140024,cadenas [joyería]
-14,140025,cadenas de reloj
-14,140027,cronógrafos [relojes de pulsera]
-14,140028,cronómetros
-14,140029,cronoscopios
-14,140030,instrumentos cronométricos
-14,140031,collares [joyería]
-14,140032,relojes eléctricos
-14,140033,pasadores de corbata
-14,140033,sujetacorbatas
-14,140034,monedas
-14,140035,diamantes*
-14,140040,hilos de metales preciosos [joyería]
-14,140040,hilados de metales preciosos [joyería]
-14,140042,relojes atómicos
-14,140043,relojes de control [relojes maestros]
-14,140043,relojes magistrales
-14,140044,cajas de reloj
-14,140045,iridio
-14,140046,joyas de marfil
-14,140047,adornos de azabache
-14,140048,azabache en bruto o semiacabado
-14,140049,fichas de cobre
-14,140050,artículos de joyería
-14,140051,medallones [joyería]
-14,140052,medallas
-14,140055,metales preciosos en bruto o semielaborados
-14,140057,relojes de uso personal
-14,140058,resortes de reloj
-14,140058,muelles de reloj
-14,140059,cristales de reloj
-14,140060,mecanismos de relojería
-14,140062,olivino [piedras preciosas]
-14,140062,peridoto [piedras preciosas]
-14,140063,oro en bruto o batido
-14,140064,hilos de oro [joyería]
-14,140064,hilados de oro [joyería]
-14,140066,osmio
-14,140067,paladio
-14,140069,alfileres de adorno
-14,140070,perlas [joyería]
-14,140073,piedras semipreciosas
-14,140074,piedras preciosas
-14,140074,pedrería [piedras preciosas]
-14,140075,platino [metal]
-14,140082,despertadores
-14,140083,rodio
-14,140085,rutenio
-14,140095,espinelas [piedras preciosas]
-14,140096,estatuas de metales preciosos
-14,140097,estrás
-14,140097,bisutería [joyería]
-14,140104,aleaciones de metales preciosos
-14,140106,áncoras [artículos de relojería]
-14,140107,anillos [joyería]
-14,140107,sortijas [joyería]
-14,140109,obras de arte de metales preciosos
-14,140113,cajas de metales preciosos
-14,140117,artículos de joyería para la sombrerería
-14,140118,pendientes
-14,140118,aretes
-14,140119,artículos de joyería para el calzado
-14,140122,gemelos*
-14,140122,mancuernas [gemelos]
-14,140123,bustos de metales preciosos
-14,140144,carcasas de reloj de uso personal
-14,140145,estuches de presentación para relojes de uso personal
-14,140146,figuritas de metales preciosos
-14,140146,estatuillas de metales preciosos
-14,140150,alfileres [joyería]
-14,140151,alfileres de corbata
-14,140151,fistoles
-14,140152,insignias de metales preciosos
-14,140162,llaveros [anillas partidas con dijes o abalorios]
-14,140163,plata en bruto o batida
-14,140164,cronómetros manuales
-14,140165,joyas de esmalte alveolado
-14,140166,joyeros
-14,140167,cuentas para confeccionar joyas
-14,140168,cierres [broches] para joyería
-14,140169,insumos de joyería
-14,140170,joyeros enrollables
-14,140171,cabujones
-14,140172,anillas abiertas de metales preciosos para llaves
-14,140173,estuches de presentación para artículos de joyería
-14,140174,manecillas de reloj de uso personal
-14,140175,misbaha [collares de oración]
-14,140176,pulseras de materias textiles bordadas [joyería]
-14,140177,dijes para llaveros
-14,140178,rosarios
-14,140179,crucifijos de metales preciosos que no sean artículos de joyería
-14,140180,crucifijos en cuanto artículos de joyería
-14,140181,llaveros retráctiles
-14,140182,alfileres de joyería para sombreros
-14,140182,prendedores de joyería para sombreros
+class|name
+14|Adornos de metales preciosos en la forma de joyas
+14|Adornos de metales preciosos para calzado
+14|Ágata y ónice (en bruto)
+14|Aleaciones de metales preciosos
+14|Aleaciones de plata en bruto
+14|Alfileres de adorno de metales preciosos
+14|Alfileres de adorno para solapa
+14|Alfileres de corbata
+14|Alfileres de corbata de metales preciosos
+14|Alfileres de joyería
+14|Alfileres de joyería para su uso en sombreros
+14|Alfileres de solapa (joyería)
+14|Alianzas de boda
+14|Amuletos (artículos de joyería)
+14|Anillos (artículos de joyería)
+14|Anillos chapados en oro
+14|Anillos de boda
+14|Anillos de compromiso
+14|Aparatos e instrumentos cronométricos
+14|Aparatos para cronometraje de eventos deportivos
+14|Aros para perforaciones corporales
+14|Artículos de bisutería
+14|Artículos de joyería
+14|Artículos de joyería chapados con metales preciosos
+14|Artículos de joyería de diamantes
+14|Artículos de joyería de imitación
+14|Artículos de joyería e imitaciones de artículos de joyería
+14|Artículos de joyería para la cabeza
+14|Artículos de joyería y piedras preciosas
+14|Artículos de joyería y relojes
+14|Artículos de relojería e instrumentos cronométricos y sus estuches
+14|Artículos de relojería e instrumentos cronométricos y sus partes
+14|Biseles de reloj
+14|Brazalete (artículos de joyería)
+14|Brazaletes
+14|Brazaletes de plástico en forma de joyas
+14|Broches para bufandas con joyas
+14|Bustos de metales preciosos
+14|Cadenas de joyería
+14|Cadenas de joyería de metales preciosos para pulseras
+14|Cadenas de reloj
+14|Cadenas para llaves como joyería (dijes o llaveros)
+14|Cadenas para llevar al cuello
+14|Cajas de metales preciosos
+14|Cajas de presentación para piedras preciosas
+14|Cajas de presentación para relojes
+14|Cajas de reloj
+14|Cajas de reloj de pulsera
+14|Cajas decorativas hechas de metales preciosos
+14|Cajas exhibidoras especiales para relojes (watch winders)
+14|Calcedonia
+14|Camafeos (joyería)
+14|Cápsulas de metales preciosos para botellas
+14|Carcasas de reloj
+14|Cierres de relojes
+14|Clips de joyería para adaptar aros de piercing a aros de clip
+14|Cofres para relojes y joyas
+14|Colgantes de ámbar (joyería)
+14|Colgantes de ámbar prensado (joyería)
+14|Collares
+14|Collares (artículos de joyería)
+14|Collares con peto
+14|Coronas de reloj
+14|Cristales de reloj
+14|Cronógrafos como relojes
+14|Cronómetros
+14|Cronómetros manuales
+14|Despertadores
+14|Diademas
+14|Diales para fabricas relojes y relojes de pulsera
+14|Diamantes cortados
+14|Diamantes en bruto
+14|Dijes de joyería de metales preciosos o chapados
+14|Dijes de metales preciosos o chapados con los mismos
+14|Esferas de reloj de pulsera
+14|Esmeralda
+14|Espinelas
+14|Estatuas de metales preciosos
+14|Estatuas de metales preciosos y sus aleaciones
+14|Estatuillas de metales preciosos
+14|Estatuillas de metales preciosos y sus aleaciones
+14|Estuches adaptados para anillos de joyería para protegerlos del impacto, la abrasión y el daño a las argollas y piedras
+14|Estuches de madera para artículos de joyería
+14|Estuches para joyas
+14|Estuches para joyas de metales preciosos
+14|Estuches para relojería
+14|Estuches para relojes
+14|Extensibles de reloj
+14|Extensibles metálicos, cuero o de materias plásticas para reloj
+14|Extensibles para reloj de cuero
+14|Extensibles y correas para reloj
+14|Figuras de metales preciosos
+14|Figuras modelo (adornos) de metales preciosos
+14|Gargantillas
+14|Gemas
+14|Gemas preciosas o semipreciosas
+14|Gemelos
+14|Gemelos de metales preciosos
+14|Gemelos de porcelana
+14|Gemelos y pasadores de corbata
+14|Hebillas para extensibles de reloj
+14|Insignias de metales preciosos
+14|Instrumentos cronométricos y relojes
+14|Iridio y sus aleaciones
+14|Jade (artículos de joyería)
+14|Joyas
+14|Joyas preciosas
+14|Joyería de filigrana de oro
+14|Joyería identificativa institucional
+14|Joyería para damas
+14|Joyería, incluyendo bisutería y bisutería de plástico
+14|Joyeros
+14|Joyeros (estuches para joyas) de metales preciosos
+14|Joyeros de metales preciosos
+14|Joyeros musicales
+14|Joyeros que no sean de metales preciosos
+14|Leontinas
+14|Lingotes de aleaciones de oro
+14|Lingotes de aleaciones de plata
+14|Lingotes de aleaciones de platino
+14|Lingotes de oro
+14|Lingotes de plata
+14|Lingotes de platino
+14|Llaveros como joyería (dijes o llaveros de aro)
+14|Llaveros de cuero
+14|Llaveros de metales comunes
+14|Llaveros de metales preciosos
+14|Llaveros metálicos
+14|Manecillas de reloj
+14|Medallas
+14|Medallas conmemorativas
+14|Medallas y medallones
+14|Medallones
+14|Medallones (artículos de joyería)
+14|Metales preciosos
+14|Metales preciosos en bruto o semielaborado
+14|Metales preciosos y las aleaciones de estos
+14|Monedas coleccionables
+14|Monedas conmemorativas
+14|Obras de arte de metales preciosos
+14|Olivina (peridoto)
+14|Ópalo
+14|Oro
+14|Oro en bruto o semielaborado
+14|Oro y sus aleaciones
+14|Osmio y sus aleaciones
+14|Paladio y sus aleaciones
+14|Partes de reloj
+14|Pasadores de corbata
+14|Pasadores de corbata de metales preciosos
+14|Pendientes
+14|Pendientes chapados en oro
+14|Pendientes con agujero
+14|Pendientes de aro
+14|Pendientes de gota
+14|Pendientes de joyería
+14|Pendientes de presión
+14|Péndulos para relojes
+14|Pequeños joyeros de metales preciosos
+14|Perlas (artículos de joyería)
+14|Perlas cultivadas
+14|Perlas de imitación
+14|Piedras preciosas
+14|Piedras preciosas artificiales
+14|Piedras preciosas en bruto
+14|Piedras preciosas o semipreciosas
+14|Piedras preciosas sintéticas
+14|Piedras preciosas y relojes
+14|Piedras preciosas y semipreciosas
+14|Piedras preciosas y sus imitaciones en bruto o semielaboradas
+14|Piedras semipreciosas
+14|Piedras semipreciosas semielaboradas y sus imitaciones
+14|Pinzas de corbata
+14|Plata
+14|Plata en lingotes
+14|Plata y sus aleaciones
+14|Platino
+14|Platino y sus aleaciones
+14|Productos de relojería
+14|Pulseras
+14|Pulseras con fines solidarios
+14|Pulseras de cuentas de madera
+14|Pulseras de tobillo
+14|Relojes
+14|Relojes atómicos
+14|Relojes de bolsillo
+14|Relojes de buceo
+14|Relojes de deportes
+14|Relojes de escritorio
+14|Relojes de mesa
+14|Relojes de metales preciosos o chapados con los mismos
+14|Relojes de pared
+14|Relojes de pared y relojes de pulsera para colombófilos
+14|Relojes de péndulo
+14|Relojes de pie
+14|Relojes de pulsera
+14|Relojes de pulsera para deportes
+14|Relojes de sol
+14|Relojes de vestir
+14|Relojes de viaje
+14|Relojes e instrumentos cronométricos
+14|Relojes mecánicos y automáticos
+14|Relojes para damas
+14|Relojes para uso en exteriores
+14|Relojes para vehículos
+14|Relojes pequeños
+14|Relojes y artículos de joyería
+14|Relojes y extensibles para reloj
+14|Relojes y partes de los mismos
+14|Relojes, artículos de joyería
+14|Relojes, artículos e imitaciones de joyería
+14|Resortes de relojes
+14|Rodio y sus aleaciones
+14|Rollos organizadores de joyas para viaje
+14|Rubí
+14|Rutenio y sus aleaciones
+14|Saquitos de joyería a medida
+14|Saquitos para relojes
+14|Sardónice (no tallado)
+14|Tanzanita (gemas)
+14|Tobilleras (artículos de joyería)
+14|Topacio
+14|Trofeos de metales preciosos
+14|Turmalinas (piedras semi-preciosas)
+14|Zafiro
+14|Zarcillos

--- a/lib/seeds/class_15_terms.csv
+++ b/lib/seeds/class_15_terms.csv
@@ -1,102 +1,116 @@
-class,reference_id,name
-15,150001,acordeones
-15,150002,afinadores de cuerdas [templadores]
-15,150002,templadores [afinadores de cuerdas]
-15,150003,lengüetas [música]
-15,150004,arcos para instrumentos musicales
-15,150005,alzas de arcos para instrumentos musicales
-15,150006,varillas de arcos para instrumentos musicales
-15,150007,crin de caballo para arcos de instrumentos musicales
-15,150008,pianos
-15,150009,batutas
-15,150010,palillos de tambor
-15,150010,baquetas
-15,150011,bandoneones
-15,150012,organillos
-15,150013,bajos [instrumentos musicales]
-15,150014,armónicas
-15,150015,cuerdas de tripa para instrumentos musicales
-15,150016,trombones Buccin
-15,150017,carillones [instrumentos musicales]
-15,150018,castañuelas
-15,150019,chinescos [instrumentos musicales]
-15,150020,pies para timbales
-15,150021,clavijas para instrumentos musicales
-15,150022,cítaras
-15,150023,clarinetes
-15,150024,teclados de instrumentos musicales
-15,150025,instrumentos musicales
-15,150026,concertinas
-15,150027,contrabajos
-15,150028,cuerdas para instrumentos musicales
-15,150029,instrumentos de cuerda
-15,150030,trompas [instrumentos musicales]
-15,150031,cornetines de pistones
-15,150032,címbalos [platillos]
-15,150033,diapasones
-15,150034,boquillas de instrumentos musicales
-15,150034,embocaduras de instrumentos musicales
-15,150035,estuches para instrumentos musicales
-15,150036,flautas
-15,150037,gongs
-15,150038,birimbaos [arpas de boca]
-15,150039,guitarras
-15,150040,armonios
-15,150041,arpas
-15,150042,cuerdas de arpa
-15,150043,oboes
-15,150044,instrumentos musicales electrónicos
-15,150045,reguladores de intensidad para pianos mecánicos
-15,150046,liras
-15,150048,plectros
-15,150048,púas para instrumentos de cuerda
-15,150049,mandolinas
-15,150050,mentoneras de violín
-15,150051,gaitas [instrumentos musicales]
-15,150052,cajas de música
-15,150053,aparatos para pasar páginas de partituras
-15,150054,puentes para instrumentos musicales
-15,150055,triángulos [instrumentos musicales]
-15,150056,ocarinas
-15,150057,órganos
-15,150058,tubos para órganos musicales
-15,150059,parches [membranas] de tambor
-15,150060,pedales de instrumentos musicales
-15,150061,teclados de piano
-15,150062,cuerdas de piano
-15,150063,teclas de piano
-15,150064,fuelles de instrumentos musicales
-15,150065,sordinas para instrumentos musicales
-15,150066,tambores [instrumentos musicales]
-15,150067,panderetas
-15,150068,tamtanes
-15,150069,timbales [instrumentos musicales]
-15,150070,trombones [instrumentos musicales]
-15,150071,clarines
-15,150072,trompetas
-15,150073,válvulas para instrumentos musicales
-15,150074,violas
-15,150075,violines
-15,150076,xilófonos
-15,150077,teclas de instrumentos musicales
-15,150078,rollos de música
-15,150078,rollos para pianolas
-15,150079,rollos de música perforados
-15,150079,rollos perforados para pianolas
-15,150080,atriles para partituras
-15,150081,huqin [violines chinos]
-15,150082,flautas de bambú
-15,150083,pipa [guitarras chinas]
-15,150084,sheng [instrumentos musicales de viento chinos]
-15,150085,suona [trompetas chinas]
-15,150086,campanillas [instrumentos musicales]
-15,150087,sintetizadores de música
-15,150088,soportes para instrumentos musicales
-15,150089,saxofones
-15,150090,balalaicas
-15,150091,banjos
-15,150092,melódicas
-15,150093,colofonia para instrumentos musicales de cuerda
-15,150094,baterías robóticas [instrumentos de música]
-15,150095,mazas para instrumentos musicales
-15,150096,correas para instrumentos musicales
+class|name
+15|Acordeones
+15|Afinadores de soplo para instrumentos musicales
+15|Almohadillas de práctica de percusión
+15|Almohadillas para baterías electrónicas
+15|Aparatos para afinar instrumentos musicales
+15|Aparatos para pasar páginas de partituras
+15|Apoyabrazos de guitarra
+15|Arcos de erhu (violín chino)
+15|Arcos para instrumentos musicales
+15|Armónicas
+15|Armonios
+15|Arneses para instrumentos musicales
+15|Arpas
+15|Atriles para partituras
+15|Bajos acústicos
+15|Bajos eléctricos
+15|Bandoleras (correas) para guitarras
+15|Bandoneones
+15|Bolsos especialmente adaptados para instrumentos musicales
+15|Bombardinos
+15|Bombos
+15|Boquillas de instrumentos musicales
+15|Cajas de música que no sean juguetes
+15|Cajas de ritmos
+15|Campanas tubulares
+15|Campanillas (instrumentos musicales)
+15|Capos (cejillas)
+15|Capos de guitarra
+15|Carillones eléctricos (instrumentos musicales)
+15|Carrillones
+15|Celestas
+15|Címbalos (platillos)
+15|Cítaras coreanas con doce cuerdas (ga-ya-geum)
+15|Cítaras coreanas con seis cuerdas (geo-mun-go)
+15|Clarinetes de bambú japoneses (shakuhachi)
+15|Clavicordios
+15|Contrabajos
+15|Contrafagotes
+15|Cornos ingleses
+15|Correas para instrumentos de música
+15|Cuerdas de erhu (violín chino)
+15|Cuerdas de guitarra
+15|Cuerdas para instrumentos de cuerda de estilo japonés
+15|Cuerdas para instrumentos musicales
+15|Cuerdas para instrumentos musicales occidentales
+15|Diapasones
+15|Djembes (instrumento musical de percusión)
+15|Dulcimeros
+15|Erhu (instrumento musical de dos cuerdas)
+15|Estuches para instrumentos musicales
+15|Fagot
+15|Flautas
+15|Flautas chinas
+15|Flautas cortas de bambú (danso)
+15|Flautas dulces (instrumentos musicales)
+15|Flautas japonesas (yokobue)
+15|Flautines
+15|Gaitas
+15|Gongs
+15|Güiros (instrumentos musicales de percusión)
+15|Guitarras
+15|Guitarras acústicas
+15|Guitarras bajo
+15|Guitarras eléctricas
+15|Guitarras japonesas de tres cuerdas (shamisen)
+15|Harpas orientales (koto)
+15|Instrumentos de percusión
+15|Instrumentos de viento de madera
+15|Instrumentos musicales
+15|Instrumentos musicales eléctricos y electrónicos
+15|Instrumentos musicales electrónicos
+15|Instrumentos musicales estilo occidental
+15|Instrumentos musicales japoneses tradicionales
+15|Laúdes
+15|Laúdes japoneses (biwa)
+15|Mandolinas
+15|Maracas
+15|Marimbas
+15|Mazas de bombo
+15|Membranas para flautas chinas
+15|Mirlitones (kazoo)
+15|Ocarinas
+15|Ocarinas Chinas (Xun)
+15|Órganos
+15|Pedales para baterías (instrumentos musicales)
+15|Pianos eléctricos automáticos
+15|Picas para violonchelos
+15|Plectros japoneses (tsume)
+15|Protectores de membranas para flauta china
+15|Púas de guitarra
+15|Púas japonesas (bachi)
+15|Púas para instrumentos de cuerda
+15|Puentes para instrumentos musicales
+15|Redoblantes (tambores)
+15|Saxofones
+15|Shofares
+15|Sistros
+15|Sordinas para instrumentos musicales
+15|Tambores (instrumentos musicales)
+15|Tambores bongó
+15|Tambores conga
+15|Tambores japoneses (taiko)
+15|Tambores metálicos (instrumentos musicales)
+15|Tapones para convertir flautas de platos abiertos en flautas de platos cerrados
+15|Timbales (instrumentos de música)
+15|Timbales (instrumentos musicales)
+15|Triángulos (instrumentos musicales)
+15|Trombones (instrumentos musicales)
+15|Trompas (corno francés)
+15|Trompetas
+15|Ukeleles
+15|Violas
+15|Violines
+15|Violines orientales (kokyu)
+15|Violoncelos

--- a/lib/seeds/class_16_terms.csv
+++ b/lib/seeds/class_16_terms.csv
@@ -1,433 +1,641 @@
-class,reference_id,name
-16,160001,letras de acero
-16,160002,plumas de acero
-16,160003,distribuidores de cinta adhesiva [artículos de papelería]
-16,160004,sellos de direcciones
-16,160004,timbres [sellos] de direcciones
-16,160004,timbres [sellos] de direcciones [señas]
-16,160005,máquinas para imprimir direcciones [señas]
-16,160005,direccionadoras [máquinas]
-16,160006,papel*
-16,160007,carteles
-16,160007,pósters
-16,160008,carteleras [tablones de anuncios] de papel o cartón
-16,160009,máquinas franqueadoras de oficina
-16,160010,grapas de oficina
-16,160010,clips de oficina
-16,160011,clips para plumas
-16,160011,prendedores de portaplumas
-16,160012,grapadoras [artículos de papelería]
-16,160012,abrochadoras [artículos de papelería]
-16,160013,álbumes
-16,160014,ilustraciones
-16,160015,láminas [grabados]
-16,160016,vitolas [anillas de puros]
-16,160016,anillas de puro [vitolas]
-16,160017,máquinas eléctricas o no para afilar lápices
-16,160018,sujetalibros
-16,160019,tientos [apoyamanos] para pintores
-16,160020,acuarelas
-16,160021,maquetas de arquitectura
-16,160022,carpetas para documentos
-16,160023,pizarras para escribir
-16,160024,lápices de pizarra
-16,160024,pizarrines
-16,160025,papel de plata
-16,160025,papel de aluminio
-16,160026,arcilla de modelar
-16,160027,tablas aritméticas
-16,160028,grabados
-16,160028,objetos de arte grabados
-16,160029,objetos de arte litografiados
-16,160030,cuadros [pinturas] enmarcados o no
-16,160030,pinturas [cuadros] enmarcadas o no
-16,160031,lápices*
-16,160032,diarios
-16,160032,periódicos
-16,160033,publicaciones periódicas
-16,160034,atlas
-16,160035,carpetas de anillas para hojas sueltas
-16,160036,cintas engomadas [artículos de papelería]
-16,160037,posavasos para cerveza
-16,160038,billetes [tickets]
-16,160038,boletos [billetes]
-16,160038,tickets [billetes]
-16,160039,muestras biológicas para la microscopia [material didáctico]
-16,160039,cortes biológicos para la microscopia [material didáctico]
-16,160040,clichés de imprenta
-16,160041,blocs de dibujo
-16,160042,blocs [artículos de papelería]
-16,160043,bobinas para cintas entintadas
-16,160045,brazaletes para sujetar instrumentos de escritura
-16,160046,folletos
-16,160047,patrones de bordado
-16,160048,chinchetas
-16,160048,chinches
-16,160048,tachuelas [chinchetas]
-16,160049,mojasellos
-16,160050,brochas para pintores
-16,160051,papel secante
-16,160051,secantes
-16,160052,sellos de estampar
-16,160053,sellos de lacre
-16,160054,tampones [almohadillas] de tinta
-16,160055,lacre
-16,160055,cera para lacrar
-16,160056,máquinas de sellado para oficinas
-16,160057,materiales para sellar
-16,160058,cuadernos
-16,160059,bandejas para contar y clasificar monedas
-16,160061,calcos
-16,160061,patrones para calcar
-16,160062,papel de calco
-16,160063,tela para calcar
-16,160064,dediles de oficina
-16,160065,caracteres de imprenta
-16,160066,papel carbón
-16,160066,papel carbónico
-16,160067,papel para máquinas registradoras
-16,160068,libretas
-16,160069,escuadras graduadas de dibujo
-16,160070,tarjetas*
-16,160071,material de instrucción, excepto aparatos
-16,160071,material didáctico, excepto aparatos
-16,160072,fichas [artículos de papelería]
-16,160074,hojas de papel [artículos de papelería]
-16,160075,cartón*
-16,160076,sombrereras de cartón [cajas]
-16,160077,tarjetas perforadas para telares Jacquard
-16,160078,tubos de cartón
-16,160080,catálogos
-16,160081,marcos portaetiquetas para ficheros
-16,160082,cancioneros
-16,160084,chibaletes [imprenta]
-16,160085,fundas para documentos
-16,160087,caballetes de pintura
-16,160088,números [caracteres de imprenta]
-16,160089,tinta china
-16,160090,cromolitografías
-16,160091,ceras de modelar que no sean para uso dental
-16,160092,archivadores [artículos de oficina]
-16,160093,perforadoras [artículos de oficina]
-16,160094,papel higiénico
-16,160095,libros
-16,160096,compases de trazado
-16,160096,compases de dibujo
-16,160097,caracteres [números y letras]
-16,160097,letras [caracteres de imprenta]
-16,160097,caracteres tipográficos
-16,160098,componedores
-16,160101,bandejas portadocumentos
-16,160101,bandejas de sobremesa [artículos de papelería]
-16,160102,cucuruchos de papel
-16,160103,líquidos correctores [artículos de oficina]
-16,160104,tintas correctoras [heliografía]
-16,160105,minas de lápices
-16,160106,cortes histológicos con fines didácticos
-16,160107,plantillas de curvas
-16,160108,forros para libros o cuadernos [artículos de papelería]
-16,160109,tiza para escribir
-16,160110,tiza litográfica
-16,160111,jabón de sastre
-16,160111,tiza de sastre
-16,160112,portatizas
-16,160113,portalápices
-16,160114,portaminas
-16,160115,recipientes de papel para crema o nata
-16,160116,ganchos para papeles [sujetapapeles o clips]
-16,160118,rodillos para máquinas de escribir
-16,160119,calcomanías*
-16,160121,impresiones gráficas
-16,160122,peines para vetear
-16,160123,tableros de dibujo
-16,160124,material de dibujo
-16,160125,instrumentos de dibujo
-16,160126,diagramas
-16,160127,sobres [artículos de papelería]
-16,160128,multicopistas
-16,160129,aguafuertes [grabados]
-16,160130,papel de envolver
-16,160130,papel de embalaje
-16,160131,plumines
-16,160131,plumas para escribir
-16,160132,máquinas de escribir eléctricas o no
-16,160133,plumieres
-16,160133,estuches para plumas
-16,160134,plumines de oro
-16,160134,plumas de oro para escribir
-16,160135,productos para borrar
-16,160136,artículos de escritura
-16,160137,escudos [sellos de papel]
-16,160138,plantillas para borrar
-16,160139,gomas de borrar
-16,160140,papel para electrocardiógrafos
-16,160141,sacabocados [artículos de oficina]
-16,160142,tintas*
-16,160143,cintas entintadas
-16,160144,tinteros
-16,160146,máquinas de oficina para cerrar sobres
-16,160147,fotografías [impresas]
-16,160148,limpiaplumas
-16,160149,sellos
-16,160150,tejidos de encuadernación
-16,160151,estuches de dibujo
-16,160153,registros [libros]
-16,160153,libros mayores
-16,160154,cuadernos con índice
-16,160155,figuritas de papel maché
-16,160155,estatuillas de papel maché
-16,160156,papel de filtro
-16,160157,materiales filtrantes de papel
-16,160158,formularios
-16,160158,impresos [formularios]
-16,160159,artículos de oficina, excepto muebles
-16,160160,carboncillos
-16,160161,plantillas [artículos de papelería]
-16,160162,galeras [tipografía]
-16,160163,galvanos
-16,160163,clichés de galvanotipia
-16,160164,mapas geográficos
-16,160165,globos terráqueos
-16,160166,salseras de acuarelas para artistas
-16,160167,reproducciones gráficas
-16,160168,representaciones gráficas
-16,160169,raspadores de oficina
-16,160170,planchas de grabado
-16,160171,hectógrafos
-16,160172,horarios impresos
-16,160173,dispositivos humectantes [artículos de oficina]
-16,160174,tarjetas postales
-16,160175,productos de imprenta
-16,160175,material impreso
-16,160176,aparatos manuales para etiquetar
-16,160177,mantillas de imprenta que no sean de materias textiles
-16,160178,imprentas portátiles [artículos de oficina]
-16,160178,equipos de impresión portátiles [artículos de oficina]
-16,160179,publicaciones impresas
-16,160180,manuales
-16,160180,guías [manuales]
-16,160182,papel de carta
-16,160183,pisapapeles
-16,160184,puntas de trazado para dibujo
-16,160185,tiralíneas
-16,160185,plumas de dibujo
-16,160186,mantelerías de papel
-16,160187,litografías
-16,160188,piedras litográficas
-16,160189,cartillas [cuadernillos]
-16,160190,papel luminoso
-16,160191,papel maché
-16,160191,cartón piedra
-16,160192,papel multicopia
-16,160193,tiza para marcar
-16,160195,materias plásticas para modelar
-16,160196,materiales para modelar
-16,160197,pasta de modelar
-16,160198,pañuelos de bolsillo de papel
-16,160199,telas entintadas para duplicadores [multicopistas]
-16,160199,telas entintadas para multicopistas
-16,160199,telas entintadas para multicopistas [duplicadores]
-16,160200,manteles de papel
-16,160201,pizarras [encerados]
-16,160201,pizarrones
-16,160202,pinzas para sujetar papeles
-16,160202,clips para sujetar papeles
-16,160203,numeradores
-16,160203,foliadores
-16,160204,oleografías
-16,160205,cartivanas [encuadernación]
-16,160206,obleas para sellar
-16,160207,paletas de pintor
-16,160208,pantógrafos [instrumentos de dibujo]
-16,160209,artículos de papelería
-16,160210,papel pergamino
-16,160211,pasteles [lápices]
-16,160212,patrones de costura
-16,160214,estuches de plantillas de estarcir
-16,160215,rodillos para pintores de obra
-16,160216,lienzos para pintar
-16,160216,telas [lienzos] para pintar
-16,160217,cajas de pinturas para uso escolar
-16,160218,películas de materias plásticas para embalar
-16,160219,encoladoras para uso fotográfico
-16,160220,soportes para fotografías
-16,160221,fotograbados
-16,160223,planos
-16,160223,cianotipos
-16,160224,plegaderas [artículos de oficina]
-16,160225,plumas estilográficas
-16,160225,estilográficas
-16,160225,plumas fuente
-16,160226,plantillas de estarcir
-16,160227,clichés de multicopista
-16,160228,retratos
-16,160229,cubremacetas de papel
-16,160230,aparatos y máquinas mimeógrafos
-16,160230,aparatos y máquinas multicopistas
-16,160231,cintas de papel o tarjetas para registrar programas de ordenador
-16,160231,cintas de papel o tarjetas para registrar programas de computadora
-16,160232,prospectos
-16,160233,papel para radiogramas
-16,160234,reglas de dibujo
-16,160235,regletas [componedores]
-16,160236,material de encuadernación
-16,160238,tela de encuadernación
-16,160239,hilos de encuadernación
-16,160241,telas entintadas para máquinas de reproducción de documentos
-16,160242,plumas [artículos de oficina]
-16,160243,revistas [publicaciones periódicas]
-16,160244,cintas de papel, que no sean de mercería o para el cabello
-16,160245,cintas para máquinas de escribir
-16,160246,bolsas [sobres, bolsitas] de papel o materias plásticas para empaquetar
-16,160247,almohadillas para sellos
-16,160248,material escolar
-16,160249,marcapáginas
-16,160249,marcadores de lectura
-16,160250,tarjetas de felicitación
-16,160251,esteatita [jabón de sastre]
-16,160253,bolas para bolígrafos
-16,160253,bolas para biromes
-16,160254,salvamanteles de papel
-16,160255,tapetes de escritorio
-16,160257,teclas de máquinas de escribir
-16,160258,soportes para sellos de estampar
-16,160259,estuches para sellos de estampar
-16,160260,sellos postales
-16,160260,estampillas [sellos postales]
-16,160260,timbres [sellos postales]
-16,160261,portasellos
-16,160262,transparencias [artículos de papelería]
-16,160263,aparatos de viñeteado
-16,160264,gluten [cola] de papelería o para uso doméstico
-16,160265,adhesivos [pegamentos] de papelería o para uso doméstico
-16,160265,pegamentos de papelería o para uso doméstico
-16,160266,cintas adhesivas de papelería o para uso doméstico
-16,160267,tiras adhesivas de papelería o para uso doméstico
-16,160268,placas para máquinas de imprimir direcciones
-16,160269,almanaques
-16,160270,calendarios
-16,160271,cola de almidón de papelería o para uso doméstico
-16,160271,engrudo de papelería o para uso doméstico
-16,160273,pinceles
-16,160273,brochas [pinceles]
-16,160274,cintas autoadhesivas de papelería o para uso doméstico
-16,160275,gomas [elásticos] de oficina
-16,160276,baberos de papel
-16,160276,babadores de papel
-16,160278,cartón de pasta de madera [artículos de papelería]
-16,160279,papel de madera
-16,160280,cajas de papel o cartón
-16,160281,soportes para plumas y lápices
-16,160282,sobres de papel o cartón para botellas
-16,160283,posabotellas y posavasos de papel
-16,160284,participaciones [artículos de papelería]
-16,160285,hojas de materias plásticas con burbujas para embalar o empaquetar
-16,160286,banderas de papel
-16,160287,trituradoras de papel [artículos de oficina]
-16,160288,hojas de celulosa regenerada para embalar
-16,160289,organizadores de escritorio para artículos de papelería [artículos de oficina]
-16,160290,colas de papelería o para uso doméstico
-16,160291,cortapapeles [abrecartas]
-16,160292,bolsas de basura de papel o materias plásticas
-16,160293,sacapuntas eléctricos o no
-16,160293,afilalápices [sacapuntas] eléctricos o no
-16,160294,toallitas de papel para desmaquillar
-16,160295,servilletas de papel
-16,160296,manteles individuales de papel
-16,160297,escuadras de dibujo
-16,160298,reglas T para dibujo
-16,160299,portaplumas
-16,160300,recados de escribir
-16,160300,estuches de escritura [artículos de papelería]
-16,160301,escribanías de escritorio
-16,160302,escribanías portátiles
-16,160303,modelos de escritura
-16,160304,embalajes de papel o cartón para botellas
-16,160305,rótulos de papel o cartón
-16,160306,toallas de papel
-16,160307,toallitas de tocador de papel
-16,160308,etiquetas de papel o de cartón
-16,160309,buriles para grabar al aguafuerte
-16,160310,hojas de viscosa para embalar
-16,160311,gomas [colas] de papelería o para uso doméstico
-16,160312,telas engomadas de papelería
-16,160313,cola de pescado [ictiocola] de papelería o para uso doméstico
-16,160313,ictiocola [cola de pescado] de papelería o para uso doméstico
-16,160323,bolsas de cocción para microondas
-16,160324,filtros de papel para café
-16,160325,películas adherentes y extensibles de materias plásticas para la paletización
-16,160327,letreros de papel o cartón
-16,160328,adhesivos [artículos de papelería]
-16,160328,autoadhesivos
-16,160330,aparatos y máquinas para encuadernar [material de oficina]
-16,160331,revistas de historietas
-16,160331,libros de cómics
-16,160331,periódicos de historietas
-16,160332,papel de copia [artículos de papelería]
-16,160333,fundas para talonarios de cheques
-16,160334,cartuchos de tinta
-16,160335,piedras de tinta [recipientes para tinta]
-16,160336,tarjetas de felicitación musicales
-16,160337,circulares
-16,160337,boletines informativos
-16,160338,materiales de fécula o almidón para empaquetar
-16,160339,papel parafinado
-16,160339,papel encerado
-16,160340,fundas para pasaportes
-16,160342,pinceles de escritura
-16,160343,instrumentos de escritura
-16,160344,papel perfumado o no para forrar armarios
-16,160345,bacaladeras para tarjetas de crédito
-16,160346,aparatos para plastificar documentos [artículos de oficina]
-16,160347,papel de pintura y caligrafía
-16,160348,borradores para pizarras
-16,160348,borradores para pizarrones
-16,160349,portapapeles de clip [artículos de oficina]
-16,160350,punteros no electrónicos para pizarras
-16,160351,lazos de papel que no sean de mercería o para el cabello
-16,160352,moldes para arcilla de modelar [material para artistas]
-16,160353,clips para billetes de banco
-16,160354,tarjetas de intercambio que no sean para juegos
-16,160354,tarjetas coleccionables que no sean para juegos
-16,160355,hojas absorbentes de papel o de materias plásticas para embalar productos alimenticios
-16,160356,hojas de control de humedad, de papel o de materias plásticas, para embalar productos alimenticios
-16,160357,cintas correctoras [artículos de oficina]
-16,160358,bandejas para pintura
-16,160359,marcadores [artículos de papelería]
-16,160360,volantes [folletos]
-16,160361,fundas portadocumentos [artículos de papelería]
-16,160362,sujetapáginas
-16,160363,arcilla polimérica para modelar
-16,160364,matasellos
-16,160365,materiales de embalaje [relleno] de papel o cartón
-16,160366,materiales de relleno de papel o cartón
-16,160366,materiales de acolchado de papel o cartón
-16,160367,billetes de banco
-16,160368,tiza en aerosol
-16,160369,cupones impresos
-16,160370,papel de arroz*
-16,160371,bolsas de plástico para excrementos de animales de compañía
-16,160372,washi [papel japonés]
-16,160373,caminos de mesa de papel
-16,160374,partituras impresas
-16,160375,banderolas de papel
-16,160376,guirnaldas de banderines de papel
-16,160377,celuloides de animación
-16,160378,bolsas de papel para la esterilización de instrumentos médicos
-16,160379,soportes de tarjetas de identificación [artículos de oficina]
-16,160380,carretes con cordón extensible para soportes de tarjetas de identificación
-16,160381,pinzas de sujeción para soportes de tarjetas de identificación [artículos de oficina]
-16,160382,papel para mesas de reconocimiento médico
-16,160383,papel para cubrir bandejas dentales
-16,160384,baberos de papel con mangas
-16,160385,guillotinas [artículos de oficina]
-16,160386,plantillas de estarcir para la decoración de alimentos y bebidas
-16,160387,tarjetas de identificación [artículos de oficina]
-16,160388,cintas de códigos de barras
-16,160389,purpurina para papelería
-16,160389,escarcha para papelería
-16,160389,brillantina para papelería
-16,160390,etiquetas de papel para reclamar equipajes
-16,160391,toallitas de papel para la limpieza
-16,160392,fundas protectoras para libros
-16,160393,libros para colorear
+class|name
+16|Abrecartas
+16|Abrecartas de metales preciosos
+16|Abrecartas eléctricos para uso en oficinas
+16|Acuarelas
+16|Acuarelas (pinturas hechas)
+16|Adaptadores ergonómicos para escritura
+16|Adhesivos (artículos de papelería)
+16|Adhesivos para papelería
+16|Adhesivos para papelería o para uso doméstico
+16|Adhesivos plásticos para papelería o uso doméstico
+16|Afilalápices eléctricos
+16|Agendas
+16|Agendas de citas
+16|Agendas de direcciones
+16|Agendas planificadoras
+16|Álbumes
+16|Álbumes de boda
+16|Álbumes de eventos
+16|Álbumes de fotos
+16|Álbumes fotográficos
+16|Álbumes para monedas
+16|Álbumes para pegatinas
+16|Álbumes para recopilar acontecimientos
+16|Alfombrillas de fieltro para caligrafía
+16|Almanaques
+16|Almanaques de derecho
+16|Almohadillas para sellos
+16|Ángulos adhesivos de fotos
+16|Anuarios escolares
+16|Archivadores para la oficina
+16|Archivos (artículos de papelería)
+16|Arcilla de modelar
+16|Arcilla para modelar para niños
+16|Baberos de papel
+16|Bandas elásticas para encuadernación
+16|Bandejas para pintura
+16|Bandejas para plumas
+16|Banderas de papel
+16|Banderas y banderines de papel
+16|Banderines de papel
+16|Barritas de tinta (sumi)
+16|Bloc de notas
+16|Bloc de notas para garabatear
+16|Blocks de notas
+16|Blocs de hojas para rotafolios
+16|Blocs de hojas sueltas
+16|Blocs de notas adhesivos
+16|Blocs de notas ilustrados
+16|Blocs de papel borrador
+16|Blocs de papel de escribir
+16|Boletos de entrada
+16|Boletos para pasajeros
+16|Bolígrafos
+16|Bolígrafos de rodillo de gel
+16|Bolígrafos tipo roller
+16|Bolsas de basura
+16|Bolsas de basura de materias plásticas
+16|Bolsas de basura de materias plásticas para uso doméstico
+16|Bolsas de basura de papel para uso doméstico
+16|Bolsas de congelación
+16|Bolsas de materias plásticas de almacenaje para uso doméstico
+16|Bolsas de materias plásticas para embalaje
+16|Bolsas de papel
+16|Bolsas de papel para fiestas
+16|Bolsas de papel para regalar vino
+16|Bolsas de plástico para desechar residuos de animales de compañía
+16|Bolsas para cocinar en microondas
+16|Bolsas plásticas biodegradables para desechos de alimentos de uso doméstico
+16|Bolsas y sacos de papel
+16|Borradores de pizarra blanca
+16|Borradores de tinta
+16|Borradores para pizarrones
+16|Brazaletes para sujetar instrumentos de escritura
+16|Caballetes de pintura
+16|Cajas de cartón
+16|Cajas de cartón corrugado
+16|Cajas de cartón para embalaje industrial
+16|Cajas de cartón para embalar
+16|Cajas de cartón para pasteles
+16|Cajas de cartón plegables
+16|Cajas de fibra de cartón
+16|Cajas de papel
+16|Cajas de papel o cartón
+16|Cajas de regalo
+16|Cajas de regalo de cartón
+16|Cajas para embalar plegables
+16|Cajas para embalar prefabricadas
+16|Cajas plegables de papel
+16|Calcomanías
+16|Calcomanías de papel termotransferibles
+16|Calcomanías de pared
+16|Calcomanías tridimensionales para uso en cualquier superficie
+16|Calendarios
+16|Calendarios de Adviento
+16|Calendarios de bolsillo
+16|Calendarios de mesa
+16|Calendarios de pared
+16|Calendarios de taco
+16|Calendarios impresos
+16|Calendarios y diarios personales
+16|Caminos de mesa de celulosa
+16|Cancioneros
+16|Caracteres de imprenta
+16|Caricaturas
+16|Carpetas (artículos de papelería)
+16|Carpetas de documentos en forma de billeteras
+16|Carpetas encuadernadoras magnéticas de tres anillos
+16|Carpetas para cartas
+16|Carpetas para hojas
+16|Carpetas para hojas (artículos de oficina)
+16|Carpetas para hojas para uso en oficina
+16|Carpetas para hojas sueltas
+16|Cartapacios
+16|Carteles de papel
+16|Carteles enmarcados
+16|Carteles impresos
+16|Carteles publicitarios
+16|Cartivanas (encuadernación)
+16|Cartón
+16|Cartón blanco
+16|Cartón corrugado
+16|Cartón de color
+16|Cartón hecho de morera de papel (senkasi)
+16|Cartón manila de marfil
+16|Cartón para acuarela
+16|Cartones de papel para huevos
+16|Cartuchos de rellenado de tinta para lapiceras
+16|Cartuchos de tinta
+16|Cartuchos de tinta para plumas
+16|Cartulina
+16|Catálogos de muestras de papel de pared
+16|Cementos de caucho de papelería
+16|Cera de modelar que no sea para uso dental
+16|Ceras y tizas
+16|Cheques bancarios
+16|Chinches
+16|Chinches para tableros de corcho
+16|Chinchetas (puntas)
+16|Chinchetas para señalización de mapas
+16|Cinta adhesiva de doble cara para uso doméstico
+16|Cinta de embalar
+16|Cinta para bolsas de alimentos para su uso en congeladores
+16|Cintas adhesivas para papelería o para uso doméstico
+16|Cintas autoadhesivas para papelería o para uso doméstico
+16|Cintas correctoras (artículos de oficina)
+16|Cintas de materias textiles para embalaje y envoltura
+16|Cintas de papel de fantasía (tanzaku)
+16|Cintas de papel para calculadoras
+16|Cintas de papel para máquinas calculadoras
+16|Cintas entintadas
+16|Cintas para máquinas de escribir
+16|Cintas para sellar cajas de cartón
+16|Clips para billetes de banco
+16|Clips para cartas
+16|Clips para plumas
+16|Clips para sujetar papeles
+16|Cola de almidón de papelería o para uso doméstico
+16|Cola de gelatina de algas rojas, para artículos de papelería o uso doméstico (funori)
+16|Cola para la papelería o la casa
+16|Colas de papelería o para uso doméstico
+16|Cómics
+16|Cuadernos de actividades para niños
+16|Cuadernos de anotaciones
+16|Cuadernos de bitácora
+16|Cuadernos de caligrafía a pluma
+16|Cuadernos de caligrafía para pinceles de escritura
+16|Cuadernos de dibujo
+16|Cuadernos de ejercicios
+16|Cuadernos de espirales
+16|Cuadernos de ortografía
+16|Cuadernos escolares para escribir
+16|Cubierta de cartón para cartón corrugado
+16|Cubiertas de papel para palillos chinos
+16|Cubiertas para documentos
+16|Cubremacetas de papel
+16|Decoraciones de cartón para productos alimenticios
+16|Decoraciones de papel para alimentos
+16|Decoraciones de papel para fiestas
+16|Decoraciones de papel para pasteles
+16|Decoraciones para lápices
+16|Decoraciones para lápices (artículos de papelería)
+16|Dediles (artículos de oficina)
+16|Diarios
+16|Diarios de escritorio
+16|Diarios en blanco
+16|Diarios personales
+16|Dibujos
+16|Diccionarios
+16|Directorios de ciudad
+16|Directorios telefónicos
+16|Dispensadores de cinta adhesiva
+16|Distribuidores de cinta adhesiva (artículos de papelería)
+16|Embalajes de cartón
+16|Embalajes de cartón o papel para botellas
+16|Encaje de papel
+16|Enciclopedias
+16|Encuadernaciones
+16|Ensobradoras para su uso en oficinas
+16|Envases de cartón
+16|Envases de cartón de comida para llevar
+16|Envoltorios de papel para monedas
+16|Envoltura de regalo metálica
+16|Esquinas adhesivas para las fotografías
+16|Estuches de plantillas de estarcir
+16|Estuches enrollables para lápices
+16|Estuches para artículos de papelería
+16|Estuches para sellos
+16|Estuches para talonarios de cheque
+16|Estuches para tarjetas de presentación
+16|Estuches y cajas para plumas y lápices
+16|Etiquetas adhesivas
+16|Etiquetas de correo
+16|Etiquetas de direcciones
+16|Etiquetas de papel
+16|Etiquetas de papel identificativas
+16|Etiquetas de papel para regalos
+16|Etiquetas de precios
+16|Fichas de archivo
+16|Fichas de inscripción impresas
+16|Fichas de recetas impresas
+16|Figuras de papel
+16|Filtros de papel para cafeteras
+16|Folletos de información farmacéutica
+16|Folletos publicitarios (sobre productos en el comercio)
+16|Formularios de pedidos
+16|Formularios para contabilidad
+16|Forros de cuero para libros
+16|Forros de papel aromatizado para cajones
+16|Forros para basureros (bolsas de basura)
+16|Fotografías (impresas)
+16|Fotografías enmarcadas y sin enmarcar
+16|Fotografías enmarcados y sin enmarcar
+16|Fundas de papel para documentos
+16|Fundas de protección para libros
+16|Fundas para pasaportes
+16|Fundas portatalonarios
+16|Globos terráqueos
+16|Goma arábiga para papelería y uso doméstico
+16|Gomas (elásticos) de oficina
+16|Gomas de borrar
+16|Gomas de borrar eléctricas
+16|Grabados artísticos
+16|Grabados y sus reproducciones
+16|Grapadoras (artículos de oficina)
+16|Grapadoras de oficina eléctricas
+16|Grapadoras no eléctricas
+16|Guías turísticas
+16|Hilos de encuadernación
+16|Hojas autoadhesivos de materias plásticas para revestir estantes
+16|Hojas de papel para tomar notas
+16|Hojas de papel sueltas
+16|Hojas de polipropileno para embalaje
+16|Hojas de resultados
+16|Hojas para álbumes de recortes
+16|Horarios impresos
+16|Implementos de escritura
+16|Implementos de escritura (instrumentos de escritura)
+16|Impresiones de artes gráficas
+16|Impresiones en giclée
+16|Impresos y representaciones gráficas
+16|Instrumentos de dibujo
+16|Juegos de pintura para niños
+16|Lacre
+16|Láminas adhesivas para papelería
+16|Lápices
+16|Lápices correctores
+16|Lápices de artistas
+16|Lápices de colores
+16|Lápices de colores pastel
+16|Lápices de pizarra
+16|Lápices para pintar y dibujar
+16|Lápices retráctiles
+16|Lazos decorativos de papel para envolturas
+16|Letras y bloques de impresión
+16|Letreros publicitarios de cartón
+16|Letreros publicitarios de papel
+16|Libretas
+16|Libretas de direcciones
+16|Libretas de direcciones y diarios personales
+16|Libretas de notas adhesivas
+16|Libretas para escribir
+16|Libros de actividades con pegatinas
+16|Libros de autógrafos
+16|Libros de cocina
+16|Libros de contabilidad
+16|Libros de cuentos
+16|Libros de cuentos para niños
+16|Libros de cupones
+16|Libros de estrategias para juegos de naipes
+16|Libros de facturas
+16|Libros de memorando de bolsillo
+16|Libros de plegarias
+16|Libros de recetas
+16|Libros de registro de huéspedes
+16|Libros de resultados
+16|Libros desplegables
+16|Libros en el ámbito de la enseñanza del golf
+16|Libros ilustrados
+16|Libros manuscritos
+16|Libros para colorear para adultos
+16|Libros parlantes para niños
+16|Lienzos de seda (artículos de pintores)
+16|Lienzos para pintar
+16|Líquido corrector para clisés
+16|Líquidos correctores (artículos de oficina)
+16|Líquidos correctores para documentos
+16|Líquidos de corrección para clichés de imprenta
+16|Listas de direcciones
+16|Manteles de papel
+16|Mantillas de imprenta que no sean de materias textiles
+16|Manuales de instrucciones de juegos de ordenador
+16|Manuales de usuario de computador
+16|Mapas
+16|Mapas de carreteras
+16|Mapas geográficos
+16|Mapas murales ilustrados
+16|Maquetas de arquitectura
+16|Máquinas de escribir
+16|Máquinas de escribir eléctricas y electrónicas
+16|Máquinas de franqueo eléctricas y electrónicas
+16|Máquinas de franqueo electrónicas y eléctricas
+16|Máquinas de oficina para cerrar sobres
+16|Máquinas emparejadoras de papel para uso en oficina
+16|Máquinas encuadernadoras para uso de oficina
+16|Máquinas franqueadoras de oficina
+16|Máquinas laminadoras para uso en oficinas
+16|Máquinas para afilar lápices
+16|Máquinas para imprimir direcciones
+16|Máquinas plegadoras de papel como artículos de oficina
+16|Marcadores con punta de fieltro
+16|Marcadores para resaltar
+16|Marcapáginas
+16|Marcapáginas de metales preciosos
+16|Marcos de cuadros de papel
+16|Marcos portaetiquetas para ficheros
+16|Material de encuadernación
+16|Material de encuadernación para libros y documentos
+16|Material impreso de muestras de colores
+16|Materiales adhesivos para oficinas
+16|Materiales de dibujo para pizarrones
+16|Materiales de embalaje hechos de sucedáneos del papel basados en minerales
+16|Mimeógrafos
+16|Moldes para arcilla de modelar (material para artistas)
+16|Novelas gráficas
+16|Novelas gráficas de Manga
+16|Objetos de arte litografiados
+16|Paletas de pintor
+16|Paletas para hidratar acuarelas
+16|Paños de papel para lavado
+16|Pañuelos de bolsillo de papel
+16|Papel
+16|Papel a prueba de mildiú
+16|Papel acanalado (corrugado)
+16|Papel adhesivo para notas
+16|Papel alveolado
+16|Papel autocopiante
+16|Papel bond
+16|Papel carbón
+16|Papel carbón (productos terminados)
+16|Papel celofán
+16|Papel celofán a prueba de humedad
+16|Papel con membretes
+16|Papel crepé
+16|Papel cristal
+16|Papel cuadriculado (papel milimetrado como producto acabado)
+16|Papel de caligrafía
+16|Papel de carta
+16|Papel de cartas (productos acabados)
+16|Papel de china
+16|Papel de cuero de imitación
+16|Papel de dibujo
+16|Papel de envoltura para regalos
+16|Papel de envoltura y embalaje
+16|Papel de envolver
+16|Papel de envolver pólvora
+16|Papel de estarcido (producto acabado)
+16|Papel de fibra
+16|Papel de filtro
+16|Papel de forrar
+16|Papel de imprenta
+16|Papel de impresión digital
+16|Papel de madera
+16|Papel de manualidades japonés
+16|Papel de papelería
+16|Papel de postales
+16|Papel de revista
+16|Papel de seda para su uso como material de papel de estarcido (ganpishi)
+16|Papel de tarjetas de visita semiacabado
+16|Papel de transmisión de faxes
+16|Papel duplicador
+16|Papel en rollo para impresoras
+16|Papel hecho de morera de papel (kohzo-gami)
+16|Papel hecho de morera de papel (tengujosi)
+16|Papel higiénico
+16|Papel higiénico de textura áspera
+16|Papel impermeable
+16|Papel japonés
+16|Papel japonés (torinoko-gami)
+16|Papel japonés grueso (hosho-gami)
+16|Papel kraft
+16|Papel laminado
+16|Papel luminoso
+16|Papel oleoso para paraguas de papel (kasa-gami)
+16|Papel opaco
+16|Papel para bolsas y sacos
+16|Papel para cuadernos o libretas
+16|Papel para empajado de suelos (mulching)
+16|Papel para estarcidos (papel de mimeógrafo)
+16|Papel para fotocopiadoras
+16|Papel para grabados
+16|Papel para gráficos
+16|Papel para guías telefónicas
+16|Papel para impresoras láser
+16|Papel para imprimir
+16|Papel para la fabricación de papel pintado
+16|Papel para máquinas de escribir
+16|Papel para notas
+16|Papel para oficinas (artículos de papelería)
+16|Papel para paneles correderos japoneses de interior (fusuma-gami)
+16|Papel para pantallas deslizantes japonesas (shoji-gami)
+16|Papel para secar
+16|Papel para sobre
+16|Papel para su uso como material de certificados de acciones (shokenshi)
+16|Papel para uso doméstico e industrial
+16|Papel para uso en la industria de las artes gráficas
+16|Papel parafinado (papel encerado)
+16|Papel pergamino
+16|Papel que contiene mica
+16|Papel rayado (producto acabado)
+16|Papel reciclado
+16|Papel resistente al ácido
+16|Papel satinado
+16|Papel secante
+16|Papel semielaborado
+16|Papel sintético
+16|Papel xerográfico
+16|Papel y cartón
+16|Papelería de oficina
+16|Papeles de imprenta
+16|Papeles para impresión en offset para panfletos
+16|Papeles para notas
+16|Papeles para sobre
+16|Papeles resistentes a la grasa
+16|Paquetes de burbujas de plástico para envolver
+16|Partituras
+16|Pasta de modelar
+16|Pasta de tinta roja utilizada como lacre
+16|Pasta para la artesanía, la papelería y para uso doméstico (banjaku-nori)
+16|Pasteles al óleo
+16|Pasteles de artistas
+16|Patrones de confección
+16|Patrones de papel
+16|Pegamento de látex para papelería y uso doméstico
+16|Pegamento gelatinoso para uso en papelería y doméstico
+16|Pegamento para oficina
+16|Pegamento para uso en oficina
+16|Pegamentos con brillantina para papelería
+16|Pegamentos para oficina
+16|Pegatinas para parachoques
+16|Pegatinas y álbumes de pegatinas
+16|Pegatinas y calcomanías
+16|Peines para vetear
+16|Película de materias plásticas para envolver alimentos de uso doméstico
+16|Perforadoras (artículos de oficina)
+16|Perforadoras de oficina
+16|Periódico
+16|Periódicos diarios
+16|Petacas para instrumentos de escritura
+16|Piedras de tinta
+16|Piedras de tinta (recipientes para tinta)
+16|Pincel de escribir para caligrafía
+16|Pinceles
+16|Pinceles de decorador
+16|Pinceles de escritura
+16|Pinceles para artistas
+16|Pinturas (cuadros) y sus reproducciones
+16|Pinturas y trabajos caligráficos
+16|Pinzas para sujetar papeles
+16|Pinzas sujetapapeles
+16|Pirotines (moldes de papel o cartón para pastelillos)
+16|Pisapapeles
+16|Pizarras (encerados)
+16|Pizarras de tiza
+16|Pizarras para escribir
+16|Pizarras pequeñas para escribir
+16|Placas para máquinas para imprimir direcciones
+16|Planificadores de escritorio
+16|Planos arquitectónicos
+16|Plantillas de curvas
+16|Plantillas de estarcir
+16|Plantillas para marcar
+16|Plantillas para papel pintado
+16|Plumas
+16|Plumas de acero (estiletes o bolígrafos de estarcido)
+16|Plumas de brillantina para papelería
+16|Plumas de colores
+16|Plumas de escribir con punta de fieltro
+16|Plumas de pegamento para papelería
+16|Plumas de tinta china
+16|Plumas estilográficas
+16|Plumas marcadoras
+16|Plumas rotuladoras de punta de fieltro
+16|Plumas sin tinta (para escribir)
+16|Plumines
+16|Portacalendarios
+16|Portacintas adhesivas
+16|Portalápices
+16|Portaminas
+16|Portaplumas
+16|Portaplumas y portalápices
+16|Portasellos
+16|Posabotellas y posavasos de papel
+16|Programas de software y procesamiento de datos en forma impresa
+16|Protectores de punta de lápices
+16|Publicaciones periódicas impresas en el campo de la cinematografía
+16|Publicaciones periódicas impresas en el campo de la danza
+16|Publicaciones periódicas impresas en el campo de la música
+16|Publicaciones periódicas impresas en el campo de las artes figurativas
+16|Publicaciones periódicas impresas en el campo de las obras teatrales
+16|Publicaciones periódicas impresas en el campo del turismo
+16|Puntas de trazado para dibujo
+16|Puntas para bolígrafos
+16|Recargas de tinta para pluma
+16|Recipientes de cartón
+16|Recipientes de cartón corrugado y papel
+16|Recipientes de cartón para embalaje
+16|Recipientes de papel o cartón para hielo
+16|Recipientes de papel para embalaje para uso industrial
+16|Recipientes de papel para embalar
+16|Reglas de dibujo
+16|Regletas de impresoras (reglas de interlineado)
+16|Reproducciones de láminas de arte
+16|Repuestos para bolígrafos
+16|Revistas musicales
+16|Revistas para armas de fuego
+16|Rodillos para aplicar pinturas
+16|Rodillos para pintores
+16|Rollos de papel para máquinas calculadoras
+16|Rotafolios en blanco
+16|Rotafolios impresos
+16|Rotuladores de borrado con un lápiz húmedo
+16|Rotuladores de marcaje
+16|Rotuladores de punta de fieltro
+16|Rotuladores para destacar
+16|Rotuladores para documentos
+16|Rótulos de papel o cartón
+16|Ruedas de impresión
+16|Ruedas de impresión para máquinas de escribir
+16|Sacapuntas
+16|Sacapuntas de tiza para modistos
+16|Sal líquida para deshelar
+16|Sello de goma
+16|Sello fechador (fechas)
+16|Sellos (artículos de papelería)
+16|Sellos de direcciones
+16|Sellos de goma
+16|Sellos de lacre
+16|Sellos de oficina
+16|Sellos de tinta
+16|Sellos numeradores
+16|Sellos para marcar
+16|Sellos para oficina
+16|Separadores para libretas
+16|Servilletas de papel
+16|Servilletas desechables
+16|Sobres
+16|Sobres para papelería
+16|Soportes de cartas
+16|Soportes de grapadoras
+16|Soportes para blocs de notas
+16|Soportes para instrumentos de escritura
+16|Soportes para pluma y lápiz
+16|Soportes para plumas
+16|Soportes para plumas y lápices
+16|Sujetacartas
+16|Sujetalibros
+16|Tablas de resultados
+16|Tableros para notas
+16|Tablones de anuncios impresos de cartón
+16|Tablones de anuncios impresos de papel
+16|Tablones de dibujo (artículos de pintores)
+16|Talonarios de cheques
+16|Talonarios de facturas
+16|Talonarios de recibos de caja
+16|Tampones (almohadillas) de tinta
+16|Tapas de cuadernos
+16|Tapas de libros de ejercicios
+16|Tapas para lápices
+16|Tapetes de escritorio
+16|Tapones decorativos para lápices
+16|Tarjetas coleccionables intercambiables
+16|Tarjetas de correspondencia
+16|Tarjetas de crédito sin codificación magnética
+16|Tarjetas de cumpleaños
+16|Tarjetas de felicitación
+16|Tarjetas de felicitación musicales
+16|Tarjetas de felicitación y tarjetas postales
+16|Tarjetas de intercambio (tarjetas coleccionables)
+16|Tarjetas de invitación
+16|Tarjetas de presentación
+16|Tarjetas de presentación (semiacabadas)
+16|Tarjetas de puntuación
+16|Tarjetas de puntuación para golf
+16|Tarjetas de registro
+16|Tarjetas de resultados
+16|Tarjetas de visita
+16|Tarjetas perforadas para telares Jacquard
+16|Tarjetas postales
+16|Tarjetas postales y tarjetas de felicitación
+16|Tarjetas postales y tarjetas postales ilustradas
+16|Teclas de máquinas de escribir
+16|Tejidos de encuadernación
+16|Tela de encuadernación
+16|Tinta china
+16|Tinta para instrumentos de escritura
+16|Tintas correctoras (heliografía)
+16|Tintas para escribir
+16|Tintas para sellos
+16|Tinteros
+16|Tiras adhesivas de papelería o para uso doméstico
+16|Tiras cómicas
+16|Tiras cómicas impresas
+16|Tiras de historietas impresas
+16|Tiras de papel japonesas para ceremonias (mizuhiki)
+16|Tiras de papel para su uso con máquinas de etiquetado
+16|Tiza
+16|Tiza litográfica
+16|Tiza para marcar
+16|Tiza y pizarrones
+16|Tizas
+16|Toallas de mano higiénicas de papel
+16|Toallas de papel
+16|Toallas de papel para manos
+16|Toallitas de papel
+16|Toallitas de papel para desmaquillar
+16|Toallitas de tocador de papel
+16|Tubos de cartón
+16|Tubos de cartón para mensajería
+16|Utensilios de escritura
+16|Utensilios de escritura hechos de fibras

--- a/lib/seeds/class_17_terms.csv
+++ b/lib/seeds/class_17_terms.csv
@@ -1,153 +1,141 @@
-class,reference_id,name
-17,170001,acetato de celulosa semielaborado
-17,170002,resinas acrílicas semielaboradas
-17,170003,cortinas de seguridad de amianto
-17,170003,cortinas de seguridad de asbesto
-17,170004,anillos de caucho
-17,170005,pizarra de amianto
-17,170005,pizarra de asbesto
-17,170006,mangueras de riego
-17,170008,materiales de insonorización
-17,170009,anillos de impermeabilidad
-17,170009,anillos de empaque
-17,170010,balata
-17,170011,guarniciones de impermeabilidad
-17,170011,empaques de impermeabilidad
-17,170012,juntas de caucho para tarros
-17,170013,burletes
-17,170014,materiales de relleno de caucho o materias plásticas
-17,170014,materiales de acolchado de caucho o materias plásticas
-17,170015,materiales para calafatear
-17,170016,productos calorífugos
-17,170017,caucho en bruto o semielaborado
-17,170018,tapones de caucho para insertar en botellas
-17,170019,válvulas de charnela de caucho
-17,170020,caucho sintético
-17,170021,topes amortiguadores de caucho
-17,170022,tubos flexibles no metálicos
-17,170023,materiales aislantes
-17,170024,materiales para impedir la radiación térmica
-17,170024,materiales para bloquear la radiación del calor
-17,170025,mangueras de materias textiles
-17,170026,materiales para impedir la radiación térmica de calderas
-17,170029,papel para condensadores eléctricos
-17,170030,juntas para tuberías
-17,170031,cuerdas de caucho
-17,170031,cordones de caucho
-17,170032,algodón para calafatear
-17,170033,juntas de cilindros
-17,170034,aislantes dieléctricos
-17,170035,hojas de amianto
-17,170035,hojas de asbesto
-17,170036,ebonita
-17,170037,cortezas para insonorizar
-17,170037,cortezas para el aislamiento acústico
-17,170038,hilos elásticos que no sean para uso textil
-17,170039,forros de embrague
-17,170039,forros para acoplamientos
-17,170040,materiales para estopar
-17,170041,rellenos para juntas de expansión
-17,170042,compuestos químicos para reparar fugas
-17,170043,juntas*
-17,170043,empaquetaduras
-17,170044,fieltro de amianto
-17,170044,fieltro de asbesto
-17,170045,fieltro aislante
-17,170046,fibra vulcanizada
-17,170047,hilos de plástico para soldar
-17,170048,materiales semielaborados para forros de freno
-17,170049,guantes aislantes
-17,170050,gutapercha
-17,170051,aceite aislante para transformadores
-17,170052,aceites aislantes
-17,170053,hojas de celulosa regenerada que no sean para embalar
-17,170055,papel aislante
-17,170056,tejidos aislantes
-17,170057,barnices aislantes
-17,170058,compuestos aislantes contra la humedad en edificios
-17,170059,láminas metálicas aislantes
-17,170060,pinturas aislantes
-17,170061,lana de escoria [aislante]
-17,170062,lana mineral [aislante]
-17,170063,lana de vidrio para aislar
-17,170064,látex [caucho]
-17,170065,tubos de lino
-17,170066,zulaque
-17,170067,manguitos no metálicos para tubos
-17,170068,manguitos de goma para proteger partes de máquinas
-17,170068,mangas de goma para proteger partes de máquinas
-17,170069,masillas para juntas
-17,170069,compuestos de sellado para juntas
-17,170070,mica en bruto o semielaborada
-17,170071,papel de amianto
-17,170071,papel de asbesto
-17,170072,películas de materias plásticas que no sean para embalar
-17,170073,racores no metálicos para tuberías
-17,170073,empalmes no metálicos para tuberías
-17,170074,manguitos de conexión para radiadores de vehículos
-17,170074,mangueras de conexión para radiadores de vehículos
-17,170074,mangueras de empalme para radiadores de vehículos
-17,170075,resinas sintéticas semielaboradas
-17,170075,resinas artificiales semielaboradas
-17,170076,arandelas de caucho o fibra vulcanizada
-17,170077,bolsas [sobres, bolsitas] de caucho para empaquetar
-17,170078,revestimientos de amianto
-17,170078,revestimientos de asbesto
-17,170079,tejidos de amianto
-17,170079,tejidos de asbesto
-17,170080,tela de amianto
-17,170080,tela de asbesto
-17,170081,empaquetaduras de amianto
-17,170081,empaquetaduras de asbesto
-17,170081,trenzas de amianto
-17,170081,trenzas de asbesto
-17,170082,válvulas de caucho o fibra vulcanizada
-17,170083,hojas de viscosa que no sean para embalar
-17,170084,aislantes para vías férreas
-17,170085,cintas adhesivas que no sean de papelería ni para uso médico o doméstico
-17,170086,armazones no metálicos para conductos de aire comprimido
-17,170087,cartón de amianto
-17,170087,cartón de asbesto
-17,170088,fibras de amianto
-17,170088,fibras de asbesto
-17,170089,armaduras no metálicas para conductos
-17,170089,materiales no metálicos para reforzar conductos
-17,170091,amianto
-17,170091,asbesto
-17,170092,cintas autoadhesivas que no sean de papelería ni para uso médico o doméstico
-17,170093,topes de caucho
-17,170094,aislantes para cables
-17,170095,hilos de caucho que no sean para uso textil
-17,170096,fibras de carbono que no sean para uso textil
-17,170097,materias plásticas semielaboradas
-17,170098,aislantes para conductos eléctricos
-17,170099,aislantes
-17,170099,aisladores
-17,170100,moldes de ebonita
-17,170101,materiales de embalar [relleno] de caucho o materias plásticas
-17,170102,fibras de materias plásticas que no sean para uso textil
-17,170103,fibras de vidrio aislantes
-17,170104,tejidos de fibras de vidrio aislantes
-17,170105,hilos de materias plásticas que no sean para uso textil
-17,170106,materiales filtrantes de espuma plástica semielaborada
-17,170107,cintas aislantes
-17,170107,bandas aislantes
-17,170108,barreras flotantes anticontaminación
-17,170109,goma para recauchutar neumáticos
-17,170110,enlucidos aislantes
-17,170111,hojas de materias plásticas para uso agrícola
-17,170112,soportes de gomaespuma para arreglos florales [productos semiacabados]
-17,170113,caucho líquido
-17,170114,soluciones de caucho
-17,170115,películas antideslumbrantes para ventanas [películas ahumadas]
-17,170115,películas antirreflejo para ventanas [películas ahumadas]
-17,170116,materiales refractarios aislantes
-17,170117,goma en bruto o semielaborada
-17,170118,cintas adhesiva de reparación
-17,170119,topes de caucho para puertas
-17,170120,topes de caucho para ventanas
-17,170121,guarniciones no metálicas para tuberías flexibles
-17,170122,guarniciones no metálicas para tuberías rígidas
-17,170123,defensas de caucho para muelles de navegación
-17,170124,materiales filtrantes de películas plásticas semielaboradas
-17,170125,filamentos de materias plásticas para imprimir en 3D
+class|name
+17|Aceites aislantes
+17|Acoplamientos no metálicos para mangueras de incendio
+17|Aislación de fibra de vidrio
+17|Aislamiento de tubos
+17|Aislante en forma de revestimientos de pisos
+17|Aislantes cerámicos de electricidad
+17|Aislantes eléctricos, térmicos y acústicos
+17|Aislantes para cables eléctricos
+17|Amianto en polvo
+17|Anillos de caucho para su uso como sellado en la conexión de tuberías
+17|Arandelas de caucho o fibra vulcanizada
+17|Barnices aislantes
+17|Barras y varillas de caucho
+17|Barreras flotantes antipolución
+17|Bolsas de caucho para embalaje de mercancías (sobres o bolsitas)
+17|Cartón de amianto
+17|Caucho acrílico
+17|Caucho clorado
+17|Caucho crudo
+17|Caucho de estireno-butadieno
+17|Caucho de etileno-propileno
+17|Caucho de isobutileno-isopreno
+17|Caucho de nitrilo
+17|Caucho de polisulfuro
+17|Caucho de silicona
+17|Caucho en bruto o semielaborado
+17|Caucho expandido de celdas cerradas para insonorización
+17|Caucho hidroclorado
+17|Caucho natural
+17|Caucho reciclado
+17|Caucho regenerado
+17|Caucho semielaborado
+17|Caucho sintético
+17|Cinta aislantes de electricidad
+17|Cinta de enmascarar
+17|Cinta para juntas de paneles de yeso
+17|Cinta para uniones de alfombras
+17|Cinta tapajuntas para tubos
+17|Cintas aislantes
+17|Compuestos para unir tubos
+17|Cordones y cuerdas de amianto
+17|Cordones y lazos de caucho
+17|Cortina ignífuga de amianto
+17|Cortinas de barrera del tipo de deflectores o barreras flotantes para retener contaminantes
+17|Derivados de caucho
+17|Ebonita (vulcanita)
+17|Elastómeros para su unión a artículos utilizados para granallado
+17|Enlucidos aislantes
+17|Espuma de caucho
+17|Fibra vulcanizada
+17|Fibras de carbón que no sean para uso textil
+17|Fibras de vidrio para aislamiento de edificios
+17|Fibras de vidrio para aislar
+17|Fibras de vidrio para uso en la fabricación de aislantes de edificios
+17|Fieltro de amianto
+17|Filamento e hilo de caucho recubierto que no sean para uso textil
+17|Forros de embrague
+17|Fundas de identificación de caucho para tuberías
+17|Goma en bruto
+17|Guantes aislantes
+17|Gutapercha
+17|Hilo de amianto
+17|Hilo de caucho que no sean para uso textil
+17|Hilo de caucho simple y recubierto que no sea para uso textil
+17|Hilos de amianto
+17|Hilos elásticos que no sean para uso textil
+17|Hojas de caucho
+17|Hojas de materias plásticas para uso agrícola
+17|Hojas de polipropileno que no sean para embalaje
+17|Juntas de expansión elastoméricas
+17|Láminas aislantes de grafito
+17|Láminas de materias plásticas con revestimiento adhesivo para la industria manufacturera
+17|Láminas de plástico autoadhesivas para uso industrial
+17|Láminas de vinilo para su uso en la fabricación de inflables
+17|Láminas metálicas para aislamiento de edificios
+17|Lana de roca
+17|Lana de vidrio para aislar
+17|Látex para uso industrial
+17|Mangueras de caucho para uso agrícola
+17|Mangueras de empalme para inyectores de vehículos
+17|Mangueras para el césped
+17|Mangueras para regar
+17|Mantas aislantes para calentadores de agua
+17|Mantas de insonorización
+17|Mantas de materias plásticas para curar hormigón
+17|Masilla de calafatear
+17|Masillas para juntas
+17|Material de goma para recauchutado de neumáticos
+17|Material de plástico en forma extruida para su uso en fabricación
+17|Material de relleno de caucho o plástico
+17|Materiales aislantes
+17|Materiales aislantes de electricidad
+17|Materiales de aislamiento para acondicionadores de aire
+17|Materiales de insonorización
+17|Materiales insonorizantes de lana de roca que no sean para la construcción
+17|Materiales para calafatear
+17|Materiales para estopar
+17|Materiales refractarios aislantes
+17|Materias de relleno de caucho
+17|Materias plásticas en forma de láminas, películas, bloques, varillas y tubos
+17|Materias plásticas semielaboradas
+17|Mica
+17|Mica en bruto o semielaborada
+17|Paneles de barrera para el aislamiento acústico
+17|Papel de amianto
+17|Película de plástico de uso agrícola
+17|Película de poliuretano para su uso como barrera contra la humedad
+17|Película para empajado de suelos (mulching)
+17|Películas de materias plásticas para uso en ventanas
+17|Películas de materias plásticas tintadas para ventanillas de vehículos
+17|Películas de plástico anti vaho para espejos retrovisores de automóviles
+17|Películas de plástico teñido para uso en ventanas
+17|Películas plásticas para uso en papel laminado
+17|Pinturas aislantes
+17|Plástico extrudido en forma de barras, bloques, pellets, varillas, láminas y tubos para fabricación
+17|Productos de caucho aislantes de electricidad
+17|Productos de materias plásticas semielaborados
+17|Productos de mica aislantes de electricidad
+17|Racores no metálicos para tuberías flexibles
+17|Recipientes de caucho para embalaje industrial
+17|Recubrimientos aislantes
+17|Redes de amianto
+17|Rellenos para juntas de expansión
+17|Rellenos plásticos
+17|Selladores de poliuretano
+17|Selladores de silicona
+17|Sello obturador de juntas de tubo
+17|Servicios de tendido de tubos
+17|Soportes de tubo aislados
+17|Tapas y tapones de caucho para recipientes de embalaje industrial
+17|Tapones de caucho para botellas
+17|Tejidos aislantes
+17|Tejidos de amianto
+17|Tejidos de fibras de vidrio para aislar
+17|Tuberías y tubos de caucho
+17|Tubos flexibles no metálicos
+17|Tubos plásticos flexibles
+17|Tubos termorretráctiles termoplásticos para gestionar cables eléctricos
+17|Válvulas hechas de fibra de caucho o vulcanizada sin incluir elementos de máquinas
+17|Varillas y barras de materias plásticas

--- a/lib/seeds/class_18_terms.csv
+++ b/lib/seeds/class_18_terms.csv
@@ -1,156 +1,253 @@
-class,reference_id,name
-18,180001,bastones de montañismo
-18,180001,bastones de alpinista
-18,180002,pieles de animales
-18,180002,pellejos [pieles de animales]
-18,180003,anillos para paraguas
-18,180004,arzones de sillas de montar
-18,180005,correas de cuero para animales
-18,180006,cinchas de sillas de montar
-18,180007,varillas para paraguas o sombrillas
-18,180008,tripa de buey
-18,180010,monederos
-18,180010,portamonedas
-18,180011,bridones
-18,180012,correaje militar
-18,180013,portafolios para partituras
-18,180014,bastones de paraguas
-18,180015,bastones*
-18,180016,bastones-asiento
-18,180017,frenos para animales [arreos]
-18,180018,armazones de paraguas o sombrillas
-18,180019,morrales de caza
-18,180020,mochilas escolares
-18,180020,carteras escolares
-18,180020,portafolios escolares
-18,180021,tarjeteros [carteras]
-18,180022,cartón cuero
-18,180023,sombrereras de cuero
-18,180025,colleras para caballos
-18,180026,mantas para caballos
-18,180027,cabritilla
-18,180028,bozales
-18,180029,baúles de viaje
-18,180030,collares para animales*
-18,180031,cordones de cuero
-18,180032,pieles curtidas
-18,180033,correas de arnés
-18,180034,correas de cuero [artículos de guarnicionería]
-18,180035,correas de patines
-18,180036,tiras de cuero
-18,180038,cueros gruesos
-18,180039,cuero en bruto o semielaborado
-18,180041,guarniciones de cuero para muebles
-18,180041,adornos de cuero para muebles
-18,180042,cuero de imitación
-18,180042,cuero artificial
-18,180043,paraguas
-18,180044,bandoleras portabebés
-18,180045,piezas de caucho para estribos
-18,180046,correas de estribo
-18,180047,bolsas de herramientas vacías 
-18,180049,fustas
-18,180049,látigos
-18,180050,morrales comederos
-18,180050,morrales para pienso
-18,180051,fundas de paraguas
-18,180052,fundas de cuero para resortes
-18,180053,rodilleras para caballos
-18,180054,mantas para cubrir animales
-18,180055,arneses para animales
-18,180055,arreos
-18,180056,anteojeras [artículos de guarnicionería]
-18,180057,tiros [arreos]
-18,180058,mochilas
-18,180059,ronzales para caballos
-18,180060,empuñaduras de bastón
-18,180061,látigos de nueve ramales
-18,180062,barboquejos de cuero
-18,180063,molesquín [cuero de imitación]
-18,180065,armazones de bolsos
-18,180065,armazones de carteras [bolsos de mano]
-18,180066,sombrillas
-18,180066,parasoles*
-18,180067,pieles de pelo [pieles de animales]
-18,180068,puños de paraguas
-18,180069,billeteras
-18,180069,carteras de bolsillo
-18,180070,bolsas de ruedas para la compra
-18,180071,bolsas para la compra
-18,180072,riendas
-18,180073,maletines para documentos
-18,180074,bolsas de montañismo
-18,180074,bolsos de montañismo
-18,180075,bolsas de campamento
-18,180075,bolsos de campamento
-18,180076,bolsas de playa
-18,180076,bolsos de playa
-18,180077,bolsos de mano
-18,180077,bolsitos de mano
-18,180077,carteras [bolsos de mano]
-18,180078,bolsas de viaje
-18,180078,bolsos de viaje
-18,180079,bolsas [sobres, bolsitas] de cuero para empaquetar
-18,180080,cinchas de cuero
-18,180081,sillas de montar
-18,180082,artículos de guarnicionería
-18,180083,portafolios [artículos de marroquinería]
-18,180083,carteras para documentos
-18,180084,estuches de viaje [artículos de marroquinería]
-18,180085,maletas
-18,180085,valijas
-18,180086,asas de maleta
-18,180086,asas de valija
-18,180087,válvulas de cuero
-18,180088,pieles de ganado
-18,180089,cajas de cuero o cartón cuero
-18,180090,monederos de malla
-18,180090,portamonedas de malla
-18,180091,estuches de cuero o cartón cuero
-18,180092,baúles [equipaje]
-18,180093,estuches para artículos de tocador
-18,180094,gamuzas que no sean para limpiar
-18,180096,bandoleras de cuero
-18,180097,fundas para sillas de montar
-18,180098,cajas de fibra vulcanizada
-18,180100,morrales
-18,180100,macutos
-18,180111,portatrajes
-18,180112,bridas para caballos
-18,180113,estuches para llaves
-18,180114,bolsas de red para la compra
-18,180115,maletas de mano
-18,180115,valijas de mano
-18,180116,revestimientos de cuero para muebles
-18,180117,almohadillas para sillas de montar
-18,180118,bolsas de deporte*
-18,180118,bolsos de deporte*
-18,180119,estribos
-18,180120,guarniciones de arreos
-18,180121,herraduras
-18,180122,fulares portabebés
-18,180122,kepinas [fulares portabebés]
-18,180123,canguros portabebés
-18,180124,bolsas*
-18,180125,estuches para tarjetas de crédito [carteras]
-18,180126,carteras para tarjetas de visita [tarjeteros]
-18,180126,carteras para tarjetas de presentación [tarjeteros]
-18,180127,randsels [mochilas escolares japonesas] 
-18,180128,etiquetas identificadoras para maletas
-18,180128,etiquetas identificadoras para equipaje
-18,180129,sudaderos para sillas de montar
-18,180130,etiquetas de cuero
-18,180131,asas para transportar sacos de provisiones
-18,180131,agarraderas para transportar sacos de provisiones
-18,180132,filacterias
-18,180133,maletas con ruedas
-18,180134,alforjas*
-18,180135,ropa para animales de compañía
-18,180136,arneses para guiar niños
-18,180137,maletas motorizadas
-18,180138,estuches de compresión especiales para el equipaje
-18,180139,carpetas de conferencias
-18,180140,bastones de senderismo
-18,180140,bastones de excursionismo
-18,180141,telas de cuero
-18,180142,mochilas portabebés
+class|name
+18|Abrigos para perros
+18|Anteojeras para aves de corral, utilizadas para evitar peleas
+18|Anteojeras para caballos
+18|Armazones de bolsos
+18|Armazones de monederos
+18|Armazones de paraguas
+18|Armazones de paraguas o sombrillas
+18|Arneses
+18|Arneses de animales
+18|Arneses para caballos
+18|Arneses y artículos de guarnicionería
+18|Artículos de guarnicionería
+18|Artículos de guarnicionería de cuero
+18|Bananos
+18|Bandas abdominales para perritos
+18|Bandoleras de cuero
+18|Bastones
+18|Bastones de excursión
+18|Bastones de montañismo
+18|Bastones de ratán
+18|Bastones de senderismo
+18|Bastones largos
+18|Bastones para caminar
+18|Baúl de viaje
+18|Baúles (equipaje) y maletas de mano
+18|Baúles como equipaje
+18|Baúles de mimbre kori
+18|Baúles de viaje
+18|Billeteras
+18|Bocados para arneses
+18|Bocados para caballerías
+18|Bolsas (envolturas, bolsitas) para embalar de cuero
+18|Bolsas (mochilas) de senderismo
+18|Bolsas con ruedas para la compra
+18|Bolsas de amuletos (omamori-ire)
+18|Bolsas de colegial
+18|Bolsas de cuero
+18|Bolsas de cuero de viaje para ropa
+18|Bolsas de cuero y cuero de imitación
+18|Bolsas de deportes
+18|Bolsas de llaves
+18|Bolsas de lona
+18|Bolsas de mano
+18|Bolsas de materias textiles para las compras
+18|Bolsas de mensajero
+18|Bolsas de piel para las compras
+18|Bolsas de playa
+18|Bolsas de punto que no sean de metales preciosos
+18|Bolsas de red para las compras
+18|Bolsas de transporte multiusos
+18|Bolsas de viaje
+18|Bolsas multiuso
+18|Bolsas para cintura y cadera
+18|Bolsas para el cinturón
+18|Bolsas para la caza
+18|Bolsas para libros
+18|Bolsas para llaves
+18|Bolsas para llevar bebés
+18|Bolsas para llevar niños
+18|Bolsas para pañales
+18|Bolsas para trajes
+18|Bolsas pequeñas para caballero
+18|Bolsas reutilizables para la compra
+18|Bolsas y carteras de cuero
+18|Bolsas, maletas y carteras de cuero
+18|Bolsones
+18|Bolsos (neceseres) de viaje
+18|Bolsos con ruedas
+18|Bolsos de campamento
+18|Bolsos de cordón
+18|Bolsos de deporte multiusos
+18|Bolsos de gimnasia
+18|Bolsos de mano
+18|Bolsos de mano de cuero
+18|Bolsos de mano para caballeros
+18|Bolsos de mano para damas
+18|Bolsos de mano para hombres
+18|Bolsos de mano pequeños
+18|Bolsos de mano sin asas
+18|Bolsos de mano tipo retícula
+18|Bolsos de mano, monederos y carteras
+18|Bolsos de noche
+18|Bolsos de viaje
+18|Bolsos multiuso
+18|Bolsos para artículos de tocador
+18|Bolsos para avión
+18|Bolsos para colgar al hombro
+18|Bolsos para compras de cuero
+18|Bolsos para transportar animales
+18|Bolsos tipo bandolera
+18|Bolsos tipo Boston
+18|Bolsos tipo satchel
+18|Bridas para caballos
+18|Bridones
+18|Cajas de cuero
+18|Cajas de cuero o cuero de imitación
+18|Caquetones para perros
+18|Carteras con compartimentos de tarjetas
+18|Carteras con portatarjetas
+18|Carteras de colegiales
+18|Carteras de colegio
+18|Carteras de cuero
+18|Carteras de cuero para tarjetas de crédito
+18|Carteras para tarjetas
+18|Carteras que no sean de metales preciosos
+18|Cinchos de silla de montar
+18|Collares de animales
+18|Collares para animales
+18|Collares para animales de compañía
+18|Collares para animales de compañía que contienen información médica
+18|Collares para perro
+18|Collares y correas para perro
+18|Colleras para caballos
+18|Correas de cuero para animales
+18|Correas de equipajes
+18|Correas de estribo
+18|Correas para animales
+18|Correas para bolsos
+18|Correas para el hombro
+18|Correas para perro
+18|Cosmetiqueros (estuches para artículos de tocador)
+18|Cuerdas de entrenamiento para caballos
+18|Cuero de poliuretano
+18|Cuero en bruto
+18|Cuero en bruto o semielaborado
+18|Cuero para arneses
+18|Cuero para muebles
+18|Cuero para zapatos
+18|Cuero y cuero de imitación
+18|Disfraces para animales
+18|Empuñaduras de bastón
+18|Equipaje para viaje
+18|Estuches de corbata
+18|Estuches de cuero
+18|Estuches de cuero de imitación
+18|Estuches de cuero o cuero de imitación para llaves
+18|Estuches de cuero para llaves
+18|Estuches de documentos
+18|Estuches de tarjetas de crédito de cuero
+18|Estuches de viaje (artículos de marroquinería)
+18|Estuches para artículos de tocador
+18|Estuches para llaves
+18|Estuches para llaves (artículos de marroquinería)
+18|Estuches para llaves de cuero y pieles
+18|Estuches para tarjetas de crédito
+18|Estuches vacíos para artículos de tocador
+18|Estuches y portatarjetas de crédito
+18|Fulares portabebés
+18|Fundas de paraguas
+18|Fundas para sillas de montar
+18|Fundas para sombrillas
+18|Fustas
+18|Fustas de jockey
+18|Fustas para montar a caballo
+18|Gorros para las orejas de caballos
+18|Guarniciones de arreos
+18|Guarniciones de hierro para arreos
+18|Herraduras
+18|Herraduras de materias plásticas
+18|Hilos de cuero
+18|Impermeables para perros
+18|Maletas
+18|Maletas con estantes incorporados
+18|Maletas de fin de semana
+18|Maletas de mano
+18|Maletas de mano para documentos
+18|Maletas y baúles de viaje
+18|Maletines
+18|Maletines (artículos de marroquinería)
+18|Maletines abisagrados de doble compartimento (tipo Gladstone)
+18|Maletines de cuero
+18|Maletines para documentos
+18|Maletines para ejecutivos
+18|Maletines plegables
+18|Maletines portadocumentos de cuero de imitación
+18|Maletines tipo portafolios
+18|Maletines y maletines para documentos
+18|Mantas para caballos
+18|Mantas riñoneras para caballos
+18|Máscaras faciales para equinos
+18|Mochilas
+18|Mochilas (macutos)
+18|Mochilas con ruedas
+18|Mochilas de deporte
+18|Mochilas para alpinistas
+18|Mochilas pequeñas
+18|Mochilas portabebés de cuero
+18|Mochilas, mochilas escolares, bolsas de deporte, riñoneras, carteras y bolsos de mano
+18|Monederos
+18|Monederos de cuero
+18|Monederos de malla
+18|Monederos de metales preciosos
+18|Monederos de muñeca
+18|Monederos pequeños
+18|Monederos que no sean de metales preciosos
+18|Monederos y carteras
+18|Monederos y carteras de metales preciosos
+18|Paraguas
+18|Paraguas de papel japoneses (karakasa)
+18|Paraguas japoneses de papel impregnado en aceite (janome-gasa)
+18|Paraguas para el aire libre
+18|Paraguas para niños
+18|Paraguas telescópicos
+18|Paraguas y sombrillas
+18|Paraguas y sus partes
+18|Parasoles (sombrillas)
+18|Parkas para perros
+18|Partes metálicas de bastones
+18|Partes metálicas de paraguas
+18|Petates grandes
+18|Piel de imitación
+18|Pieles curtidas
+18|Pieles de animales
+18|Pieles y cuero de animales
+18|Pieles y cueros
+18|Pieles y cueros manufacturados y semimanufacturados
+18|Piezas de caucho para estribos
+18|Polainas para animales
+18|Polainas y rodilleras ortopédicas para caballos
+18|Porta animales (bolsos)
+18|Portabilletes
+18|Portaetiquetas para equipaje
+18|Portafolios (artículos de marroquinería)
+18|Portafolios escolares
+18|Portatarjetas de crédito de cuero
+18|Portatrajes
+18|Portatrajes, fundas para camisas y fundas para vestidos
+18|Protectores de pezuñas
+18|Puños de paraguas
+18|Riendas (arneses)
+18|Riendas de cuerda
+18|Riñonera
+18|Riñoneras
+18|Ropa para animales de compañía
+18|Ropa para caballos
+18|Sacos de lona
+18|Sacos de lona para viajes
+18|Saquitos de utilidades japoneses (shingen-bukuro)
+18|Sillas de montar
+18|Sombrereras de cuero
+18|Sombrillas
+18|Sombrillas de golf
+18|Sombrillas de playa (parasoles de playa)
+18|Sombrillas impermeables
+18|Sombrillas para exterior
+18|Sombrillas para terrazas
+18|Soporte dorsal para llevar niños
+18|Sudaderos para sillas de montar
+18|Tarjeteros para tarjetas de crédito
+18|Tiras de cuero
+18|Vendajes para patas equinas
+18|Zapatos para perro

--- a/lib/seeds/class_19_terms.csv
+++ b/lib/seeds/class_19_terms.csv
@@ -1,307 +1,327 @@
-class,reference_id,name
-19,190001,columnas publicitarias no metálicas
-19,190002,vidrio alabastrino
-19,190002,cristal de alabastro
-19,190003,alabastro
-19,190004,cemento de amianto
-19,190004,amianto-cemento
-19,190004,cemento de asbesto
-19,190005,mortero de amianto
-19,190005,mortero de asbesto
-19,190006,pizarra*
-19,190007,pizarras para techados
-19,190008,polvo de pizarra
-19,190009,cabrios para techados
-19,190009,caballetes para techados
-19,190010,arena argentífera
-19,190011,arcilla de alfarería
-19,190012,piedras refractarias
-19,190012,ladrillos refractarios
-19,190013,asfalto
-19,190014,materiales asfálticos para pavimentación
-19,190015,ristreles
-19,190015,listones de madera para el artesonado
-19,190016,balaustres no metálicos
-19,190017,betún [material de construcción]
-19,190018,tiras alquitranadas para la construcción
-19,190019,barracas
-19,190020,barracas de feria
-19,190021,chillas [tablillas] para techados
-19,190022,puertas plegables no metálicas
-19,190023,hormigón
-19,190023,concreto
-19,190024,elementos de construcción de hormigón
-19,190024,elementos de construcción de concreto
-19,190025,productos bituminosos para la construcción
-19,190026,madera semielaborada
-19,190027,madera de construcción
-19,190027,madera de obra
-19,190028,contrachapados
-19,190029,madera trabajada
-19,190030,madera para fabricar utensilios domésticos
-19,190031,madera de sierra
-19,190032,materiales de madera para pavimentación
-19,190033,chapados de madera
-19,190034,madera de chapado
-19,190035,paneles [revestimientos] de madera
-19,190036,cemento*
-19,190037,pez*
-19,190038,ladrillos
-19,190039,tierra para ladrillos
-19,190040,aglutinantes para fabricar briquetas y ladrillos
-19,190040,aglutinantes para fabricar piedras
-19,190041,cabinas telefónicas no metálicas
-19,190042,campanas neumáticas para obras de construcción subacuáticas
-19,190043,caliza
-19,190043,piedra caliza
-19,190044,canalones no metálicos
-19,190044,goterones no metálicos
-19,190044,canaletas no metálicas
-19,190045,cartón para la construcción
-19,190046,cartón asfaltado para la construcción
-19,190048,chamota
-19,190048,arcilla refractaria
-19,190049,mantos de chimenea no metálicos
-19,190050,entramados no metálicos para la construcción
-19,190051,materiales de construcción y revestimiento de calzadas
-19,190052,cal*
-19,190053,mortero para la construcción
-19,190054,yeso [escayola]
-19,190055,chimeneas no metálicas
-19,190056,enlucidos de cemento ignífugos
-19,190056,revestimientos de cemento ignífugos
-19,190057,losas de cemento
-19,190058,postes de cemento
-19,190059,esquistos
-19,190060,tabiques no metálicos
-19,190061,construcciones no metálicas
-19,190062,papel de construcción
-19,190063,vidrio de construcción
-19,190064,cornisas no metálicas
-19,190065,molduras no metálicas para cornisas
-19,190066,tapajuntas no metálicos para tejados
-19,190067,angulares no metálicos
-19,190068,ventanas no metálicas
-19,190069,puertas no metálicas*
-19,190070,tapas no metálicas para bocas de inspección
-19,190071,cubiertas de tejado no metálicas
-19,190072,tiza en bruto
-19,190073,cuarzo
-19,190074,peldaños no metálicos
-19,190074,escalones no metálicos
-19,190075,tubos de canalones no metálicos
-19,190076,tuberías de agua no metálicas
-19,190077,válvulas no metálicas ni de materias plásticas para tuberías de agua
-19,190078,andamios no metálicos
-19,190079,postes no metálicos para líneas eléctricas
-19,190080,tuberías de ramificación no metálicas
-19,190081,cercados no metálicos para tumbas
-19,190082,enlucidos bituminosos para techados
-19,190083,vigas no metálicas
-19,190083,jácenas no metálicas
-19,190084,pocilgas no metálicas
-19,190085,establos no metálicos
-19,190086,puntales no metálicos
-19,190086,entibos
-19,190088,losas funerarias no metálicas
-19,190088,losas sepulcrales no metálicas
-19,190089,placas conmemorativas no metálicas
-19,190090,fieltro para la construcción
-19,190091,moldes de fundición no metálicos
-19,190092,cemento para hornos
-19,190093,cemento para altos hornos
-19,190094,piedra*
-19,190095,cristales [vidrios] para la construcción
-19,190096,arcilla*
-19,190097,alquitrán de hulla
-19,190098,granito
-19,190099,grava
-19,190100,gres para la construcción
-19,190100,arenisca para la construcción
-19,190101,tuberías de gres
-19,190102,yeso [material de construcción]
-19,190103,celosías no metálicas
-19,190104,escorias [materiales de construcción]
-19,190105,balasto
-19,190106,tablas de parqué
-19,190107,persianas de exterior no metálicas ni de materias textiles
-19,190108,rampas de lanzamiento de cohetes no metálicas
-19,190109,listones no metálicos
-19,190110,aglutinantes para reparar carreteras
-19,190111,corcho aglomerado para la construcción
-19,190112,parqués
-19,190113,zancas de escalera no metálicas
-19,190114,dinteles no metálicos
-19,190115,adoquines luminosos
-19,190116,macadán
-19,190117,monumentos no metálicos
-19,190118,cemento de oxicloruro de magnesio
-19,190119,construcciones transportables no metálicas
-19,190120,mármol
-19,190121,microesferas de vidrio para la señalización horizontal de carreteras
-19,190122,láminas y bandas de materiales sintéticos para la señalización horizontal de carreteras
-19,190123,marquesinas [estructuras] no metálicas
-19,190124,mástiles [postes] no metálicos
-19,190125,madera para duelas
-19,190126,mosaicos para la construcción
-19,190127,madera moldeable
-19,190128,molduras no metálicas para la construcción
-19,190129,enlucidos [materiales de construcción]
-19,190130,chapados murales no metálicos para la construcción
-19,190131,tapajuntas no metálicos para la construcción
-19,190131,limahoyas no metálicas para la construcción
-19,190132,olivina para la construcción
-19,190133,contraventanas no metálicas
-19,190134,empalizadas no metálicas
-19,190135,cercas no metálicas
-19,190136,tablestacas no metálicas
-19,190137,paneles de señalización no metálicos ni luminosos ni mecánicos
-19,190138,revestimientos interiores murales no metálicos para la construcción
-19,190139,pistas de patinaje [estructuras] no metálicas
-19,190140,perchas [palos para aves]
-19,190141,piedras de construcción
-19,190142,piedra artificial
-19,190143,piedras de escoria
-19,190144,lápidas sepulcrales
-19,190145,toba
-19,190146,obras de cantería
-19,190147,suelos no metálicos
-19,190147,pisos no metálicos
-19,190148,techos no metálicos
-19,190149,tablones de madera para la construcción
-19,190150,revestimientos interiores no metálicos para la construcción
-19,190151,tejas no metálicas para techados
-19,190152,trampolines no metálicos
-19,190153,portones no metálicos
-19,190154,entrepaños de puerta no metálicos
-19,190155,postes telegráficos no metálicos
-19,190156,gallineros no metálicos
-19,190157,viguetas no metálicas
-19,190158,plataformas [andenes o muelles] prefabricadas no metálicas
-19,190160,depósitos de obra
-19,190160,tanques de obra
-19,190161,materiales de revestimiento de calzadas
-19,190162,umbrales no metálicos
-19,190163,caña para la construcción
-19,190164,mojones no metálicos ni luminosos ni mecánicos para carreteras
-19,190165,señales no metálicas ni luminosas ni mecánicas
-19,190166,arena, excepto arena de fundición
-19,190167,invernaderos transportables no metálicos
-19,190168,sílice [cuarzo]
-19,190169,silos no metálicos
-19,190170,estatuas de piedra, hormigón o mármol
-19,190170,estatuas de piedra, concreto o mármol
-19,190171,alquitrán
-19,190171,brea [material de construcción]
-19,190172,barro cocido [material de construcción]
-19,190173,techados no metálicos
-19,190174,tumbas no metálicas
-19,190175,cenadores [estructuras] no metálicos
-19,190175,glorietas [estructuras] no metálicas
-19,190176,traviesas de ferrocarril no metálicas
-19,190176,durmientes de ferrocarril no metálicos
-19,190177,enrejados [celosías] no metálicos
-19,190178,tuberías rígidas no metálicas para la construcción
-19,190179,tragaluces no metálicos
-19,190180,vidrio aislante para la construcción
-19,190181,vidrio para ventanas, que no sea vidrio para ventanillas de vehículos
-19,190182,vitrales
-19,190182,vidrieras de colores
-19,190183,vidrio para ventanas para la construcción
-19,190184,pajareras [estructuras] no metálicas
-19,190185,alfarjías
-19,190186,xilolita
-19,190187,bolardos de amarre no metálicos
-19,190188,muelles flotantes no metálicos para amarrar barcos
-19,190189,rodapiés [frisos] no metálicos
-19,190190,acuarios [estructuras]
-19,190191,armazones no metálicos para la construcción
-19,190192,vidrio armado
-19,190192,cristal de seguridad
-19,190193,obras de arte de piedra, hormigón o mármol
-19,190193,obras de arte de piedra, concreto o mármol
-19,190194,bañeras para pájaros [estructuras] no metálicas
-19,190195,balizas no metálicas ni luminosas
-19,190196,piscinas [estructuras] no metálicas
-19,190196,albercas de natación [estructuras] no metálicas
-19,190196,piletas de natación [estructuras] no metálicas
-19,190197,materiales de construcción no metálicos
-19,190198,encofrados no metálicos para hormigón
-19,190198,encofrados no metálicos para concreto
-19,190199,instalaciones no metálicas para aparcar bicicletas
-19,190200,pavimentos no metálicos
-19,190201,cartón de pasta de madera para la construcción
-19,190202,bustos de piedra, hormigón o mármol
-19,190202,bustos de piedra, concreto o mármol
-19,190203,cabinas de baño no metálicas
-19,190205,cabinas de pulverización de pintura no metálicas
-19,190206,postes no metálicos
-19,190208,marcos de ventana no metálicos
-19,190209,marcos de puerta no metálicos
-19,190209,armaduras de puerta no metálicas
-19,190209,armazones de puerta no metálicos
-19,190209,bastidores de puerta no metálicos
-19,190210,armazones de invernadero no metálicos
-19,190211,margas calcáreas
-19,190212,sombreretes de chimenea no metálicos
-19,190213,baldosas no metálicas para la construcción
-19,190214,baldosas no metálicas para suelos
-19,190215,panteones no metálicos
-19,190216,caperuzas de chimenea no metálicas
-19,190217,alargadores no metálicos para chimeneas
-19,190218,tubos de chimenea no metálicos
-19,190219,losas de pavimentación no metálicas
-19,190220,tuberías de desagüe no metálicas
-19,190221,sifones de desagüe no metálicos ni de materias plásticas
-19,190222,escaleras no metálicas
-19,190223,paneles no metálicos para la construcción
-19,190224,figuritas de piedra, hormigón o mármol
-19,190224,estatuillas de piedra, concreto o mármol
-19,190224,estatuillas de piedra, hormigón o mármol
-19,190224,figuritas de piedra, concreto o mármol
-19,190225,monumentos funerarios no metálicos
-19,190226,estelas funerarias no metálicas
-19,190227,barreras de seguridad no metálicas para carreteras
-19,190227,guardarraíles no metálicos
-19,190227,guardarrieles no metálicos
-19,190228,buzones de correo de obra
-19,190231,aglomerados de bagazo [materiales de construcción]
-19,190232,tuberías forzadas no metálicas
-19,190233,gravilla para acuarios
-19,190234,arena para acuarios
-19,190235,conductos no metálicos para instalaciones de ventilación y aire acondicionado
-19,190236,geotextiles
-19,190237,cantos rodados
-19,190238,revestimientos exteriores de vinilo [materiales de construcción]
-19,190239,mosquiteros [bastidores] no metálicos
-19,190240,techados no metálicos con células fotovoltaicas integradas
-19,190241,enrejados no metálicos
-19,190242,materiales de construcción refractarios no metálicos
-19,190243,casas prefabricadas [kits] no metálicas
-19,190244,pórfido [piedra]
-19,190245,cunetas no metálicas
-19,190246,torniquetes [molinetes] no metálicos
-19,190247,placas funerarias no metálicas
-19,190248,tablas para suelos de madera
-19,190248,tablas para pisos de madera
-19,190249,solados no metálicos de baldosas
-19,190250,tejas acanaladas no metálicas
-19,190250,tejas flamencas no metálicas
-19,190251,baldosas no metálicas para paredes
-19,190252,losas no metálicas para la construcción
-19,190253,cristal de roca
-19,190254,puertas blindadas no metálicas
-19,190255,vidrio esmaltado para la construcción
-19,190256,pilares no metálicos para la construcción
-19,190257,escuadras no metálicas para la construcción
-19,190258,recubrimientos no metálicos para la construcción
-19,190259,borduras de materias plásticas para paisajismo
-19,190260,rodamientos de caucho para el aislamiento sísmico de edificios
-19,190261,blindajes no metálicos
-19,190262,astas de bandera [estructuras] no metálicas
-19,190263,puertas batientes no metálicas
-19,190264,puertas de acordeón no metálicas
-19,190265,cabinas insonorizadas transportables, no metálicas
-19,190266,paneles acústicos no metálicos
-19,190267,armazones no metálicos para miniinvernaderos
-19,190267,armazones no metálicos para camas frías
+class|name
+19|Adoquines
+19|Adoquines y peñascos
+19|Alcantarillas de calle no metálicas
+19|Alcantarillas no metálicas
+19|Alféizares no metálicos
+19|Alquitrán de hulla
+19|Alquitrán de madera
+19|Alquitrán y brea
+19|Andamios de madera
+19|Andesita
+19|Arcilla de ceniza
+19|Arena
+19|Arena para acuarios
+19|Arena para la construcción
+19|Arenisca
+19|Armaduras de puerta no metálicas
+19|Arquetas de desagüe no metálicas para construcción de sistemas de impermeabilización de sótanos
+19|Arrimadillos no metálicos
+19|Asfalto
+19|Asfalto para carretera
+19|Asfalto para la construcción
+19|Asfalto, pez y bitumen
+19|Azulejos cerámicos para paredes
+19|Azulejos cerámicos para pisos y superficies
+19|Azulejos de cerámica para paredes, pisos o cielos
+19|Azulejos de madera
+19|Azulejos de pared no metálicos
+19|Azulejos de pavimento no metálicos
+19|Azulejos de piso cerámicos
+19|Azulejos de suelo de terracota
+19|Azulejos y lozas para pavimentar, no metálicas
+19|Badenes de control de velocidad no metálicos
+19|Baldosas cerámicas esmaltadas
+19|Baldosas de cerámica
+19|Baldosas de cerámica para suelos y revestimiento
+19|Baldosas de cubiertas de cerámica
+19|Baldosas de madera
+19|Baldosas de mosaico
+19|Baldosas de piedra para techos
+19|Baldosas de plástico
+19|Baldosas de vidrio que no sean para tejados
+19|Baldosas de yeso
+19|Balizas de anclaje no metálicas
+19|Balizas no metálicos no luminosos (estructuras de torre)
+19|Betún (material de construcción)
+19|Blindajes no metálicos para la construcción
+19|Bloques de hormigón
+19|Bloques de madera
+19|Bloques de pavimento no metálicos
+19|Bolardos de hormigón
+19|Bordes de puerta no metálicos
+19|Brea de petróleo
+19|Bustos de concreto
+19|Bustos de mármol
+19|Buzones de correo de obra
+19|Calcita
+19|Caliza
+19|Canalones de lluvia (que no sean metálicos)
+19|Canalones no metálicos
+19|Canalones no metálicos para tejados
+19|Caperuzas de chimenea no metálicas
+19|Casas de troncos prefabricadas
+19|Cemento
+19|Cemento con sílice (cemento puzolánico)
+19|Cemento de alúmina
+19|Cemento de escoria-cal
+19|Cemento de oxicloruro de magnesio
+19|Cemento de relleno
+19|Cemento hidráulico
+19|Cemento Portland
+19|Cemento portland de escorias de altos hornos
+19|Cemento refractario
+19|Cenadores transportables principalmente no metálicos
+19|Cercas eslabonadas no metálicas
+19|Chamota
+19|Chapa de madera
+19|Chapados de madera
+19|Chimeneas no metálicas
+19|Cobertizos de materiales no metálicos
+19|Coberturas no metálicas para techos
+19|Columnas publicitarias no metálicas
+19|Composiciones de pavimentación de asfalto
+19|Compuestos a base de betún para la construcción
+19|Compuestos para lechadas
+19|Concreto refractario
+19|Conducciones de agua de cemento
+19|Construcciones transportables no metálicas
+19|Contornos de chimenea
+19|Contrachapados
+19|Contraventanas no metálicas
+19|Cornisas no metálicas
+19|Cristales de ventanas para construcción
+19|Depósitos de agua de albañilería para uso doméstico
+19|Depósitos de almacenamiento de albañilería
+19|Depósitos de mampostería para el almacenamiento de líquidos para uso industrial
+19|Ductos de ventilación no metálicos
+19|Durmientes de madera
+19|Edificios transportables de madera
+19|Emulsión de betún polimérico para impermeabilizar construcciones
+19|Emulsiones de betún polimérico para superficies de carreteras
+19|Enlucidos bituminosos para tejados
+19|Enlucidos de cemento ignífugos
+19|Enrejados no metálicos
+19|Entablado no metálico
+19|Entrepaños de puerta no metálicos
+19|Enyesados de acabado hechos de resina artificial coloreada
+19|Escaleras no metálicas
+19|Escaleras no metálicas para su uso en edificios
+19|Esculturas de hormigón
+19|Esculturas de mármol
+19|Esculturas de piedra
+19|Estatuas de concreto
+19|Estatuas de mármol
+19|Estatuas de piedra
+19|Estatuas de piedra, hormigón o mármol
+19|Estatuillas de piedra, concreto o mármol
+19|Fieltro de asfalto para la construcción
+19|Fieltro de asfalto para tejados
+19|Fieltro para tejados
+19|Figuritas de hormigón
+19|Figuritas de mármol
+19|Figuritas de piedra
+19|Granulados minerales para la construcción
+19|Grava
+19|Gravilla para acuarios
+19|Hojas de vidrio para la construcción
+19|Hormigón
+19|Hormigón autonivelante para su uso en la edificación
+19|Hormigón listo para usar
+19|Hormigón para uso industrial en trabajos de ingeniería civil
+19|Invernaderos transportables no metálicos de uso doméstico
+19|Ladrillos
+19|Ladrillos cocidos
+19|Ladrillos de vidrio
+19|Ladrillos semirefractarios no metálicos
+19|Ladrillos sin cocer
+19|Láminas de revestimiento de madera contrachapada
+19|Lápidas sepulcrales
+19|Lápidas sepulcrales de piedra, hormigón o mármol
+19|Liparita
+19|Losas funerarias no metálicas
+19|Losas y embaldosados de piedra natural
+19|Macadán
+19|Madera
+19|Madera artificial
+19|Madera aserrada en bruto
+19|Madera balsa
+19|Madera conformada
+19|Madera de chapado
+19|Madera de construcción
+19|Madera estructural
+19|Madera laminada encolada
+19|Madera multicapa
+19|Madera para minería
+19|Madera partida
+19|Madera resistente al fuego
+19|Madera semielaborada
+19|Madera tratada (madera anti-pudrición)
+19|Mamparas corredizas japonesas de papel fino (shoji)
+19|Marcos de puerta no metálicos
+19|Marcos de puertas no metálicos
+19|Marcos de ventana no metálicos
+19|Mármol (material de construcción)
+19|Marquesinas (no metálicas)
+19|Marquesinas no metálicas para la construcción
+19|Materiales de construcción de cal
+19|Materiales de construcción de listones de cedro aromático
+19|Materiales de construcción refractarios no metálicos
+19|Materiales refractarios no metálicos
+19|Materiales sintéticos para revestimientos de suelos o revestimientos murales
+19|Media madera (ensambles)
+19|Membranas de PVC para techos
+19|Mezclas de cemento
+19|Microesferas de vidrio para la señalización horizontal de carreteras
+19|Minerales no metálicos para edificios y la construcción
+19|Moldes de madera para tornos
+19|Monumentos de concreto
+19|Monumentos de mármol
+19|Monumentos de piedra
+19|Monumentos no metálicos
+19|Mortero
+19|Mortero de revestimiento
+19|Mortero de unión para fines de construcción
+19|Mortero para la construcción
+19|Morteros
+19|Mosquiteros (bastidores) no metálicos
+19|Muros de hormigón
+19|Muros de hormigón para la construcción
+19|Paneles de cemento reforzado con fibra de madera (tableros de cemento mejorado)
+19|Paneles de hormigón
+19|Paneles de hormigón para pavimentar carreteras
+19|Paneles de techo no metálicos
+19|Paneles de vallado no metálicos
+19|Paneles multicapa de plástico para uso en construcción
+19|Paneles no metálicos para suelos
+19|Panteones no metálicos
+19|Papel de asfalto para tejados
+19|Papel de construcción
+19|Paredes no metálicas prefabricadas
+19|Parqués
+19|Parqués de corcho
+19|Parqués de madera
+19|Partes de puertas no metálicas
+19|Partes de ventanas no metálicas
+19|Particiones no metálicas para construcción
+19|Persianas de exterior no metálicas ni textiles
+19|Persianas exteriores no metálicas
+19|Pez y betún
+19|Piedra artificial
+19|Piedra caliza (piedra calcárea)
+19|Piedra de alfarería
+19|Piedra de sílice
+19|Piedra natural
+19|Piedra para muros
+19|Piedra para pavimentación
+19|Piedra pizarra
+19|Piedras de construcción
+19|Piedras decorativas para acuario
+19|Pilotes de hormigón
+19|Pisos de bambú
+19|Pisos de hormigón
+19|Pisos de madera
+19|Pizarras de mortero de cemento
+19|Pizarras para el revestimiento de paredes
+19|Pizarras para el revestimiento de tejados
+19|Placas conmemorativas de piedra
+19|Placas de cemento
+19|Placas de sepultura no metálicas
+19|Placas de vidrio para su uso en construcción
+19|Placas funerarias no metálicas
+19|Placas y planchas para parquet
+19|Planchas de madera
+19|Plataformas de clavados no metálicas
+19|Plataformas lanzacohetes que no sean de metal
+19|Pórfido (piedra)
+19|Postes de madera para líneas eléctricas
+19|Postes de plástico para demarcación
+19|Postes en T no metálicos para vallas
+19|Postes no metálicos para cercados móviles
+19|Postigos de ventana no metálicos
+19|Puertas cortafuegos no metálicas
+19|Puertas de seguridad no metálicas
+19|Puertas giratorias no metálicas
+19|Puertas no metálicas
+19|Puertas no metálicas para gatos
+19|Puertas para perros no metálicas
+19|Puertas ventana de vinilo
+19|Raíles de friso
+19|Raíles de madera
+19|Reductores de velocidad no metálicos
+19|Repisas de chimenea
+19|Revestimientos bituminosos para tejados
+19|Revestimientos de madera
+19|Riolita
+19|Sacos de arena
+19|Silos no metálicos
+19|Suelos deportivos de madera
+19|Sumideros no metálicos (estructuras)
+19|Tabiques deslizantes de interior de estilo japonés (fusuma)
+19|Tablas de construcción de materias plásticas
+19|Tablas de madera
+19|Tablas de parqué
+19|Tablas de yeso
+19|Tablas para pisos de madera
+19|Tablero de fibra de madera
+19|Tableros de contrachapados
+19|Tableros de madera para techos
+19|Tableros de madera para tejados
+19|Tableros de plástico para tabiques
+19|Tableros de suelos de plástico
+19|Tablestacas de madera
+19|Tablones
+19|Tablones de astilla en bruto y recubiertos para la industria de la construcción, de los muebles y la decoración de interiores
+19|Tablones de madera
+19|Tablones de yeso
+19|Tanques de madera para almacenamiento
+19|Tapajuntas de tejado que no sean metálicos
+19|Tapas no metálicas para bocas de inspección
+19|Techumbres no metálicas con células solares integradas
+19|Tejas de arcilla para techado
+19|Tejas de mortero de cemento para tejados
+19|Tejas de vidrio
+19|Tejidos, alfombrillas y láminas de control de la erosión, no metálicos (geotextiles)
+19|Terracota (material de construcción)
+19|Textiles no tejidos de fibras sintéticas para la industria de la construcción
+19|Torniquetes (molinetes) no metálicos
+19|Tragaluces no metálicos
+19|Troncos (material de construcción)
+19|Tuberías de agua no metálicas
+19|Tuberías de cemento
+19|Tuberías de concreto
+19|Tuberías de desagüe no metálicas
+19|Tuberías de drenaje cerámicas
+19|Tuberías y conductos de arcilla
+19|Tubos de canalones no metálicos
+19|Tubos de empalmes no metálicos
+19|Tubos de hormigón
+19|Tubos rígidos no metálicos para la construcción
+19|Válvulas no metálicas ni de materias plásticas para tuberías de agua
+19|Ventanas de seguridad de plástico que permiten la comunicación
+19|Ventanas no metálicas
+19|Vidrieras
+19|Vidrio absorbente de rayos infrarrojos para la construcción
+19|Vidrio aislado para la construcción
+19|Vidrio aislante para la construcción
+19|Vidrio alambrado para la construcción
+19|Vidrio con conductores eléctricos finos incorporados que no sea para la construcción
+19|Vidrio de construcción
+19|Vidrio de seguridad para uso en construcción
+19|Vidrio decorativo para construcción
+19|Vidrio decorativo para la construcción
+19|Vidrio empavonado para la construcción
+19|Vidrio laminado coloreado para la construcción
+19|Vidrio laminado común para la construcción
+19|Vidrio laminado modificado (para la construcción)
+19|Vidrio luminoso para la construcción
+19|Vidrio para la construcción
+19|Vidrio plano laminado para la construcción
+19|Vidrio reforzado para la construcción
+19|Vidrio templado para la construcción
+19|Vidrios de ventana
+19|Vigas de madera
+19|Viguetas
+19|Yeso (material de construcción)
+19|Yeso para la construcción
+19|Yeso para revestimiento

--- a/lib/seeds/class_1_terms.csv
+++ b/lib/seeds/class_1_terms.csv
@@ -1,770 +1,909 @@
-class,reference_id,name
-1,010001,comburentes [aditivos químicos para carburantes]
-1,010002,adhesivos [pegamentos] para uso industrial
-1,010002,pegamentos para uso industrial
-1,010003,sal de conservación que no sea para alimentos
-1,010004,fluidos auxiliares para abrasivos
-1,010005,aceleradores de vulcanización
-1,010006,soluciones antiespumantes para acumuladores
-1,010006,soluciones antiespumantes para baterías
-1,010007,acetatos [productos químicos]*
-1,010008,acetato de celulosa en bruto
-1,010009,preparaciones bacteriológicas para la acetificación
-1,010010,anhídrido acético
-1,010011,acetona
-1,010012,acetileno
-1,010013,tetracloruro de acetileno
-1,010014,ácidos*
-1,010015,productos químicos de condensación
-1,010016,compuestos químicos resistentes a los ácidos
-1,010017,preparaciones de acabado para ser utilizadas en la fabricación del acero
-1,010018,actinio
-1,010019,aditivos químicos para lodos de perforación
-1,010020,aditivos químicos para carburantes
-1,010020,aditivos químicos para combustibles de motor
-1,010021,aditivos detergentes para gasolina
-1,010022,adhesivos para vendajes quirúrgicos
-1,010022,preparaciones adhesivas para vendajes quirúrgicos
-1,010023,productos para ablandar el agua
-1,010024,goma tragacanto para uso industrial
-1,010025,carbón activo
-1,010025,carbón activado
-1,010026,gases propulsores para aerosoles
-1,010027,agentes reductores para uso fotográfico
-1,010028,colas para carteles
-1,010028,adhesivos para carteles
-1,010029,agar-agar para uso industrial
-1,010030,aglutinantes para hormigón
-1,010030,aglutinantes para concreto
-1,010031,productos químicos para uso agrícola, excepto fungicidas, herbicidas, insecticidas y parasiticidas
-1,010032,compuestos para reparar cámaras de aire de neumáticos
-1,010033,albúmina [animal o vegetal, materia prima]
-1,010034,albúmina iodada
-1,010035,albúmina de malta
-1,010036,papel albuminado
-1,010037,álcalis
-1,010038,álcali cáustico
-1,010039,metales alcalinotérreos
-1,010040,alcohol*
-1,010041,alcohol etílico
-1,010042,aldehídos*
-1,010043,algas [fertilizantes]
-1,010044,productos químicos para conservar alimentos
-1,010045,productos químicos para facilitar la aleación de metales
-1,010046,alúmina
-1,010047,alumbre de aluminio
-1,010048,hidrato de aluminio
-1,010049,silicato de aluminio
-1,010050,cloruro de aluminio
-1,010051,ioduro de aluminio
-1,010052,alumbre
-1,010053,preparaciones para enmendar suelos
-1,010054,americio
-1,010055,almidón para uso industrial
-1,010055,fécula para uso industrial
-1,010056,agentes químicos para desleír el almidón [agentes para despegar]
-1,010056,agentes para despegar [agentes químicos para desleír el almidón]
-1,010057,sal de amoniaco
-1,010057,sal de amoníaco
-1,010058,espíritu de sal
-1,010060,sales amoniacales
-1,010061,amoniaco*
-1,010061,amoníaco*
-1,010062,aldehído de amoniaco
-1,010062,aldehído de amoníaco
-1,010063,alumbre de amoniaco
-1,010063,alumbre de amoníaco
-1,010064,acetato de amilo
-1,010065,alcohol amílico
-1,010066,amoniaco anhidro
-1,010066,amoníaco anhidro
-1,010067,anhídridos
-1,010068,negro animal
-1,010069,albúmina animal [materia prima]
-1,010070,ácido antranílico
-1,010071,antidetonantes para motores de explosión
-1,010071,antidetonantes para motores de combustión interna
-1,010072,anticongelantes
-1,010073,antiincrustantes
-1,010073,productos antitártricos
-1,010074,antimonio
-1,010075,óxido de antimonio
-1,010076,sulfuro de antimonio
-1,010077,aprestos para la industria textil
-1,010078,goma arábiga para uso industrial
-1,010079,emplastos para uso en arboricultura
-1,010079,emplastos para injertos [arboricultura]
-1,010080,mástique para rellenar las cavidades de los árboles [arboricultura]
-1,010081,soluciones de sales de plata para platear
-1,010081,soluciones para platear
-1,010082,argón
-1,010083,arseniato de plomo
-1,010084,arsénico
-1,010085,ácido arsenioso
-1,010086,ástato
-1,010087,combustibles para reactores nucleares
-1,010089,productos químicos para descarburar motores
-1,010090,papel autovirador [fotografía]
-1,010091,productos químicos para avivar los colores de materias textiles
-1,010092,nitrógeno
-1,010093,óxido nitroso
-1,010094,fertilizantes nitrogenados
-1,010095,ácido nítrico
-1,010096,bactericidas para uso enológico [productos químicos utilizados en la elaboración del vino]
-1,010097,baños fijadores [fotografía]
-1,010098,baños de galvanización
-1,010099,baños viradores [fotografía]
-1,010100,ceniza de soda [barrilla]
-1,010100,ceniza de sosa [barrilla]
-1,010101,bario
-1,010102,barita
-1,010103,papel barritado
-1,010104,compuestos de bario
-1,010105,productos para impedir el desmallado de las medias
-1,010106,bases [productos químicos]
-1,010107,productos químicos para fabricar esmaltes, excepto pigmentos
-1,010108,bauxita
-1,010109,bentonita
-1,010110,ácidos de la serie del benceno
-1,010111,derivados del benceno
-1,010112,ácido benzoico
-1,010113,sulfimida benzoica
-1,010114,sacarina
-1,010115,berkelio
-1,010116,productos químicos para airear el hormigón
-1,010116,productos químicos para airear el concreto
-1,010117,conservadores de hormigón, excepto pinturas y aceites
-1,010117,conservadores de concreto, excepto pinturas y aceites
-1,010118,bicloruro de estaño
-1,010119,bicromato de potasio
-1,010119,bicromato de potasa
-1,010120,bicromato de soda
-1,010120,bicromato de sosa
-1,010121,productos para clarificar y conservar la cerveza
-1,010122,catalizadores bioquímicos
-1,010123,dioxalato de potasio
-1,010123,dioxalato de potasa
-1,010124,dióxido de manganeso
-1,010125,bismuto
-1,010126,galato básico de bismuto
-1,010127,productos de remojo [lavandería]
-1,010127,productos humectantes [lavandería]
-1,010128,productos químicos para blanquear la cera
-1,010130,madera para curtir
-1,010131,espíritu [alcohol] de madera
-1,010131,alcohol de madera
-1,010132,pasta de madera
-1,010133,vinagre de madera [ácido piroleñoso]
-1,010133,ácido piroleñoso [vinagre de madera]
-1,010134,bórax
-1,010135,ácido bórico para uso industrial
-1,010136,lodos para facilitar la perforación
-1,010137,productos para soldar
-1,010138,productos antivaho
-1,010139,cachú*
-1,010140,cainita
-1,010141,cianamida cálcica [abono]
-1,010141,cianamida de calcio [abono]
-1,010142,californio
-1,010143,plastificantes
-1,010145,productos para conservar el caucho
-1,010146,carbonatos
-1,010147,carbonato de magnesia
-1,010147,carbonato de magnesio
-1,010148,carbono
-1,010149,disulfuro de carbono
-1,010149,sulfuro de carbono
-1,010150,ácido carbónico
-1,010151,carburos*
-1,010152,carburo de calcio
-1,010153,casiopeo [lutecio]
-1,010153,lutecio [casiopeo]
-1,010154,catalizadores
-1,010155,celulosa
-1,010156,pasta de papel
-1,010157,viscosa
-1,010158,cementos [metalurgia]
-1,010159,fermio [centurio]
-1,010159,centurio [fermio]
-1,010160,vidriados para cerámica
-1,010161,cerio
-1,010162,sales de metales de las tierras raras
-1,010163,cesio
-1,010164,cetonas
-1,010165,preparaciones de carbón animal
-1,010166,carbón para filtros
-1,010167,carbón de huesos
-1,010168,carbón de sangre
-1,010169,productos para ahorrar carbón
-1,010170,pegamentos para el calzado
-1,010171,acetato de cal
-1,010172,carbonato de cal
-1,010173,cloruro de cal
-1,010174,productos químicos para limpiar chimeneas
-1,010175,productos químicos para renovar el cuero
-1,010176,productos químicos para uso industrial
-1,010177,preparaciones químicas de uso científico que no sean para uso médico ni veterinario
-1,010178,reactivos químicos que no sean para uso médico ni veterinario
-1,010179,moderadores para reactores nucleares
-1,010180,elementos químicos fisibles
-1,010181,productos químicos para análisis en laboratorio que no sean de uso médico ni veterinario
-1,010182,cloratos
-1,010183,cloro
-1,010184,clorhidratos
-1,010185,ácido clorhídrico
-1,010186,ácido cólico
-1,010187,cromatos
-1,010188,alumbre de cromo
-1,010189,óxido de cromo
-1,010190,sales de cromo
-1,010191,ácido crómico
-1,010192,masillas para el cuero
-1,010193,masillas para neumáticos
-1,010194,pegamentos para reparar objetos rotos
-1,010195,productos químicos para impermeabilizar cemento, excepto pinturas
-1,010196,conservadores de cemento, excepto pinturas y aceites
-1,010197,líquidos para circuitos hidráulicos
-1,010198,cera para injertos de árboles
-1,010199,ácido cítrico para uso industrial
-1,010200,preparaciones para desfangar mostos
-1,010202,colas [aprestos]
-1,010202,aprestos de imprimación y acabado
-1,010203,colas para papel pintado
-1,010203,adhesivos para papel pintado
-1,010203,adhesivos para papel tapiz
-1,010203,colas para papel tapiz
-1,010205,colas para desfangar vinos
-1,010206,colodión*
-1,010207,sales para colorear metales
-1,010208,baños alcalinos [productos para ablandar el cuero]
-1,010208,aprestos, excepto aceites, para el cuero
-1,010209,productos para conservar las flores
-1,010210,conservantes para la industria farmacéutica
-1,010211,productos químicos para uso fotográfico
-1,010212,tela sensibilizada para uso fotográfico
-1,010213,placas fotosensibles
-1,010214,productos corrosivos
-1,010215,productos para adobar [curtir] el cuero
-1,010216,productos para adobar [curtir] las pieles
-1,010219,crémor tártaro para uso químico
-1,010220,aldehído crotónico
-1,010221,productos criogénicos
-1,010222,colas para el cuero
-1,010223,productos químicos para preparar el cuero
-1,010224,productos químicos para impregnar el cuero
-1,010225,vitriolo azul
-1,010225,sulfato de cobre [vitriolo azul]
-1,010226,curio
-1,010227,soluciones para la cianotipia
-1,010228,cianuros [prusiatos]
-1,010228,prusiatos
-1,010229,ferrocianuros
-1,010230,cimeno
-1,010231,productos desengrasantes para procesos de fabricación
-1,010232,preparaciones para desencolar
-1,010232,preparaciones para despegar y separar
-1,010233,productos químicos para separar aceites
-1,010234,productos de descrudecimiento
-1,010234,productos de desgomado
-1,010236,defoliantes
-1,010237,productos para desmoldar
-1,010238,sustancias para deslustrar
-1,010239,deshidratantes para uso industrial
-1,010240,desincrustantes*
-1,010241,detergentes para procesos de fabricación
-1,010242,dextrina [apresto]
-1,010243,preparaciones de diagnóstico que no sean para uso médico ni veterinario
-1,010244,diastasas para uso industrial
-1,010245,papel diazoico
-1,010246,productos para renovar discos fonográficos
-1,010247,agua destilada
-1,010248,dolomita para uso industrial
-1,010249,preparaciones para endurecer metales
-1,010250,disprosio
-1,010251,agua acidulada para recargar acumuladores
-1,010251,agua acidulada para recargar baterías
-1,010252,glicerina para uso industrial
-1,010253,agua pesada
-1,010254,preparaciones para clarificar
-1,010254,preparaciones para purificar
-1,010255,intercambiadores de iones [productos químicos]
-1,010256,productos para producir flashes
-1,010257,productos para ahorrar combustible
-1,010259,papel reactivo que no sea para uso médico o veterinario
-1,010260,productos antiestáticos que no sean para uso doméstico
-1,010261,sales para elementos galvánicos
-1,010261,sales para celdas galvánicas
-1,010261,sales para pilas galvánicas
-1,010262,opacificantes para esmaltes
-1,010263,opacificantes para el vidrio
-1,010265,productos químicos matificantes para esmaltes
-1,010267,emulsiones fotográficas
-1,010268,emulsionantes
-1,010269,placas fotográficas sensibilizadas
-1,010270,productos para encolar
-1,010271,abonos para el suelo
-1,010271,fertilizantes
-1,010272,preparaciones enzimáticas para uso industrial
-1,010273,enzimas para uso industrial
-1,010274,resinas epoxi en bruto
-1,010275,productos para depurar gases
-1,010276,erbio
-1,010277,espíritu de vinagre [ácido acético diluido]
-1,010278,papel químico para ensayos
-1,010279,ésteres*
-1,010280,etano
-1,010281,éteres*
-1,010282,éter etílico
-1,010283,éteres de glicol
-1,010284,éter metílico
-1,010285,éter sulfúrico
-1,010286,productos químicos para proteger los textiles contra las manchas
-1,010287,europio
-1,010288,compuestos extintores
-1,010289,harinas para uso industrial
-1,010290,sales de hierro
-1,010291,fermentos para uso químico
-1,010292,placas para ferrotipos [fotografía]
-1,010293,preparaciones fertilizantes
-1,010294,productos ignífugos
-1,010294,productos de protección contra el fuego
-1,010295,compuestos para aterrajar
-1,010296,agentes filtrantes para la industria de las bebidas
-1,010297,cuerpos fisibles para la energía nuclear
-1,010298,fijadores [fotografía]
-1,010299,flor de azufre para uso químico
-1,010301,productos para impermeabilizar con fluoratos
-1,010302,flúor
-1,010303,compuestos de flúor
-1,010304,ácido fluorhídrico
-1,010305,grafito para uso industrial
-1,010306,aglutinantes de fundición
-1,010307,preparaciones de moldeo para la fundición
-1,010308,aditivos químicos para insecticidas
-1,010309,aditivos químicos para fungicidas
-1,010310,ácido fórmico
-1,010311,aldehído fórmico para uso químico
-1,010312,productos de abatanado para la industria textil
-1,010313,materias para abatanar
-1,010314,francio
-1,010315,líquido de frenos
-1,010316,negro de humo para uso industrial
-1,010317,preparaciones químicas para ahumar carne
-1,010318,gadolinio
-1,010319,nuez de agalla
-1,010320,ácido gálico para fabricar tintas
-1,010321,galio
-1,010322,papel fotográfico
-1,010323,ácido galotánico
-1,010324,productos para galvanizar
-1,010325,gambir
-1,010326,gases protectores para soldar
-1,010328,gases solidificados para uso industrial
-1,010329,gelatina para uso fotográfico
-1,010330,gelatina para uso industrial
-1,010331,sal gema
-1,010332,desgasificadores [reactivos]
-1,010333,hielo seco [dióxido de carbono]
-1,010334,liga
-1,010335,glucósidos
-1,010336,glicéridos
-1,010337,glicol
-1,010339,productos para blanquear grasas
-1,010340,ácidos grasos
-1,010341,mástique para injertar árboles
-1,010342,guano
-1,010343,bálsamo de gurjun para ser utilizado en la fabricación de barnices
-1,010344,helio
-1,010345,holmio
-1,010346,hormonas para activar la maduración de la fruta
-1,010347,productos químicos para uso hortícola, excepto fungicidas, herbicidas, insecticidas y parasiticidas
-1,010348,aceites para conservar alimentos
-1,010349,aceites para preparar el cuero
-1,010350,aceites curtientes
-1,010351,dispersantes de petróleo
-1,010352,dispersantes de aceites
-1,010353,productos químicos para blanquear aceites
-1,010354,productos químicos para purificar aceites
-1,010355,humus
-1,010356,hidratos
-1,010357,hidratos de carbono
-1,010358,hidracina
-1,010359,hidrógeno
-1,010360,hipoclorito de soda
-1,010360,hipoclorito de sosa
-1,010361,hiposulfitos
-1,010362,productos químicos para impermeabilizar materias textiles
-1,010363,productos químicos para impregnar materias textiles
-1,010364,productos químicos para impermeabilizar el cuero
-1,010365,iodo para uso químico
-1,010366,sales de iodo
-1,010367,ácido iódico
-1,010368,ioduros para uso industrial
-1,010369,isótopos para uso industrial
-1,010370,caolín
-1,010370,arcilla china
-1,010370,arcilla blanca
-1,010371,kieselgur
-1,010372,kriptón
-1,010372,criptón
-1,010373,ácido láctico
-1,010374,fermentos lácteos para uso químico
-1,010375,lantano
-1,010377,productos para que no se empañen los lentes de contacto
-1,010377,productos para que no se empañen las lentillas
-1,010378,litina
-1,010379,litio
-1,010380,productos para conservar obras de albañilería, excepto pinturas y aceites
-1,010381,productos para conservar ladrillos, excepto pinturas y aceites
-1,010382,magnesita
-1,010383,cloruro de magnesio
-1,010384,manganato
-1,010385,corteza de mangle para uso industrial
-1,010386,productos químicos para esmerilar el vidrio
-1,010387,mercurio
-1,010388,sales de mercurio
-1,010389,óxido de mercurio
-1,010389,óxido mercúrico
-1,010390,metaloides
-1,010391,sales de metales preciosos para uso industrial
-1,010393,preparaciones para el recocido de metales
-1,010394,metano
-1,010395,preparaciones químicas de protección contra el mildiu
-1,010396,ácidos minerales
-1,010397,sales para uso industrial
-1,010398,productos de remojo [tintorería]
-1,010398,productos humectantes [tintorería]
-1,010399,naftalina
-1,010400,neodimio
-1,010401,neón
-1,010402,neptunio
-1,010403,neutralizantes de gases tóxicos
-1,010404,preparaciones químicas de protección contra el tizón del trigo
-1,010405,nitrato de uranio
-1,010406,placas sensibilizadas para imprimir en offset
-1,010407,ácido oleico
-1,010408,olivino [minerales de silicato]
-1,010409,sales de oro
-1,010410,sal de acedera
-1,010411,oxalatos
-1,010412,ácido oxálico
-1,010413,oxígeno para uso industrial
-1,010414,peróxido de hidrógeno para uso industrial 
-1,010414,agua oxigenada para uso industrial
-1,010415,cloruro de paladio
-1,010416,papel nitrado
-1,010417,papel fotométrico
-1,010418,papel sensible
-1,010419,papel de tornasol
-1,010420,pectina para uso fotográfico
-1,010421,perborato de soda
-1,010421,perborato de sosa
-1,010422,percarbonatos
-1,010423,percloratos
-1,010424,persulfatos
-1,010425,ácido persulfúrico
-1,010426,fenol para uso industrial
-1,010427,fosfatos [fertilizantes]
-1,010428,escoria [fertilizante]
-1,010429,fosfátidos
-1,010430,fósforo
-1,010431,superfosfatos [fertilizantes]
-1,010432,papel para fotocalcos
-1,010433,ácido fosfórico
-1,010434,telas para fotocalcos
-1,010435,reveladores fotográficos
-1,010436,sensibilizadores fotográficos
-1,010437,ácido pícrico
-1,010438,materias plásticas en bruto
-1,010439,plastisoles
-1,010440,acetato de plomo
-1,010441,óxido de plomo
-1,010442,plutonio
-1,010443,polonio
-1,010444,harina de patata para uso industrial
-1,010444,harina de papa para uso industrial
-1,010445,macetas de turba para uso hortícola
-1,010446,potasa
-1,010447,potasio
-1,010448,aguas potásicas
-1,010449,praseodimio
-1,010450,prometio
-1,010451,protactinio
-1,010452,proteína [materia prima]
-1,010453,ácido pirogálico
-1,010454,quebracho para uso industrial
-1,010455,resinas sintéticas en bruto
-1,010455,resinas artificiales en bruto
-1,010456,elementos radiactivos para uso científico
-1,010457,radón
-1,010458,radio para uso científico
-1,010459,fluidos refrigerantes
-1,010460,productos derivados del procesamiento de cereales para uso industrial
-1,010461,resinas acrílicas en bruto
-1,010463,renio
-1,010464,películas de rayos X sensibilizadas pero no expuestas
-1,010464,películas radiográficas sensibilizadas pero no expuestas
-1,010465,compuestos para reparar neumáticos
-1,010466,rubidio
-1,010467,arena de fundición
-1,010468,ácido salicílico
-1,010469,salitre
-1,010470,samario
-1,010471,salsa para preparar tabaco
-1,010472,jabones metálicos para uso industrial
-1,010473,escandio
-1,010474,ácido sebácico
-1,010475,sales [productos químicos]
-1,010476,sal en bruto
-1,010477,sales crómicas
-1,010478,sales [fertilizantes]
-1,010479,selenio
-1,010480,productos para preservar semillas
-1,010481,silicatos
-1,010483,silicio
-1,010484,siliconas
-1,010485,sodio
-1,010486,sulfuros
-1,010487,preparaciones químicas para soldar
-1,010488,soda calcinada
-1,010488,sosa calcinada
-1,010489,productos cáusticos para uso industrial
-1,010490,soda cáustica para uso industrial
-1,010490,sosa cáustica para uso industrial
-1,010491,sales sódicas [compuestos químicos]
-1,010491,sales de sodio
-1,010493,azufre
-1,010494,subnitrato de bismuto para uso químico
-1,010495,espato pesado
-1,010495,baritina [espato pesado]
-1,010496,espinela [minerales óxidos]
-1,010497,ácido esteárico
-1,010498,estroncio
-1,010499,hollín para uso agrícola o industrial
-1,010500,líquidos para desulfatar acumuladores eléctricos
-1,010500,líquidos para desulfatar pilas o baterías
-1,010501,ácidos sulfónicos
-1,010502,ácido sulfuroso
-1,010503,ácido sulfúrico
-1,010504,zumaque para curtir pieles
-1,010505,productos químicos para la silvicultura, excepto fungicidas, herbicidas, insecticidas y parasiticidas
-1,010506,talco [silicato de magnesio]
-1,010507,casca para curtir pieles
-1,010508,tanino
-1,010509,sustancias curtientes
-1,010510,sales de calcio
-1,010511,ácido tánico
-1,010512,harina de tapioca para uso industrial
-1,010514,tártaro que no sea para uso farmacéutico
-1,010515,ácido tartárico
-1,010516,tecnecio
-1,010517,telurio
-1,010518,agentes tensioactivos
-1,010518,agentes surfactivos
-1,010519,terbio
-1,010521,productos químicos para deslustrar el vidrio
-1,010522,productos contra el deslustre del vidrio
-1,010523,productos contra el deslustre de las ventanas
-1,010524,tierra de cultivo
-1,010525,greda para la industria textil
-1,010526,tierras raras
-1,010527,tierra de marga
-1,010528,tetracloruro de carbono
-1,010529,tetracloruros
-1,010530,productos de remojo para la industria textil
-1,010530,productos humectantes para la industria textil
-1,010532,talio
-1,010533,tiocarbanilida
-1,010534,tulio
-1,010535,torio
-1,010536,anhídrido titánico para uso industrial
-1,010536,dióxido de titanio para uso industrial
-1,010537,titanita
-1,010538,tolueno
-1,010539,turba [fertilizante]
-1,010540,productos para conservar tejas, excepto pinturas y aceites
-1,010541,ácido túngstico
-1,010542,uranio
-1,010543,urano
-1,010544,vidrio soluble [silicato]
-1,010545,ablandadores de carne para uso industrial
-1,010546,preparaciones químicas de protección contra las enfermedades de la vid
-1,010547,alcohol vínico
-1,010548,sales de viraje [fotografía]
-1,010549,productos de vulcanización
-1,010550,witherita
-1,010551,xenón
-1,010552,iterbio
-1,010553,itrio
-1,010554,cloruros
-1,010555,sulfatos
-1,010556,zircón
-1,010557,productos de uso industrial para activar la cocción
-1,010558,álcali volátil [amoniaco] para uso industrial
-1,010558,amoniaco [álcali volátil] para uso industrial
-1,010558,amoníaco [álcali volátil] para uso industrial
-1,010559,ioduros alcalinos para uso industrial
-1,010560,metales alcalinos
-1,010561,sales de metales alcalinos
-1,010562,alcaloides*
-1,010564,alginatos para uso industrial
-1,010565,acetato de aluminio*
-1,010566,cola de almidón que no sea de papelería ni para uso doméstico
-1,010567,sales de amonio
-1,010568,carbón animal
-1,010569,nitrato de plata
-1,010569,azoato de plata
-1,010570,productos químicos de uso industrial para avivar los colores
-1,010571,productos antigerminativos para verduras, hortalizas y legumbres
-1,010572,nitratos
-1,010572,azoatos
-1,010573,adhesivos para baldosas de revestimiento
-1,010574,sulfato de bario
-1,010575,productos químicos para fabricar pinturas
-1,010576,metilbenzol
-1,010577,metilbenceno
-1,010578,bicarbonato de soda para uso químico
-1,010578,bicarbonato de sosa para uso químico
-1,010579,preparaciones biológicas que no sean para uso médico ni veterinario
-1,010580,decolorantes para uso industrial
-1,010580,productos de blanqueo [decolorantes] para uso industrial
-1,010581,películas sensibilizadas no expuestas
-1,010582,productos para destilar espíritu [alcohol] de madera
-1,010583,fundentes para la soldadura fuerte
-1,010584,fundentes para soldar
-1,010585,bromo para uso químico
-1,010586,carbonilo para proteger las plantas
-1,010587,floculantes
-1,010588,lecitina [materia prima]
-1,010589,sustratos para el cultivo sin suelo [agricultura]
-1,010590,ésteres de celulosa para uso industrial
-1,010591,caseína para uso industrial
-1,010592,derivados químicos de la celulosa
-1,010593,éteres de celulosa para uso industrial
-1,010594,preparaciones bacterianas que no sean para uso médico ni veterinario
-1,010595,preparaciones bacteriológicas que no sean para uso médico ni veterinario
-1,010596,cultivos de microorganismos que no sean para uso médico ni veterinario
-1,010597,negro de carbón para uso industrial
-1,010598,películas cinematográficas sensibilizadas pero no expuestas
-1,010599,óxido de cobalto para uso industrial
-1,010600,colas para uso industrial
-1,010601,aceites para endurecer el cuero
-1,010602,creosota para uso químico
-1,010603,compuestos para fabricar discos acústicos
-1,010604,productos para separar las grasas
-1,010605,dispersiones de materias plásticas
-1,010606,disolventes para barnices
-1,010607,edulcorantes artificiales [productos químicos]
-1,010608,productos químicos para purificar el agua
-1,010609,emolientes para uso industrial
-1,010610,materiales filtrantes de materias plásticas en bruto
-1,010611,materiales filtrantes compuestos de sustancias químicas
-1,010612,materiales filtrantes compuestos de sustancias minerales
-1,010613,materiales filtrantes compuestos de sustancias vegetales
-1,010614,glucosa para uso industrial
-1,010615,gluten [cola] que no sea de papelería ni para uso doméstico
-1,010616,gomas [colas] para uso industrial
-1,010617,productos químicos hidrófugos para obras de albañilería, excepto pinturas
-1,010617,productos químicos contra la humedad en obras de albañilería, excepto pinturas
-1,010618,ictiocola que no sea de papelería ni para uso alimenticio
-1,010619,productos para conservar la cerveza
-1,010620,materias sintéticas para absorber aceites
-1,010621,materiales cerámicos en partículas para utilizar como medios filtrantes
-1,010622,compost
-1,010622,abonos orgánicos
-1,010631,compuestos para fabricar cerámica técnica
-1,010632,tierra de diatomeas
-1,010633,mordientes para metales
-1,010634,preparaciones para regular el crecimiento de las plantas
-1,010635,desincrustantes que no sean para uso doméstico
-1,010636,agua de mar para uso industrial
-1,010637,preparaciones de oligoelementos para plantas
-1,010638,alcanfor para uso industrial
-1,010639,reforzadores químicos para el papel
-1,010640,reforzadores químicos para el caucho
-1,010641,coberturas de humus
-1,010642,fluido magnético para uso industrial
-1,010643,fluidos para la dirección asistida
-1,010644,fluidos de transmisión
-1,010644,líquidos de transmisión
-1,010645,preparaciones antiebullición para refrigerantes de motores
-1,010646,compuestos de cerámica para la sinterización [granulados y en polvo]
-1,010647,agentes refrigerantes para motores de vehículos
-1,010648,productos químicos para limpiar radiadores
-1,010649,masillas para reparar carrocerías de automóviles
-1,010649,mástiques para reparar carrocerías de coches
-1,010650,geles de electroforesis
-1,010651,masilla de vidriero
-1,010652,arcilla expandida para cultivos hidropónicos [sustrato]
-1,010653,preparaciones para desempapelar
-1,010654,aditivos químicos para aceites
-1,010655,masillas al aceite
-1,010656,genes de semillas para la producción agrícola
-1,010657,células madre que no sean para uso médico ni veterinario
-1,010658,cultivos de tejidos biológicos que no sean para uso médico ni veterinario
-1,010659,fertilizantes de harina de pescado
-1,010660,preparaciones enzimáticas para la industria alimentaria
-1,010661,enzimas para la industria alimentaria
-1,010662,glucosa para la industria alimentaria
-1,010663,lecitina para la industria alimentaria
-1,010664,lecitina para uso industrial
-1,010665,pectina para la industria alimentaria
-1,010666,pectina para uso industrial
-1,010667,crémor tártaro para la industria alimentaria
-1,010668,crémor tártaro para uso industrial
-1,010669,alginatos para la industria alimentaria
-1,010670,gluten para la industria alimentaria
-1,010671,gluten para uso industrial
-1,010672,lactosa para la industria alimentaria
-1,010673,lactosa para uso industrial
-1,010674,lactosa [materia prima]
-1,010675,fermentos lácteos para la industria alimentaria
-1,010676,fermentos lácteos para uso industrial
-1,010677,caseína para la industria alimentaria
-1,010678,espíritu de sal de amoníaco
-1,010678,espíritu de sal de amoniaco
-1,010679,productos químicos para fabricar pigmentos
-1,010680,preparaciones de microorganismos que no sean para uso médico ni veterinario
-1,010681,mantillo
-1,010682,preparaciones para templar metales
-1,010683,ácido glutámico para uso industrial
-1,010684,extractos de té para ser utilizados en la fabricación de productos farmacéuticos
-1,010685,extractos de té para la industria alimentaria
-1,010686,digestato orgánico [fertilizante]
-1,010687,extractos de té para ser utilizados en la fabricación de cosméticos
-1,010688,colágeno para uso industrial
-1,010689,carburo de silicio [materia prima]
-1,010690,adyuvantes que no sean para uso médico ni veterinario
-1,010691,vitaminas para ser utilizadas en la fabricación de complementos alimenticios
-1,010691,vitaminas para ser utilizadas en la fabricación de suplementos alimenticios
-1,010692,vitaminas para la industria alimentaria
-1,010693,antioxidantes para ser utilizados en procesos de fabricación
-1,010694,antioxidantes para ser utilizados en la fabricación de cosméticos
-1,010695,antioxidantes para ser utilizados en la fabricación de productos farmacéuticos
-1,010696,antioxidantes para ser utilizados en la fabricación de complementos alimenticios
-1,010696,antioxidantes para ser utilizados en la fabricación de suplementos alimenticios
-1,010697,proteínas para ser utilizadas en procesos de fabricación
-1,010698,proteínas para ser utilizadas en la fabricación de complementos alimenticios
-1,010698,proteínas para ser utilizadas en la fabricación de suplementos alimenticios
-1,010699,proteínas para la industria alimentaria
-1,010700,nitrato de amonio
-1,010701,vitaminas para ser utilizadas en la fabricación de productos farmacéuticos
-1,010702,vitaminas para ser utilizadas en la fabricación de cosméticos
-1,010703,flavonoides [compuestos fenólicos] para uso industrial
-1,010704,timol para uso industrial
-1,010705,tierra vegetal
-1,010706,aceites de transmisión
-1,010707,resinas poliméricas en bruto
-1,010708,revestimientos químicos para lentes oftálmicas
-1,010709,calomel [cloruro de mercurio]
-1,010710,estiércol
-1,010711,xilol
-1,010712,xileno
-1,010713,benceno
-1,010714,benzol
-1,010715,grafeno
-1,010716,yeso utilizado como fertilizante
-1,010717,nanopolvos para uso industrial
-1,010718,polímeros dendriméricos para ser utilizados en la fabricación de cápsulas para productos farmacéuticos
-1,010719,preparaciones químicas de protección contra las enfermedades de las plantas de cereales
-1,010720,bioestimulantes para las plantas
+class|name
+1|Abonos orgánicos
+1|Aceleradores de vulcanización (preparaciones químicas)
+1|Acetal
+1|Acetaldehído (etanal)
+1|Acetanilida
+1|Acetato de butilo
+1|Acetato de metilo
+1|Acetato de octilo
+1|Acetato de vinilo
+1|Acetatos
+1|Acetileno
+1|Acetofenona
+1|Acetona
+1|Ácido acético
+1|Ácido acético glacial
+1|Ácido adípico
+1|Ácido antranílico
+1|Ácido arsenioso
+1|Ácido benzoico
+1|Ácido bórico
+1|Ácido carbónico
+1|Ácido cítrico
+1|Ácido clorhídrico (cloruro de hidrógeno)
+1|Ácido cloroacético
+1|Ácido clorosulfónico
+1|Ácido cólico
+1|Ácido crotónico
+1|Ácido esteárico
+1|Ácido fórmico
+1|Ácido fosfórico
+1|Ácido ftálico
+1|Ácido glutámico como materia prima para la fabricación de cosméticos
+1|Ácido iódico
+1|Ácido metacrílico
+1|Ácido molibdénico
+1|Ácido monocloroacético
+1|Ácido nítrico
+1|Ácido oleico
+1|Ácido oxálico
+1|Ácido palmítico
+1|Ácido perclórico
+1|Ácido pícrico
+1|Ácido piroleñoso
+1|Ácido propiónico
+1|Ácido succínico
+1|Ácido sulfínico
+1|Ácido sulfúrico
+1|Ácido sulfuroso
+1|Ácido tánico
+1|Ácido tartárico
+1|Ácido túngstico
+1|Ácido valérico
+1|Ácidos clorados
+1|Ácidos para decapado de metales
+1|Acrilonitrilo
+1|Actinio
+1|Adhesivos (pegamentos) para la industria
+1|Adhesivos con fines industriales
+1|Adhesivos conductores para su uso en la industria
+1|Adhesivos de plástico que no sean de papelería ni uso doméstico
+1|Adhesivos de poliuretano
+1|Adhesivos para aplicación de azulejos de pisos
+1|Adhesivos para baldosas de revestimiento
+1|Adhesivos para la colocación de baldosas de cerámica
+1|Adhesivos para papel tapiz
+1|Adhesivos para productos fabricados en cemento
+1|Adhesivos para revestimiento y sellado para uso industrial
+1|Adhesivos para revestimientos cerámicos y para pavimentos ornamentales
+1|Adhesivos para su uso en la encuadernación de libros
+1|Adhesivos para su uso en la fabricación de contrachapados
+1|Adhesivos para su uso en la fabricación de muebles
+1|Adhesivos para su uso en la fabricación de revestimiento de paredes
+1|Adhesivos para suelos, techos y baldosas de revestimiento
+1|Adhesivos para techos
+1|Adhesivos para uso en la industria de la construcción
+1|Adhesivos para uso industrial
+1|Adhesivos que no sean de papelería ni para uso doméstico
+1|Adhesivos y pegamentos para uso industrial
+1|Aditivo a base de óxido de hierro para arenas de fundición en la fabricación de piezas de fundición metálicas
+1|Aditivo químico de combustible de sobrealimentador de octanaje
+1|Aditivos de detergentes para usar con aceite de motor
+1|Aditivos detergentes para carburantes
+1|Aditivos químicos para aceites
+1|Aditivos químicos para el tratamiento de combustible
+1|Aditivos químicos para gasolina
+1|Aditivos químicos para perforación en lodos
+1|Agar-agar
+1|Agentes antiespumantes
+1|Agentes catalíticos
+1|Agentes de curación para resina sintética
+1|Agentes de lavado para radiadores de automóvil
+1|Agentes de revestimiento de polímeros para el papel
+1|Agentes desengrasantes que no sean para uso doméstico
+1|Agentes desmoldantes de asfalto (químicos)
+1|Agentes dispersantes
+1|Agentes humectantes
+1|Agentes para eliminar aceites
+1|Agentes para mejorar los suelos
+1|Agentes químicos para impregnar o revestir textiles, pieles y cuero, no tejidos y telas
+1|Agentes químicos para la fabricación de materias tintóreas
+1|Agentes químicos para revestimiento retardante de fuego para materias textiles
+1|Agua acidulada para recargar acumuladores
+1|Agua acidulada para recargar baterías
+1|Agua amoniacal
+1|Agua de mar para uso industrial
+1|Agua desionizada
+1|Agua destilada
+1|Agua pesada
+1|Álcali volátil (amoniaco) para uso industrial
+1|Álcalis
+1|Alcanfor para uso industrial
+1|Alcohol alílico
+1|Alcohol amílico (pentanol)
+1|Alcohol bencílico
+1|Alcohol cetílico
+1|Alcohol etílico
+1|Alcohol hexílico
+1|Alcohol laúrico
+1|Alcohol metílico (metanol)
+1|Alcohol oleico
+1|Alcohol para uso industrial
+1|Alcohol terc-butílico para uso industrial
+1|Alcoholes de azúcar para uso industrial
+1|Aldehído de amoniaco
+1|Aldehídos y cetonas
+1|Alifáticos
+1|Almidón para uso industrial
+1|Alquilbenceno
+1|Alumbre
+1|Alumbre amónico
+1|Alumbre de cromo
+1|Alumbre de manganeso
+1|Alumbre de sodio
+1|Aluminato de calcio
+1|Alunita
+1|Americio
+1|Anhídrido crómico
+1|Anhídrido fosfórico
+1|Anhídrido ftálico
+1|Anhídridos
+1|Anilina
+1|Anisola
+1|Anticongelante para sistemas de refrigeración de vehículos
+1|Anticongelantes
+1|Antidetonantes para motores de combustión interna
+1|Antimoniato
+1|Antimonio
+1|Antraceno
+1|Arcilla expandida para el crecimiento de plantas hidropónicas
+1|Argón
+1|Arsénico
+1|Ascorbato de calcio para la industria alimentaria
+1|Ascorbato de sodio para la industria alimentaria
+1|Aspartamo
+1|Azufre (elemento no metálico)
+1|Azufre (mineral no metálico)
+1|Bacterias (microorganismos) que no sean de uso médico o veterinario
+1|Baños de galvanización
+1|Bario
+1|Bario sintético
+1|Baritina (barita, espato pesado)
+1|Bauxita
+1|Bentonita
+1|Benzaldehído
+1|Benzofenona
+1|Berkelio
+1|Bicarbonato de amonio
+1|Bicarbonato de sodio
+1|Bicromato de amonio
+1|Bicromato de sodio
+1|Bioestimulantes para la estimulación del crecimiento de plantas
+1|Biofertilizantes
+1|Biofertilizantes no químicos
+1|Bismuto
+1|Bisulfito de sodio
+1|Bisulfuro de calcio
+1|Borneol
+1|Boro
+1|Bromo
+1|Bromobenceno
+1|Bromoformo
+1|Bromuro de amonio
+1|Bromuro de sodio
+1|Butadieno
+1|Butanol
+1|Butileno
+1|Calcio
+1|Californio
+1|Calomelano (cloruro de mercurio)
+1|Caolín
+1|Caolín calcinado para uso industrial
+1|Carbazol
+1|Carbón de leña para uso como acondicionador de suelos
+1|Carbón de leña para uso hortícola
+1|Carbonato de amonio
+1|Carbonato de calcio
+1|Carbonato de calcio ligero
+1|Carbonato de cobre
+1|Carbonato de manganeso
+1|Carbonato de plomo
+1|Carbonato de sodio
+1|Carbono
+1|Carburo de calcio
+1|Carburo de niobio
+1|Carburo de silicio
+1|Carburo de tungsteno
+1|Carburos
+1|Catalizadores bioquímicos
+1|Catalizadores para procesos de oxidación
+1|Catalizadores para procesos químicos y bioquímicos
+1|Catalizadores para su uso en la fabricación de plásticos (químicos)
+1|Catalizadores para uso en la fabricación de sintéticos, cauchos y polímeros
+1|Células madre para fines de investigación
+1|Células madre para investigación o fines científicos
+1|Celulosa
+1|Celulosa para uso en la fabricación de detergentes
+1|Cemento de caucho para reparar neumáticos
+1|Cementos de espuma adhesivos premezclados
+1|Cerio
+1|Cesio
+1|Cianamida de calcio
+1|Cianato de potasio
+1|Cianuro de calcio
+1|Cianuro de hidrógeno
+1|Cianuro de plata
+1|Cianuro de potasio
+1|Cianuro de sodio
+1|Cianuros y cianatos
+1|Ciclohexano
+1|Ciclohexanol
+1|Ciclopentano
+1|Cimeno
+1|Clorálcalis
+1|Clorato de sodio
+1|Clorito de sodio
+1|Cloro
+1|Cloro líquido
+1|Cloro para piscinas
+1|Clorofluorocarbonos
+1|Clorofluorocarburo
+1|Cloronaftaleno
+1|Cloronitroanilina
+1|Cloropreno
+1|Cloropropileno
+1|Cloruro de alilo
+1|Cloruro de amonio
+1|Cloruro de bario
+1|Cloruro de bencilo
+1|Cloruro de bismuto
+1|Cloruro de cacodilo
+1|Cloruro de calcio
+1|Cloruro de cerio
+1|Cloruro de circonio
+1|Cloruro de cromo
+1|Cloruro de estaño
+1|Cloruro de etilo
+1|Cloruro de fósforo
+1|Cloruro de hierro
+1|Cloruro de manganeso
+1|Cloruro de mercurio
+1|Cloruro de metileno
+1|Cloruro de metilo
+1|Cloruro de oro
+1|Cloruro de plata
+1|Cloruro de sodio
+1|Cloruro de toluensulfonilo
+1|Cloruro de vinilideno
+1|Cloruro de vinilo
+1|Cloruro de zinc
+1|Cloruro sódico de oro
+1|Cloruros metálicos
+1|Cola de almidón que no sea de papelería ni para uso doméstico
+1|Cola de látex (no para fines de papelería o domésticos)
+1|Colágeno para uso como materia prima en la fabricación de cosméticos
+1|Colas (aprestos)
+1|Colas de madera para uso industrial
+1|Colas para textiles para uso industrial
+1|Colas para uso industrial
+1|Combustibles para pilas atómicas
+1|Composiciones químicas impermeabilizantes para artículos tejidos
+1|Composiciones retardantes de fuego para uso comercial y doméstico
+1|Composiciones retardantes de llamas
+1|Compost
+1|Compost (fertilizante)
+1|Comprobadores de líquidos de frenos
+1|Compuestos de enmascaramiento para su uso en la fabricación de tarjetas de circuitos impresos
+1|Compuestos de nitrógeno
+1|Compuestos extintores
+1|Compuestos extintores de fuego
+1|Compuestos heterocíclicos
+1|Compuestos para reparar cubiertas de neumáticos
+1|Compuestos químicos desmoldantes para uso en la industria de la fibra de vidrio
+1|Conservadores químicos para uso como inhibidores de la corrosión en sistemas de escape para automóviles
+1|Conservantes para alimentos
+1|Conservantes para productos farmacéuticos
+1|Conservantes químicos de alimentos
+1|Crémor tártaro para uso químico
+1|Cresol
+1|Criolita
+1|Criolita sintética
+1|Cromato de plomo
+1|Cromato de sodio
+1|Crotonaldehído
+1|Cultivos bacterianos para agregar a productos alimenticios
+1|Cultivos de microorganismos que no sean para uso médico ni veterinario
+1|Cumeno
+1|Curio
+1|Decapantes para la fabricación de semiconductores
+1|Decapantes para la fabricación de tarjetas de circuitos impresos
+1|Defoliantes
+1|Desecantes
+1|Desecantes para absorber la humedad
+1|Detergentes para uso industrial
+1|Dextrina
+1|Dextrina (apresto)
+1|Dextrinas para uso industrial
+1|Dianisidina
+1|Dicloroetano
+1|Diclorometano
+1|Dicloruro de etileno
+1|Dicyandiamide
+1|Dietil ftalato
+1|Dietilenoglicol
+1|Difenil
+1|Difenilmetano
+1|Diisopropil éter
+1|Dimetil ftalato
+1|Dimetilanilina
+1|Dinitronaftaleno
+1|Dióxido de carbono líquido
+1|Dióxido de silicio
+1|Dióxido de sulfuro líquido
+1|Dióxidos de manganeso
+1|Dispersante de pigmentos para su uso en la fabricación de cosméticos
+1|Disprosio
+1|Disulfuro de carbono
+1|Dolomita
+1|Edulcorantes artificiales
+1|Electrolitos para baterías
+1|Emolientes para uso industrial
+1|Emulsionantes para su uso en la fabricación de alimentos
+1|Emulsiones fotográficas
+1|Endulzantes artificiales sin azúcar para bebidas
+1|Enzimas derivadas de procesos biotecnológicos para uso industrial
+1|Enzimas para la industria textil
+1|Enzimas para su uso en la industria de detergentes
+1|Enzimas para uso en la industria de la cervecera
+1|Enzimas para uso en la industria de la panadera
+1|Enzimas para utilizar en el procesamiento de la caña de azúcar
+1|Enzimas para utilizar en la hidrólisis de proteínas
+1|Enzimas para utilizar en la hidrólisis del almidón
+1|Erbio
+1|Eritritol
+1|Escandio
+1|Escorias de magnesita
+1|Espuma contraincendios
+1|Estabilizadores de suelo para carreteras, estanques y lagos
+1|Estabilizadores enzimáticos
+1|Estañatos
+1|Ésteres de ácido acético
+1|Ésteres de metilo
+1|Estiércol de oveja como fertilizante
+1|Estiércol de pollo fermentado como fertilizante
+1|Estilbeno
+1|Estireno
+1|Estroncio
+1|Etano
+1|Éter de bencilo
+1|Éter de clorometilo
+1|Éter etílico
+1|Éter metílico
+1|Etil uretano
+1|Etilamina
+1|Etilenclorhidrina
+1|Etileno
+1|Europio
+1|Extractos botánicos para elaborar cosméticos
+1|Exudado silíceo
+1|Fenantreno
+1|Fenilendiamina
+1|Fenoles
+1|Fenotiazina para su uso como intermedio farmacéutico
+1|Fermio (centurio)
+1|Feromonas que no sean para uso médico
+1|Ferricianuro de potasio
+1|Ferrocianuro potásico
+1|Fertilizante de cloruro de amonio
+1|Fertilizante de cloruro de potasio
+1|Fertilizante de fosfatos de escoria (escorias Thomas)
+1|Fertilizante de manganeso
+1|Fertilizante de nitrato de amonio
+1|Fertilizante de nitrato de sodio
+1|Fertilizante de potasio calcinado
+1|Fertilizante de silicato de calcio
+1|Fertilizante de sulfato de amonio
+1|Fertilizante de sulfato de potasio
+1|Fertilizante de superfosfato de calcio
+1|Fertilizante de urea
+1|Fertilizante marino
+1|Fertilizantes
+1|Fertilizantes artificiales de corral
+1|Fertilizantes complejos
+1|Fertilizantes compuestos convertidos químicamente
+1|Fertilizantes de liberación lenta para jardinería
+1|Fertilizantes mezclados
+1|Fertilizantes minerales
+1|Fertilizantes multinutrientes
+1|Fertilizantes naturales
+1|Fertilizantes orgánicos
+1|Fertilizantes para plantas
+1|Fertilizantes para plantas de interior
+1|Fertilizantes para tierra y mantillo
+1|Fertilizantes químicos
+1|Fertilizantes y abonos
+1|Fijadores fotográficos
+1|Fluido magnético para uso industrial
+1|Fluidos descongelantes de parabrisas
+1|Fluidos para la dirección asistida
+1|Fluidos para la transmisión automática
+1|Flúor
+1|Fluorocirconato de potasio
+1|Fluoruro de aluminio de sodio
+1|Fluoruro de amonio
+1|Fluoruro de calcio
+1|Fluoruro de cerio
+1|Fluoruro de magnesio
+1|Fluoruro de potasio
+1|Fluoruro sódico
+1|Fluosilicato de potasio
+1|Formaldehído
+1|Formato de sodio
+1|Formiato
+1|Fosfato de amonio
+1|Fosfato de bario
+1|Fosfato de boro
+1|Fosfato de calcio
+1|Fosfato de cobre
+1|Fosfato de hierro
+1|Fosfato de litio
+1|Fosfato de magnesio
+1|Fosfato de manganeso
+1|Fosfato de potasio
+1|Fosfato de potasio dibásico
+1|Fosfato de sodio y aluminio
+1|Fosfato de zinc
+1|Fosfato sódico
+1|Fosfatos
+1|Fosfina
+1|Fosfoproteína
+1|Fósforo
+1|Fosgeno
+1|Fotocatalizador
+1|Francio
+1|Ftalato de etilo
+1|Fundentes para fontanería
+1|Fundentes para soldadura
+1|Fundentes para soldar
+1|Gas ácido carbónico
+1|Gas ácido sulfuroso (dióxido de azufre)
+1|Gases propulsores para aerosoles
+1|Gases protectores solidificados para soldar
+1|Gases y mezclas de gases para uso en imagenología médica
+1|Gel de sílice
+1|Gelatina para la fabricación de papel de impresión
+1|Geles de electroforesis que no sean para uso médico ni veterinario
+1|Genes formados mediante métodos biotecnológicos para su uso en la manufactura de semillas para la agricultura
+1|Glicol
+1|Glicol etileno
+1|Glicoproteína
+1|Goma guar para su uso en la industria de fabricación de alimentos
+1|Goma guar para uso industrial
+1|Grafito artificial para uso industrial
+1|Grafito natural
+1|Grafito natural para uso industrial
+1|Guano
+1|Halógenitas orgánicas
+1|Haluros y sales de ácidos halógenos
+1|Harina de huesos (fertilizante)
+1|Harinas para uso industrial
+1|Helio
+1|Hexacloroetano
+1|Hexametilendiamina
+1|Hidrato de aluminio
+1|Hidratos de carbono
+1|Hidrazona
+1|Hidrocarburos aromáticos
+1|Hidrógeno
+1|Hidromagnesita
+1|Hidroquinona
+1|Hidrosulfuro de calcio
+1|Hidróxido de aluminio
+1|Hidróxido de bario
+1|Hidróxido de calcio
+1|Hidróxido de cerio
+1|Hidróxido de estroncio
+1|Hidróxido de litio
+1|Hidróxido de magnesio
+1|Hidróxido de níquel
+1|Hidróxido de preaseodimio
+1|Hipoclorito de sodio
+1|Holmio
+1|Hormonas vegetales (fitohormonas)
+1|Humus
+1|Huntita
+1|Ingredientes químicos activos para la fabricación de drogas contra el cáncer
+1|Inhibidores de la germinación (productos antigerminativos)
+1|Inhibidores de la herrumbre para sistemas de refrigeración de automóviles
+1|Ioduro de aluminio
+1|Ioduro de etilo de zinc
+1|Isobutanol de uso industrial
+1|Isobutileno
+1|Isopreno
+1|Isopropanol para fines industriales
+1|Iterbio
+1|Itrio
+1|Kieserita
+1|Kriptón
+1|Lactosa para uso en la manufactura de alimentos
+1|Lantano
+1|Líquidos anticongelantes
+1|Líquidos de frenos
+1|Líquidos de frenos hidráulicos
+1|Líquidos de silicona
+1|Líquidos de transmisión automática
+1|Líquidos descongelantes
+1|Líquidos hidráulicos
+1|Líquidos para transmisiones de energía
+1|Litio
+1|Lodos de perforación para su uso en la perforación de pozos de petróleo
+1|Magnesita
+1|Malonato de etilo
+1|Manganato
+1|Mantillo
+1|Masilla de vidriero
+1|Masillas al aceite
+1|Mástique para carrocerías
+1|Mástique para carrocerías de automóviles
+1|Mástique para carrocerías de coches
+1|Material de origen químico para el depósito de películas finas sobre obleas de semiconductores para la fabricación de semiconductores
+1|Materiales adhesivos para la industria de la construcción y baldosas
+1|Materias plásticas en bruto, en polvo, líquido o en pasta
+1|Melamina
+1|Membranas de resina de intercambio iónico (preparaciones químicas)
+1|Mercaptano
+1|Mercurio
+1|Metafosfato de manganeso
+1|Metalatos (sales metálicas de ácidos)
+1|Metales alcalinos
+1|Metales alcalinotérreos
+1|Metales de las tierras raras
+1|Metalocenos
+1|Metano
+1|Metanol refinado para uso industrial
+1|Metilamina
+1|Mezclas hortícolas para el cultivo
+1|Minerales de manganeso
+1|Moho de hoja (fertilizante)
+1|Molibdato de amonio
+1|Molibdato de sodio
+1|Monómeros acrílicos
+1|Monómeros de cloruro de vinilo
+1|Mordientes para el grabado al aguafuerte (ácidos)
+1|Naftaleno
+1|Naftilamina
+1|Naftionato de sodio
+1|Neodimio
+1|Neón
+1|Neptunio
+1|Neutralizantes de gases tóxicos
+1|Nitrato de aluminio
+1|Nitrato de amonio
+1|Nitrato de bario
+1|Nitrato de bismuto
+1|Nitrato de calcio
+1|Nitrato de hierro
+1|Nitrato de manganeso
+1|Nitrato de mercurio
+1|Nitrato de plata
+1|Nitrato de plomo
+1|Nitrato de potasio
+1|Nitrato de sodio
+1|Nitrato de torio
+1|Nitrato de uranio
+1|Nitrito de plata
+1|Nitrito de sodio
+1|Nitroaminofenol
+1|Nitrobacterias para uso en acuicultura
+1|Nitrofenol
+1|Nitrógeno
+1|Nitronaftaleno
+1|Nitroparafina
+1|Nitrotolueno
+1|Nitrotoluidina
+1|Nutrientes de plantas
+1|Octanol para uso industrial
+1|Organohalogenosilano
+1|Organosilanos
+1|Organosiloxano
+1|Orujos de cerveza (fertilizantes)
+1|Oxalato
+1|Óxido de aluminio
+1|Óxido de antimonio
+1|Óxido de circonio
+1|Oxido de cobalto
+1|Óxido de etileno
+1|Óxido de magnesio
+1|Óxido de nitrógeno
+1|Óxidos
+1|Óxidos de aluminio (alúmina)
+1|Óxidos de calcio
+1|Óxidos de cromo
+1|Óxidos de estaño
+1|Óxidos de hierro
+1|Óxidos de magnesio
+1|Óxidos de mercurio
+1|Óxidos de níquel
+1|Óxidos de plata
+1|Óxidos de plomo
+1|Óxidos de titanio
+1|Óxidos de uranio
+1|Óxidos metálicos
+1|Oxígeno
+1|Oxima
+1|Oxinaftionato de sodio
+1|Oxinitruro de aluminio
+1|Papel de tornasol
+1|Papel fotográfico sensibilizado químicamente
+1|Papel para comprobaciones químicas
+1|Papel para fotocalcos
+1|Paraldehído
+1|Pasta de celulosa
+1|Pasta de madera
+1|Pasta de madera en disolución para fines de fabricación
+1|Pasta de madera químico-mecánica
+1|Pasta de papel
+1|Pegamento de goma arábiga que no sea para papelería y ni para uso doméstico
+1|Pegamento de látex que no sea de papelería o para uso doméstico
+1|Películas fotográficas no impresionadas
+1|Películas para rayos X no impresionadas
+1|Pentaeritritol
+1|Pepsinas
+1|Perborato de sodio
+1|Perclorato de amonio
+1|Percloroetileno
+1|Permanganato de sodio
+1|Peróxidos de bario
+1|Persulfato de amonio
+1|Piridina
+1|Pirimidina
+1|Pirrol
+1|Placas secas fotográficas
+1|Plásticos de polimerización
+1|Plásticos de proteína
+1|Plásticos en bruto (materia prima)
+1|Plásticos en bruto en forma de polvo o gránulos
+1|Plásticos en bruto en forma de polvo, líquido o pasta
+1|Plásticos en bruto en todas sus formas
+1|Plásticos en bruto para uso industrial
+1|Plastificantes
+1|Plastificantes para plásticos
+1|Plastisoles
+1|Plutonio
+1|Poliamida
+1|Polímeros no procesados para uso industrial
+1|Polioles
+1|Polisilazanos
+1|Poliuretano
+1|Poliuretanos
+1|Polixilanos
+1|Polvo de antimonio
+1|Polvos acrílicos poliméricos
+1|Potasa
+1|Potasa cáustica
+1|Potasa cáustica (hidróxido de potasio)
+1|Praseodimio
+1|Preparaciones bioquímicas para uso científico
+1|Preparaciones de diagnóstico que no sean para uso médico ni veterinario
+1|Preparaciones desincrustantes para uso industrial
+1|Preparaciones enzimáticas para su uso en la industria de los detergentes
+1|Preparaciones enzimáticas para su uso en la industria del alcohol
+1|Preparaciones extintoras de fuego
+1|Preparaciones fertilizantes
+1|Preparaciones minerales fertilizantes
+1|Preparaciones para desempapelar
+1|Preparaciones para el temple de metales (químicos para temple)
+1|Preparaciones para enmendar suelos
+1|Preparaciones para mejorar los suelos
+1|Preparaciones para regular el crecimiento de las plantas
+1|Preparaciones para temple
+1|Preparaciones para uso en la fabricación de pinturas
+1|Preparaciones químicas para ahumar carmes
+1|Preparaciones químicas para derretir la nieve y el hielo
+1|Preparaciones químicas para el tratamiento del hollín del trigo
+1|Preparaciones químicas para prevenir infecciones patógenas en plantas
+1|Preparaciones químicas para soldar
+1|Preparado biológico para su uso en cultivos celulares excepto para uso médico o veterinario
+1|Preparado repelente de lluvia de base química para aplicación a parabrisas
+1|Preparados bacteriológicos para la industria alimentaria
+1|Preparados de diagnóstico para su uso en la investigación o para uso científico excepto para uso médico
+1|Preparados para la nutrición de plantas
+1|Preparados químicos para prevenir la propagación de partículas de zinc en superficies galvanizadas
+1|Preparados químicos para su uso en la fotografía
+1|Productos anticongelantes
+1|Productos anticongelantes y descongelantes
+1|Productos bioquímicos para uso científico in vitro e in vivo
+1|Productos de blanqueo (decolorantes) para uso industrial
+1|Productos de diagnóstico para uso científico
+1|Productos de diagnóstico para uso científico o de investigación
+1|Productos de diagnóstico para uso en la ciencia
+1|Productos fertilizantes
+1|Productos ignífugos
+1|Productos para ablandar el agua
+1|Productos para desmoldar
+1|Productos para el fortalecimiento de las plantas
+1|Productos para mantener fresca la flor cortada
+1|Productos químicos absorbentes
+1|Productos químicos anticongelantes
+1|Productos químicos de protección contra el Mildiú
+1|Productos químicos de soldadura fuerte
+1|Productos químicos de soldadura y braseado
+1|Productos químicos industriales para su uso en la fabricación de barnices
+1|Productos químicos para acuarios
+1|Productos químicos para cromatografía
+1|Productos químicos para dar brillo a los colorantes
+1|Productos químicos para el acondicionamiento del suelo
+1|Productos químicos para estabilizar alimentos
+1|Productos químicos para la descontaminación de sitios contaminados
+1|Productos químicos para la preparación de esmaltes
+1|Productos químicos para la silvicultura, excepto fungicidas, herbicidas, insecticidas y parasiticidas
+1|Productos químicos para lustrar el cuero
+1|Productos químicos para mantener frescos y conservar productos alimenticios
+1|Productos químicos para neutralizar aleaciones de acero inoxidable, hierro y metales de varios colores
+1|Productos químicos para su uso en la fabricación de poliuretanos
+1|Productos químicos para tratamiento de aguas residuales para uso industrial
+1|Productos químicos para tratar el agua
+1|Productos químicos para uso hortícola, excepto fungicidas, herbicidas, insecticidas y parasiticidas
+1|Productos químicos para uso industrial
+1|Productos químicos pirorretardantes
+1|Productos químicos prevenir las incrustaciones
+1|Prometio
+1|Propilenglicol
+1|Propileno (propeno)
+1|Protactinio
+1|Protamina
+1|Pulpa de papel reciclado
+1|Pulpa de sulfito
+1|Químicos para acondicionar los suelos
+1|Químicos para conservar los alimentos
+1|Químicos para el tratamiento de aguas de irrigación
+1|Químicos para el tratamiento de residuos peligrosos
+1|Químicos para fermentación del vino
+1|Químicos para purificar el agua de piscinas de natación
+1|Químicos para soldadura
+1|Químicos para uso industrial
+1|Químicos usados en la industria
+1|Quinhidrona
+1|Quitosanos para uso industrial
+1|Radón
+1|Ramnosa
+1|Reactivo para análisis químicos
+1|Reactivos bioquímicos utilizados para uso no médico
+1|Reactivos de cultivo celular para uso científico y de investigación
+1|Reactivos de diagnóstico para uso científico o de investigación
+1|Reactivos de diagnóstico para uso in vitro en bioquímica, química clínica y microbiología
+1|Reactivos para comprobar de la esterilidad de equipos médicos
+1|Reactivos para comprobar de la esterilidad de productos farmacéuticos y soluciones inyectables
+1|Reactivos para uso en aparatos científicos de análisis químico o biológico
+1|Reactivos para uso en investigación
+1|Reactivos para uso en la determinación analítica de la humedad
+1|Reactivos químicos que no sean para uso médico
+1|Reactivos químicos que no sean para uso médico ni veterinario
+1|Reactivos y productos de diagnóstico que no sean para uso médico o veterinario
+1|Refrigerantes
+1|Reguladores del crecimiento de las plantas para uso agrícola
+1|Renio
+1|Repelentes de manchas
+1|Resina epoxy
+1|Resinas acrílicas
+1|Resinas artificiales en bruto
+1|Resinas artificiales en bruto en forma de polvos, líquidos o pastas
+1|Resinas de acetato de polivinilo sin procesar
+1|Resinas de melamina
+1|Resinas de silicona
+1|Resinas fenólicas
+1|Resinas para el intercambio de iones (preparaciones químicas)
+1|Resinas sintéticas en bruto
+1|Resorcinol
+1|Reveladores fotográficos
+1|Revestimientos químicos para uso en la fabricación de placas de circuitos
+1|Rubidio
+1|Sacarina
+1|Sal de roca para descongelar
+1|Sales amoniacales
+1|Sales de magnesio
+1|Sales de metales alcalinos
+1|Sales de metales de las tierras raras
+1|Sales de níquel
+1|Sales inorgánicas
+1|Salvado de arroz (abono para tierras)
+1|Samario
+1|Sangre en polvo (fertilizante)
+1|Semicarbazona
+1|Sensibilizadores fotográficos
+1|Silanos
+1|Silicato de aluminio
+1|Silicato de calcio
+1|Silicato de potasio
+1|Silicato de sodio
+1|Silicato de zinc
+1|Silicofluoruro de magnesio
+1|Sodio
+1|Sodio fluosilicato
+1|Sosa cáustica (hidróxido de sodio)
+1|Subnitrato de bario
+1|Subnitrato de bismuto
+1|Suelos artificiales de materias minerales para cultivo de plantas
+1|Suelos artificiales de materias plásticas para el cultivo de plantas
+1|Suelos artificiales para el cultivo de plantas
+1|Sulfanilato de sodio
+1|Sulfato amónico de níquel
+1|Sulfato de aluminio
+1|Sulfato de amonio
+1|Sulfato de bario
+1|Sulfato de cobre
+1|Sulfato de dimetilo
+1|Sulfato de hierro
+1|Sulfato de magnesio
+1|Sulfato de mercurio
+1|Sulfato de níquel
+1|Sulfato de plata
+1|Sulfato de plomo
+1|Sulfato de sodio
+1|Sulfato de tolidina
+1|Sulfato de toluidina
+1|Sulfato de zinc
+1|Sulfato potásico
+1|Sulfatos
+1|Sulfatos ferrosos frente al amarilleo de hojas de plantas
+1|Sulfito de sodio
+1|Sulfito para conservar alimentos
+1|Sulfonato aminonaftol de toluidina
+1|Sulfuro de amonio
+1|Sulfuro de antimonio
+1|Sulfuro de bario
+1|Sulfuro de cadmio
+1|Sulfuro de calcio
+1|Sulfuro de estaño
+1|Sulfuro de fósforo
+1|Sulfuro de hidrógeno
+1|Sulfuro de hierro
+1|Sulfuro de mercurio
+1|Sulfuro de sodio
+1|Sulfuro de zinc
+1|Sulfuros
+1|Superfosfato doble o triple (fertilizante)
+1|Sustancias adhesivas para uso industrial
+1|Sustancias para conservar la flores cortadas
+1|Sustancias para la regular el crecimiento de las plantas
+1|Sustancias para temple
+1|Sustancias químicas viscosas para su uso en la industria manufacturera
+1|Sustratos enzimáticos
+1|Talio
+1|Tartrato de sodio
+1|Tecnecio
+1|Telurio
+1|Terbio
+1|Tetraborato de sodio
+1|Tetracloroetano
+1|Tetracloruro de acetileno
+1|Tetracloruro de zirconio
+1|Tetraetilo de plomo
+1|Tierra de diatomeas
+1|Tierra vegetal
+1|Tierras raras
+1|Timol
+1|Tioéter
+1|Tiofeno
+1|Tiosulfato de sodio
+1|Tiourea
+1|Tolidina
+1|Tolueno
+1|Toluidina
+1|Torio
+1|Tricloroetileno
+1|Trietanolamina
+1|Trietilenglicol para uso industrial
+1|Trifenilmetano
+1|Trióxido de sulfuro
+1|Tripsina
+1|Tulio
+1|Tungstato de amonio
+1|Tungstato de calcio
+1|Tungstato de zinc
+1|Turba (fertilizante)
+1|Uranato
+1|Uranio
+1|Ureasa
+1|Vanadato de amonio
+1|Volframato de sodio
+1|Xenón
+1|Xilenol
+1|Xilosa
+1|Yeso para uso como fertilizante
+1|Yoduro de calcio
+1|Yoduro de plata
+1|Yoduro de sodio
+1|Zinc etílico
+1|Zirconato de cobalto

--- a/lib/seeds/class_20_terms.csv
+++ b/lib/seeds/class_20_terms.csv
@@ -1,389 +1,326 @@
-class,reference_id,name
-20,200001,colmenas para abejas
-20,200002,tablones de anuncios
-20,200003,decoraciones de materias plásticas para alimentos
-20,200005,ámbar amarillo
-20,200006,animales disecados
-20,200007,camas para animales de compañía
-20,200007,lechos para animales de compañía
-20,200008,cunas para animales de compañía
-20,200009,casetas para animales de compañía
-20,200009,cuchas para animales de compañía
-20,200010,garras de animales
-20,200011,anillas de cortinas
-20,200013,vidrio plateado [espejos]
-20,200013,cristal plateado [espejos]
-20,200014,armarios empotrados
-20,200015,botiquines [armarios para medicinas]
-20,200016,bridas de fijación no metálicas para cables y tubos
-20,200017,barriles de madera para decantar el vino
-20,200018,ballena en bruto o semielaborada
-20,200019,bambú
-20,200020,bancos [muebles]
-20,200021,banastas de pesca
-20,200021,cestas de pesca
-20,200022,parques de bebés
-20,200022,corrales de bebés
-20,200022,corralitos de bebés
-20,200023,minicunas de balancín
-20,200024,anaqueles de biblioteca
-20,200024,estantes de biblioteca
-20,200025,carretes de madera para hilo, seda, torzales
-20,200026,armazones de cama de madera
-20,200027,cintas de madera
-20,200029,tapones de botella
-20,200030,tapones de corcho
-20,200031,botelleros [muebles]
-20,200032,bastidores para bordar
-20,200033,monturas de cepillos
-20,200034,aparadores [muebles]
-20,200035,cuernos de animales
-20,200036,escritorios [muebles]
-20,200037,muebles de oficina
-20,200038,bustos de sastre
-20,200039,cera estampada para colmenas
-20,200040,cuadros [marcos] de colmenas
-20,200041,muebles
-20,200041,piezas de mobiliario
-20,200042,espitas no metálicas para toneles
-20,200042,canillas no metálicas para toneles
-20,200043,ficheros [muebles]
-20,200043,muebles archivadores
-20,200043,archiveros
-20,200044,casilleros
-20,200045,concha de imitación
-20,200045,carey de imitación
-20,200046,pantallas de chimenea [mobiliario]
-20,200047,ataúdes
-20,200048,guarniciones no metálicas para ataúdes
-20,200049,cornamentas de ciervo
-20,200050,sillas [asientos]
-20,200050,asientos*
-20,200051,chaises longues
-20,200052,cabeceras [muebles]
-20,200053,percheros para sombreros
-20,200054,palés de carga no metálicos
-20,200055,gálibos de carga no metálicos para ferrocarriles
-20,200056,bisagras no metálicas
-20,200057,expositores [muebles]
-20,200058,casetas de perro
-20,200058,cuchas
-20,200059,perchas para prendas de vestir
-20,200062,anaqueles para archivadores
-20,200063,sillones*
-20,200064,maniquís*
-20,200065,recipientes no metálicos para combustibles líquidos
-20,200066,cómodas
-20,200067,mostradores [mesas]
-20,200068,contenedores no metálicos [almacenamiento, transporte]
-20,200069,contenedores flotantes no metálicos
-20,200070,mesas*
-20,200071,coral
-20,200072,bandejas no metálicas*
-20,200074,cuerno en bruto o semielaborado
-20,200076,corozo
-20,200077,accesorios de cama, excepto ropa de cama
-20,200078,cojines*
-20,200078,almohadones*
-20,200079,colchones*
-20,200080,ganchos no metálicos para percheros
-20,200081,cubas no metálicas
-20,200082,carritos de té
-20,200083,mesas de dibujo
-20,200083,restiradores
-20,200084,distribuidores fijos de toallas no metálicos
-20,200085,divanes
-20,200087,duelas
-20,200088,productos de ebanistería
-20,200089,concha
-20,200089,carey
-20,200090,conchas de ostras
-20,200091,tutores no metálicos para plantas y árboles
-20,200091,rodrigones no metálicos para plantas y árboles
-20,200092,escaleras de madera o materias plásticas
-20,200093,escaleras [escalas] móviles no metálicas para el embarque de pasajeros
-20,200094,mobiliario escolar
-20,200095,mesas de mecanografía
-20,200096,rótulos de madera o materias plásticas
-20,200097,tuercas no metálicas
-20,200098,espuma de mar
-20,200099,revestimientos amovibles para fregaderos
-20,200100,recipientes de materias plásticas para empaquetar
-20,200101,alzapaños que no sean de materias textiles
-20,200102,camas*
-20,200103,devanadoras no metálicas ni mecánicas para tubos flexibles
-20,200103,carretes no metálicos ni mecánicos para tubos flexibles
-20,200104,enrolladores no metálicos ni mecánicos para tubos flexibles
-20,200105,varillas para alfombras de escalera
-20,200106,bancos de trabajo
-20,200108,estantes [muebles]
-20,200109,cajas nido
-20,200109,nidales*
-20,200110,abanicos
-20,200112,cierres no metálicos para recipientes
-20,200113,guarniciones no metálicas para muebles
-20,200115,jardineras [muebles]
-20,200116,pedestales para macetas de flores
-20,200117,comederos para forraje
-20,200117,pesebres para forraje
-20,200118,armeros para fusiles
-20,200119,barricas no metálicas
-20,200119,cubas
-20,200119,toneles no metálicos
-20,200120,soportes no metálicos para barriles
-20,200120,soportes no metálicos para toneles
-20,200121,ruedecillas para cortinas
-20,200122,fresqueras
-20,200123,guarniciones no metálicas para ventanas
-20,200124,guarniciones no metálicas para camas
-20,200125,guarniciones no metálicas para puertas
-20,200126,tajos de carnicero
-20,200128,jaulas de embalaje
-20,200128,guacales
-20,200129,fundas de prendas de vestir para armarios
-20,200130,matrículas [placas de matriculación] no metálicas
-20,200130,placas de matriculación no metálicas
-20,200132,muebles metálicos
-20,200133,mimbre
-20,200133,caña de la India [rota]
-20,200134,expositores para periódicos
-20,200135,revisteros
-20,200136,persianas de laminillas para interiores
-20,200137,tocadores [muebles]
-20,200138,camas de hospital
-20,200139,ruedas de cama no metálicas
-20,200140,pestillos no metálicos
-20,200141,atriles*
-20,200143,cestos [cestas] para transportar objetos
-20,200144,percheros [muebles]
-20,200145,palés de transporte no metálicos
-20,200146,palés de manipulación no metálicos
-20,200147,escaleras de tijera no metálicas
-20,200148,entrepaños de madera para muebles
-20,200149,ruedas no metálicas para muebles
-20,200150,panales de miel
-20,200151,móviles [objetos de decoración]
-20,200152,pupitres
-20,200153,nácar en bruto o semielaborado
-20,200154,placas de identificación no metálicas
-20,200155,números de casa no luminosos ni metálicos
-20,200156,pájaros disecados
-20,200157,almohadas*
-20,200158,almohadas de aire que no sean para uso médico
-20,200159,jergones
-20,200160,paja trenzada, excepto esteras
-20,200161,trenzas de paja
-20,200162,cintas de paja
-20,200163,cestos de panadería
-20,200164,paragüeros
-20,200165,biombos [muebles]
-20,200166,ganchos [garfios] no metálicos para prendas de vestir
-20,200167,cortinas de cuentas para decorar
-20,200168,estacas no metálicas para tiendas de campaña
-20,200168,estacas no metálicas para carpas
-20,200169,tableros de mesa
-20,200170,puertas de muebles
-20,200171,rieles para cortinas
-20,200172,anaqueles [baldas] de muebles
-20,200173,perfiles [piezas de acabado] de materias plásticas para muebles
-20,200174,depósitos no metálicos ni de obra
-20,200174,tanques no metálicos ni de obra
-20,200175,barras de cortinas
-20,200176,ganchos de cortinas
-20,200177,alzapaños de cortinas
-20,200178,caña [material trenzable]
-20,200179,pezuñas de animales
-20,200180,secreteres
-20,200181,cerraduras no metálicas para vehículos
-20,200182,asientos metálicos
-20,200183,sofás
-20,200184,canapés [sillones]
-20,200185,somieres de camas
-20,200186,válvulas no metálicas que no sean partes de máquinas
-20,200186,compuertas no metálicas que no sean partes de máquinas
-20,200187,estatuas de madera, cera, yeso o materias plásticas
-20,200188,mesas metálicas
-20,200189,mesas de tocador
-20,200190,molduras para marcos de cuadros
-20,200191,estantes de almacenamiento
-20,200191,repisas de almacenamiento
-20,200192,cajones
-20,200192,taquillas [casilleros]
-20,200193,espejos
-20,200194,tumbonas [hamacas]
-20,200194,perezosas
-20,200195,travesaños [almohadas]
-20,200196,caballetes [muebles]
-20,200197,tableros para colgar llaves
-20,200198,vasares [muebles]
-20,200199,artículos de cestería
-20,200200,vitrinas [muebles]
-20,200201,cojines de aire que no sean para uso médico
-20,200202,colchones de aire que no sean para uso médico
-20,200203,barras de ambroide
-20,200203,barras de ámbar prensado
-20,200204,placas de ambroide
-20,200204,placas de ámbar prensado
-20,200205,obras de arte de madera, cera, yeso o materias plásticas
-20,200206,artesas no metálicas para argamasa
-20,200207,cajas no metálicas
-20,200207,cofres no metálicos
-20,200207,arcas no metálicas
-20,200209,bancos de trabajo [muebles]
-20,200210,barriles no metálicos
-20,200211,cercos no metálicos para toneles
-20,200211,cercos no metálicos para barriles
-20,200212,bastidores para máquinas de calcular
-20,200213,piqueras no metálicas
-20,200213,bitoques no metálicos
-20,200214,cápsulas de taponado no metálicas
-20,200215,tornillos no metálicos
-20,200216,remaches no metálicos
-20,200217,clavijas no metálicas
-20,200217,tarugos no metálicos
-20,200218,pernos no metálicos
-20,200219,cápsulas no metálicas para botellas
-20,200220,cierres no metálicos para botellas
-20,200221,pulseras de identificación no metálicas
-20,200222,carritos de servicio
-20,200223,bustos de madera, cera, yeso o materias plásticas
-20,200224,sujetacables no metálicos
-20,200225,marcos [arte y decoración]
-20,200226,varillas para marcos
-20,200226,listones para marcos
-20,200229,mesas de masaje
-20,200230,camas de agua que no sean para uso médico
-20,200231,sifones de desagüe de materias plásticas
-20,200232,tacos [chavetas] no metálicos
-20,200232,chavetas [tacos] no metálicas
-20,200233,conchas
-20,200235,taburetes
-20,200236,válvulas de materias plásticas para tuberías de agua
-20,200238,embalajes de madera para botellas
-20,200238,envases de madera para botellas
-20,200239,figuritas de madera, cera, yeso o materias plásticas
-20,200239,estatuillas de madera, cera, yeso o materias plásticas
-20,200240,cerraduras que no sean eléctricas ni metálicas
-20,200241,sillones de peluquería
-20,200242,barras no metálicas
-20,200243,cestas no metálicas
-20,200243,cestos no metálicos
-20,200244,buzones de correo no metálicos ni de obra
-20,200251,boyas de amarre no metálicas
-20,200252,fundas para guardar prendas de vestir
-20,200253,letreros de madera o materias plásticas
-20,200254,carritos [mobiliario]
-20,200255,cortinas de bambú
-20,200256,baúles para juguetes
-20,200256,cajas para juguetes
-20,200257,tronas para niños
-20,200257,sillas altas para niños
-20,200258,andadores para niños
-20,200259,objetos inflables para publicidad
-20,200260,tarjetas de acceso de materias plásticas no codificadas ni magnéticas
-20,200261,placas de vidrio para espejos
-20,200261,placas de espejo
-20,200262,poleas de materias plásticas para persianas
-20,200263,caballetes de aserrar
-20,200263,burros [caballetes de aserrar]
-20,200264,rascadores para gatos
-20,200265,palos para transportar cargas a hombros
-20,200266,mesas con ruedas para ordenadores
-20,200266,mesas con ruedas para computadoras
-20,200267,urnas funerarias
-20,200268,carillones de viento [decoración]
-20,200269,persianas de interior de madera tejida
-20,200270,soportes para libros
-20,200270,portalibros
-20,200271,cojines para animales de compañía
-20,200272,persianas de interior para ventanas [mobiliario]
-20,200273,manijas de puerta no metálicas
-20,200273,perillas de puerta no metálicas
-20,200273,picaportes de puerta no metálicos 
-20,200274,espejos de mano [espejos de tocador]
-20,200275,colchonetas para parques de bebés
-20,200275,colchonetas para corrales de bebés
-20,200275,colchonetas para corralitos de bebés
-20,200276,toalleros [muebles]
-20,200277,pomos [tiradores] no metálicos
-20,200278,cambiadores de pared [muebles]
-20,200279,cambiadores para bebés [colchonetas]
-20,200280,cerrojos de puerta no metálicos
-20,200281,estores de papel
-20,200282,estores de materias textiles para ventanas
-20,200283,timbres de puerta que no sean metálicos ni eléctricos
-20,200284,tabiques autoportantes [muebles]
-20,200285,tapas de rosca no metálicas para botellas
-20,200286,aldabas no metálicas para puertas
-20,200287,bancos de aserrar [muebles]
-20,200288,muebles inflables
-20,200288,muebles hinchables
-20,200289,escalerillas [taburetes] no metálicas
-20,200290,barras de apoyo no metálicas para bañeras
-20,200290,asideros no metálicos para bañeras
-20,200291,abrazaderas no metálicas para tuberías
-20,200292,expositores [organizadores] de joyas
-20,200293,colchonetas para dormir
-20,200293,esteras para dormir
-20,200294,anillas abiertas no metálicas para llaves
-20,200295,distribuidores no metálicos fijos de bolsas para excrementos de perros
-20,200296,topes para puertas, que no sean metálicos ni de caucho
-20,200297,topes para ventanas, que no sean metálicos ni de caucho
-20,200298,aldabillas no metálicas para ventanas
-20,200299,cierres no metálicos para ventanas
-20,200300,cierres no metálicos para puertas
-20,200301,cajas de herramientas no metálicas, vacías
-20,200302,cofres de herramientas no metálicos, vacíos
-20,200303,estanterías
-20,200304,cuelgabolsos no metálicos
-20,200305,llaves de materias plásticas
-20,200306,escuadras no metálicas para muebles
-20,200307,etiquetas de materias plásticas
-20,200308,consolas [muebles]
-20,200309,bibliotecas [muebles]
-20,200309,libreros [muebles]
-20,200310,galanes de noche
-20,200311,bidones no metálicos
-20,200312,casas para pájaros
-20,200313,pinzas de materias plásticas para cerrar bolsas
-20,200314,protectores de barrotes para cunas de bebé que no sean ropa de cama
-20,200315,cajas de madera o de materias plásticas
-20,200316,cunas de bebé
-20,200317,moisés
-20,200318,patas de muebles
-20,200319,patas cortas para muebles
-20,200320,armarios
-20,200321,reposapiés
-20,200322,clavijas no metálicas para el calzado
-20,200323,remaches no metálicos para el calzado
-20,200324,crucifijos de madera, cera, yeso o materias plásticas, que no sean artículos de joyería
-20,200325,recipientes no metálicos para purgar el aceite
-20,200326,colchones hinchables que no sean para uso médico
-20,200326,colchones inflables que no sean para uso médico
-20,200326,camas de aire que no sean para uso médico
-20,200327,colchones de camping
-20,200328,rampas de materias plásticas utilizadas con vehículos
-20,200329,sillas de ducha
-20,200330,almohadas en forma de cuña para bebés
-20,200331,cojines antivuelco para bebés
-20,200332,almohadas ergonómicas para bebés
-20,200333,astas de bandera portátiles no metálicas
-20,200334,tapones que no sean de cristal, metal o caucho para insertar en botellas
-20,200334,tapones que no sean de vidrio, metal o caucho para insertar en botellas
-20,200335,cierres de puertas no metálicos ni eléctricos
-20,200335,muelles de puertas no metálicos ni eléctricos
-20,200336,guías no metálicas para puertas correderas
-20,200336,rieles no metálicos para puertas correderas
-20,200337,asientos de bañera para bebés
-20,200338,escritorios de regazo
-20,200339,escritorios portátiles
-20,200340,dispositivos no metálicos ni eléctricos para abrir puertas
-20,200341,dispositivos no metálicos ni eléctricos para abrir ventanas
-20,200342,dispositivos no metálicos ni eléctricos para cerrar ventanas
-20,200343,poleas no metálicas para ventanas
-20,200343,poleas no metálicas para ventanas de guillotina
-20,200344,candados que no sean electrónicos ni metálicos
-20,200345,muebles de lavabo
-20,200346,cajones para muebles
-20,200347,taquillas para equipaje 
-20,200347,casilleros para equipaje
+class|name
+20|Abanicos de mano
+20|Abanicos de mano planos
+20|Abanicos de mano plegables
+20|Abanicos para uso personal (no eléctricos)
+20|Aldabas de puerta no metálicas
+20|Aldabas no metálicas para puertas
+20|Almohadas
+20|Almohadas cervicales
+20|Almohadas de bambú
+20|Almohadas de látex
+20|Almohadas en forma de u
+20|Almohadas inflables
+20|Almohadas para viaje
+20|Almohadas reposacabezas
+20|Almohadones (muebles)
+20|Altares de shinto de uso doméstico (kamidana)
+20|Anaqueles para libros
+20|Andadores para bebé
+20|Anillas de cortinas
+20|Animales embalsamados a través de taxidermia
+20|Aparadores (muebles)
+20|Armario para artículos para servir el te (chadansu)
+20|Armarios
+20|Armarios con espejo
+20|Armarios de almacenamiento metálicos
+20|Armarios de cocina
+20|Armarios expositores
+20|Armarios metálicos
+20|Armarios para herramientas metálicos
+20|Armarios para platos
+20|Armarios para zapatos
+20|Armazones de madera para camas
+20|Asientos de suelo de estilo japonés (zaisu)
+20|Atrapasueños (decoración)
+20|Atriles para libros
+20|Balancines de jardín
+20|Ballena
+20|Bancos
+20|Bancos de trabajo
+20|Bandejas de plástico (recipientes) utilizadas en el embalaje de alimentos
+20|Barandillas de cama
+20|Barras de colgar ropa usados para líneas automáticas de lavado
+20|Barras de cortinas
+20|Barras metálicas para cortinas
+20|Barras no metálicas para cortinas
+20|Barras para cortinas de ducha
+20|Barras, ruedecillas y ganchos de cortinas
+20|Barriles de madera
+20|Barriles no metálicos
+20|Bastidores de lienzo para artistas
+20|Baúles nagamochi
+20|Baúles para juguete
+20|Biombo vertical oriental de un solo panel (tsuitate)
+20|Biombos (muebles)
+20|Biombos separadores plegables orientales (byoubu)
+20|Botelleros (muebles)
+20|Boyas de amarre no metálicas
+20|Buffets (muebles)
+20|Bustos de madera, cera, yeso o materias plásticas
+20|Buzones de correo no metálicos ni de obra
+20|Cajas para juguetes (muebles)
+20|Cajas y baúles para juguetes
+20|Cajones
+20|Cajones (partes de muebles)
+20|Camas
+20|Camas de agua que no sean para uso médico
+20|Camas de hospital
+20|Camas de madera
+20|Camas para animales de compañía
+20|Camas para gatos
+20|Camas para niños
+20|Camas para perros
+20|Camas plegables
+20|Camas, colchones, almohadas y respaldos de cama
+20|Cambiadores para bebés (colchonetas)
+20|Canastas de fruta fresca para regalo
+20|Cápsulas de taponado no metálicas
+20|Cápsulas no metálicas para botellas
+20|Carillones de viento
+20|Carritos de servicio
+20|Casilleros
+20|Cierres de barril, no metálicos
+20|Cierres no metálicos para botellas
+20|Cierres no metálicos para recipientes
+20|Clavijas no metálicas
+20|Cofres no metálicos
+20|Cojines
+20|Cojines de apoyo para el cuello
+20|Cojines de fieltro para patas de muebles
+20|Cojines de lactancia
+20|Cojines decorativos
+20|Cojines hinchables para apoyar el cuello
+20|Cojines hinchables, excepto para usos médicos
+20|Cojines japoneses para suelos (zabuton)
+20|Cojines para embarazadas
+20|Cojines para sillas
+20|Cojines rellenos con pelo
+20|Colchones
+20|Colchones de látex
+20|Colchones de madera flexible
+20|Colchones y almohadas
+20|Colchonetas para dormir
+20|Colchonetas para dormir para niños
+20|Colchonetas para parques de bebés
+20|Colmenas para abejas (cajas de colmena o panales de colmena)
+20|Colmillos en bruto o semielaborado
+20|Conchas de caracoles de mar
+20|Conchas de mar
+20|Conchas de tortuga en bruto o semielaboradas
+20|Contenedores de embalaje industriales de madera
+20|Contenedores industriales de embalaje de bambú
+20|Contenedores para transporte, no de metal
+20|Coral en bruto o semielaborado
+20|Corrales de bebé
+20|Cortinas de bambú
+20|Cortinas de cuentas para decoración
+20|Cortinas de cuentas para decorar
+20|Cubas no metálicas
+20|Cubos no metálicos de reciclaje de uso comercial
+20|Cubos no metálicos de reciclaje de uso doméstico
+20|Cuernos
+20|Cuernos artificiales
+20|Cuernos de animales
+20|Cunas
+20|Cunas de viaje
+20|Decoraciones de materias plásticas para alimentos
+20|Decoraciones de plástico para tartas
+20|Dientes de animal
+20|Divanes
+20|Divisores de armarios
+20|Encimeras
+20|Escritorios (muebles)
+20|Escritorios bajos de estilo japonés (wazukue)
+20|Escritorios de oficina
+20|Escritorios de pie
+20|Esculturas de madera
+20|Esculturas de materias plásticas
+20|Espejos de mano (espejos de tocador)
+20|Espejos decorativos
+20|Espejos para el cuarto de baño y para afeitar
+20|Espejos que no sean de mano
+20|Espuma de mar (en bruto a semielaborada)
+20|Estanterías de exposición
+20|Estanterías metálicas
+20|Estanterías plegables
+20|Estantes de libros
+20|Estantes de montaje para hardware computacional
+20|Estantes inclinados
+20|Estantes para equipaje (muebles)
+20|Estantes para kimonos
+20|Estantes para mancuernas
+20|Estantes para papelería
+20|Estantes para plantas
+20|Estantes para vino (mobiliario)
+20|Estatuas de ámbar
+20|Estatuas de ámbar prensado
+20|Estatuas de hueso
+20|Estatuas de marfil
+20|Estatuas de plástico
+20|Estatuas de yeso
+20|Estatuillas de resina
+20|Estatuillas hechas de ámbar
+20|Estores de papel
+20|Estructuras de concha
+20|Expositores (muebles)
+20|Expositores de trajes
+20|Figuras de ratán
+20|Figuritas de resina
+20|Flotadores de pesca
+20|Formas de cuerpo humano de tamaño natural para exhibir ropa de vestir
+20|Ganchos de cortina para ducha
+20|Ganchos de cortinas
+20|Ganchos para la ropa no metálicos
+20|Ganchos para sombreros, no de metal
+20|Goteros para café no eléctricos
+20|Guarniciones no metálicas para muebles
+20|Guarniciones no metálicas para ventanas
+20|Heno onigaya en bruto o semielaborado
+20|Huesos de animales en bruto o semielaborados
+20|Imitación de alimentos hechos de plástico
+20|Juncosen bruto o semielaborados
+20|Lechos inflables para mascotas
+20|Letreros verticales de madera o materias plásticas
+20|Literas
+20|Madreperla
+20|Manijas de puerta no metálicas
+20|Maniquíes
+20|Marcos (arte y decoración)
+20|Marcos para cuadros y fotografías
+20|Marcos para cuadros y fotos que no sean de metales preciosos
+20|Marcos para espejo
+20|Mesas bajas de estilo japonés (zataku)
+20|Mesas de acicalado para animales de compañía
+20|Mesas de altura ajustable
+20|Mesas de caballete
+20|Mesas de camping
+20|Mesas de comedor
+20|Mesas de exposición
+20|Mesas de madera para cortar
+20|Mesas de mármol
+20|Mesas de masaje
+20|Mesas de oficina
+20|Mesas de té
+20|Mesas de tocador con tres espejos
+20|Mesas para cambiado de bebés
+20|Mesitas auxiliares
+20|Mobiliario escolar
+20|Móviles para la decoración
+20|Mudadores
+20|Mueble de baño
+20|Muebles
+20|Muebles a medida para cocinas
+20|Muebles de camping
+20|Muebles de casa, oficina y jardín
+20|Muebles de dormitorio
+20|Muebles de materias plásticas para jardines
+20|Muebles de oficina
+20|Muebles de tubos de acero
+20|Muebles hechos de madera o sucedáneos de la madera
+20|Muebles metálicos
+20|Muebles metálicos y muebles de camping
+20|Muebles para animales de compañía
+20|Muebles para exhibir productos
+20|Muebles para niños
+20|Muebles tapizados
+20|Nidales para animales de compañía
+20|Objetos de arte de ámbar prensado
+20|Objetos de arte de bambú
+20|Obras de arte de cera
+20|Obras de arte de corcho
+20|Obras de arte de madera
+20|Obras de arte de madera, cera, yeso o materias plásticas
+20|Obras de arte de paja
+20|Obras de arte de yeso
+20|Obras de arte hechas de ámbar
+20|Palés de carga no metálicos
+20|Palos de madera para sujetar caramelos o helados
+20|Palos para transportar cargas a hombros
+20|Pantallas de chimenea
+20|Paragüeros
+20|Parques de bebés
+20|Partes de camas no metálicas
+20|Partes de muebles
+20|Peras (sillas en forma de saco rellenos de materias plásticas)
+20|Perchas para prendas de vestir
+20|Percheros
+20|Percheros mostradores de tablas de surf
+20|Percheros para sombreros
+20|Perillas no metálicas
+20|Persianas de caña, ratán o bambú (sudare)
+20|Persianas de interior
+20|Persianas de interior de laminillas para ventanas
+20|Persianas de laminillas para interiores
+20|Persianas metálicas de interior para ventanas
+20|Persianas metálicas enrollables de interior para guiar la luz
+20|Persianas venecianas interiores
+20|Placas de identificación no metálicas
+20|Placas para nombres de puertas, no de metal
+20|Plataformas para cambiado de bebés
+20|Ratán (material en bruto o semielaborado)
+20|Recipientes de materias plásticas para embalar
+20|Remaches no metálicos
+20|Reposabrazos de estilo japonés (kyosoku)
+20|Revisteros
+20|Rieles metálicos para cortinas
+20|Rieles no metálicos para cortinas
+20|Rieles para cortinas
+20|Secreteres
+20|Sillas
+20|Sillas adaptadas para su uso por personas con problemas de movilidad
+20|Sillas de comedor
+20|Sillas de oficina
+20|Sillas inflables
+20|Sillas mecedoras
+20|Sillas plegables
+20|Sillas reclinables
+20|Sillones
+20|Sillones cama
+20|Sillones de barberías
+20|Sillones de oficina
+20|Sillones de peluquería
+20|Sillones para tratamientos cosméticos
+20|Sillones reclinables
+20|Sobrecolchones (toppers)
+20|Sofá de dos cuerpos
+20|Sofás cama
+20|Somieres
+20|Somieres de camas
+20|Tabiques autoportantes (muebles)
+20|Tabiques de oficina móviles
+20|Tableros de mesa
+20|Tablones de anuncios
+20|Taburetes
+20|Tachuelas no metálicas para tapicería
+20|Tanques de agua no metálicos ni de obra para uso industrial
+20|Tanques de almacenamiento de gas no metálicos ni de obra
+20|Tanques de almacenamiento de líquidos no metálicos ni de obra
+20|Tanques de almacenamiento no metálicos ni de obra
+20|Tanques de materias plásticas para almacenamiento
+20|Tapas de madera para contenedores de embalaje industriales
+20|Tapas de rosca no metálicas para botellas
+20|Tapetes para fregaderos
+20|Tapones de caucho para contenedores de embalaje industrial
+20|Tapones de corcho
+20|Tapones de madera para contenedores industriales de embalaje
+20|Tapones de plástico para botellas
+20|Tapones no metálicas para botellas
+20|Tapones plásticos para contenedores de embalaje industrial
+20|Tarimas
+20|Timbres de puerta no metálicos ni eléctricos
+20|Toalleros (muebles)
+20|Tornillos no metálicos
+20|Tornillos sujetacables no metálicos
+20|Travesaños (almohadas)
+20|Trenzas de paja
+20|Tronas para niños
+20|Tubos de plástico para envíos por correo
+20|Tumbonas
+20|Urnas crematorias
+20|Urnas funerarias
+20|Válvulas cerámicas operadas manualmente que no sean partes de máquinas
+20|Veladores (muebles)
+20|Vestidores (mesas de tocador)
+20|Vitrinas
+20|Vitrinas para mercancías

--- a/lib/seeds/class_21_terms.csv
+++ b/lib/seeds/class_21_terms.csv
@@ -1,465 +1,570 @@
-class,reference_id,name
-21,210001,abrevaderos
-21,210002,comederos*
-21,210005,lana de acero para limpiar
-21,210006,tablas de lavar
-21,210007,recipientes térmicos para alimentos
-21,210008,sacudidores de alfombras
-21,210009,ampollas de vidrio [recipientes]
-21,210010,cerdas de animales [cepillos y pinceles]
-21,210011,anillos para aves de corral
-21,210012,boquillas para mangueras de riego
-21,210013,instrumentos de riego
-21,210013,dispositivos de riego
-21,210014,cepillos*
-21,210015,aspersores*
-21,210016,regaderas
-21,210017,cestas para el pan de uso doméstico
-21,210018,anillos para pájaros
-21,210019,bañeras para pájaros*
-21,210020,escobas
-21,210021,escobas mecánicas
-21,210021,barrealfombras mecánicos
-21,210022,frascos de vidrio [recipientes]
-21,210022,balones de vidrio [recipientes]
-21,210023,baldes
-21,210023,cubos*
-21,210025,palanganas [recipientes]
-21,210026,baterías de cocina
-21,210027,picos vertederos
-21,210028,almohazas
-21,210030,mantequeras [vajilla]
-21,210030,mantequilleras
-21,210031,campanas para mantequilla
-21,210031,campanas para manteca
-21,210032,jarras de cerveza
-21,210033,tarros [bocales]
-21,210034,recipientes para beber
-21,210035,recipientes térmicos para bebidas
-21,210036,cajas distribuidoras de toallitas de papel
-21,210037,jaboneras [estuches]
-21,210038,cajas para té
-21,210039,boles
-21,210039,cuencos
-21,210039,escudillas
-21,210040,damajuanas
-21,210040,bombonas*
-21,210041,sacabotas
-21,210042,tapones de vidrio para insertar en botellas
-21,210042,tapones de cristal para insertar en botellas
-21,210043,sacacorchos, eléctricos y no eléctricos
-21,210044,bolas de vidrio decorativas
-21,210045,botellas
-21,210046,botellas aislantes
-21,210046,termos
-21,210047,botellas refrigerantes
-21,210048,abrebotellas, eléctricos y no eléctricos
-21,210049,brochetas [varillas metálicas] para uso culinario
-21,210050,cepillos de uñas
-21,210051,escobillas de baño
-21,210052,cepillos para cristales de lámparas
-21,210054,materiales para fabricar cepillos
-21,210055,cerdas para cepillos
-21,210056,quemadores de perfume [pebeteros]
-21,210056,pebeteros
-21,210057,vinajeras
-21,210058,licoreras [bandejas]
-21,210059,pajareras [jaulas de pájaros]
-21,210059,jaulas de pájaros
-21,210061,cedazos [utensilios domésticos]
-21,210062,recipientes térmicos
-21,210063,decantadores
-21,210063,jarras
-21,210064,portamenús
-21,210065,cacerolas
-21,210066,estropajos metálicos para fregar
-21,210066,esponjas metálicas para fregar
-21,210067,tamices para ceniza [utensilios domésticos]
-21,210068,artículos de cerámica para uso doméstico
-21,210069,matamoscas
-21,210070,calderas [ollas]
-21,210071,cepillos para zapatos
-21,210073,cepillos para caballos
-21,210074,comederos para animales
-21,210075,peines para animales
-21,210076,peines*
-21,210077,trapos de limpieza
-21,210077,paños [trapos] de limpieza
-21,210078,adornos de porcelana
-21,210079,moldes [utensilios de cocina]
-21,210080,enceradoras no eléctricas
-21,210082,cocteleras
-21,210084,botes para pegamento
-21,210084,frascos para pegamento
-21,210085,vasos [recipientes]
-21,210086,cuernos para beber
-21,210087,utensilios cosméticos
-21,210088,filtros para uso doméstico
-21,210089,fruteros
-21,210090,soportes para cuchillos de mesa
-21,210091,cierres para tapas de ollas
-21,210092,tapas de olla
-21,210093,fundas para tablas de planchar
-21,210094,prensas para corbatas
-21,210096,mezcladores no eléctricos para uso doméstico
-21,210097,tamices [utensilios domésticos]
-21,210098,artículos de cristalería
-21,210099,moldes para cubitos de hielo
-21,210099,cubeteras
-21,210100,cuero para lustrar
-21,210101,ollas
-21,210101,marmitas
-21,210102,palas para uso doméstico
-21,210103,moldes de cocina
-21,210104,instrumentos de limpieza accionados manualmente
-21,210105,mondadientes
-21,210105,palillos [mondadientes]
-21,210106,tinas para lavar la ropa
-21,210107,placas para impedir que se derrame la leche
-21,210108,tablas de cortar para la cocina
-21,210110,peines de púas anchas
-21,210110,peines desenredantes
-21,210111,aparatos no eléctricos para quitar el polvo
-21,210112,soportes para planchas de ropa
-21,210114,vidrio en polvo para decorar
-21,210115,neceseres de tocador
-21,210116,distribuidores de papel higiénico
-21,210117,distribuidores de jabón
-21,210118,sifones para agua gaseosa
-21,210118,sifones para agua carbonatada
-21,210119,vidrio esmaltado, que no sea para la construcción
-21,210120,hormas para zapatos
-21,210121,embudos
-21,210122,servicios para especias [especieros]
-21,210123,esponjas de aseo personal
-21,210124,portaesponjas [esponjeras]
-21,210124,esponjeras [portaesponjas]
-21,210125,paños para desempolvar muebles
-21,210126,tendederos de ropa
-21,210127,cubos de tela
-21,210128,estuches para peines
-21,210129,artículos de loza
-21,210132,soportes para plantas [arreglos florales]
-21,210132,soportes para flores [arreglos florales]
-21,210133,macetas [tiestos]
-21,210134,batidoras no eléctricas para uso doméstico
-21,210135,mopas*
-21,210135,fregonas
-21,210135,trapeadores*
-21,210136,sartenes
-21,210137,cepillos para el suelo
-21,210137,cepillos para el piso
-21,210138,exprimidores de fruta no eléctricos para uso doméstico
-21,210139,productos absorbentes del humo para uso doméstico
-21,210140,fiambreras
-21,210141,abreguantes
-21,210142,moldes para pasteles
-21,210142,moldes para tortas
-21,210143,vidrio [materia prima]
-21,210144,cantimploras
-21,210145,parrillas [utensilios de cocina]
-21,210146,soportes para parrillas
-21,210147,escobillas para extender el alquitrán
-21,210148,borlas de polvera
-21,210149,vidrio en bruto o semielaborado, excepto el vidrio de construcción
-21,210150,trampas para insectos
-21,210152,lana de vidrio que no sea para aislar
-21,210153,vasijas
-21,210154,fuentes para hortalizas
-21,210155,servicios para servir licores
-21,210156,cucharones [utensilios de cocina]
-21,210157,mayólica
-21,210158,trituradoras no eléctricas para uso culinario
-21,210159,utensilios para uso doméstico
-21,210160,recogemigas
-21,210161,mosaicos de vidrio que no sean para la construcción
-21,210162,molinillos de mano para uso doméstico
-21,210163,desechos de lana para limpiar
-21,210163,desperdicios de lana para limpiar
-21,210164,nidales [huevos artificiales]
-21,210165,hueveras
-21,210166,vidrio opalino
-21,210167,opalina
-21,210168,estropajos para limpiar
-21,210169,tablas de cortar pan
-21,210170,cestas de picnic con vajilla
-21,210171,prensas para pantalones
-21,210173,platos de papel
-21,210175,rodillos de pastelería
-21,210175,palos de amasar
-21,210176,peines eléctricos
-21,210177,palas para tartas
-21,210178,pipetas para vino
-21,210178,catavinos
-21,210179,tablas de planchar
-21,210180,bandejas de papel para uso doméstico
-21,210180,charolas de papel para uso doméstico
-21,210181,cazuelas
-21,210183,alcachofas de regadera
-21,210184,molinillos de pimienta manuales
-21,210185,pimenteros
-21,210186,aparatos y máquinas de lustrar no eléctricos para uso doméstico
-21,210187,materiales para pulir [sacar brillo] que no sean preparaciones ni papel ni piedra
-21,210189,artículos de porcelana
-21,210190,jarrones
-21,210191,portajabones [jaboneras]
-21,210192,bacinillas
-21,210193,artículos de alfarería
-21,210194,cubos de basura
-21,210194,basureros [cubos de basura]
-21,210195,polveras vacías
-21,210196,cubiteras
-21,210196,baldes para hielo
-21,210197,ralladores para uso culinario
-21,210198,trampas para ratas [cepos]
-21,210199,recipientes para uso doméstico o culinario
-21,210200,servilleteros de aro
-21,210203,ensaladeras
-21,210204,saleros
-21,210206,jeringas para regar flores y plantas
-21,210207,servicios de mesa [vajilla]
-21,210208,fuentes [vajilla]
-21,210209,servicios de té
-21,210210,servilleteros de mesa
-21,210211,aparatos para hacer helados y sorbetes
-21,210212,platillos [platos pequeños]
-21,210213,calzadores
-21,210214,soperas
-21,210215,cepillos para las cejas
-21,210216,ratoneras [trampas para ratones]
-21,210217,estatuas de porcelana, cerámica, loza, barro cocido o vidrio
-21,210217,estatuas de porcelana, cerámica, loza, barro cocido o cristal
-21,210218,azucareros
-21,210219,centros de mesa
-21,210220,tazas
-21,210221,tensores para prendas de vestir
-21,210222,teteras
-21,210223,abotonadores
-21,210224,huchas de cerdito
-21,210224,alcancías de chanchito
-21,210224,alcancías de cochinito
-21,210224,alcancías de marranito
-21,210225,utensilios de tocador
-21,210226,dispensadores de bebidas calientes no eléctricos
-21,210227,vajilla
-21,210228,vaporizadores de perfume
-21,210228,pulverizadores de perfume
-21,210229,vidrio con conductores eléctricos finos incorporados
-21,210230,vidrio pintado
-21,210230,artículos de cristalería pintados
-21,210231,vidrio para ventanillas de vehículos [producto semiacabado]
-21,210232,tazas altas
-21,210232,mugs [tazas altas]
-21,210233,aerosoles [recipientes] que no sean para uso médico
-21,210234,objetos de arte de porcelana, cerámica, loza, barro cocido o vidrio
-21,210234,objetos de arte de porcelana, cerámica, loza, barro cocido o cristal
-21,210235,platos
-21,210236,ollas a presión no eléctricas
-21,210236,ollas exprés no eléctricas
-21,210238,batidoras no eléctricas
-21,210239,calientabiberones no eléctricos
-21,210240,brochas de afeitar
-21,210241,portabrochas de afeitar
-21,210242,arandelas de candelero
-21,210243,cajas de vidrio
-21,210244,cajas para caramelos
-21,210244,bomboneras
-21,210245,candeleros
-21,210245,candelabros
-21,210245,palmatorias
-21,210246,hervidores no eléctricos
-21,210248,filtros de té [bolas y pinzas]
-21,210250,cepillos de dientes
-21,210251,cepillos eléctricos, excepto partes de máquinas
-21,210252,bustos de porcelana, cerámica, loza, barro cocido o vidrio
-21,210252,bustos de porcelana, cerámica, loza, barro cocido o cristal
-21,210253,cubremacetas que no sean de papel
-21,210254,molinillos de café accionados manualmente
-21,210255,servicios de café
-21,210256,filtros de café no eléctricos
-21,210257,cafeteras de filtro no eléctricas
-21,210258,posabotellas y posavasos que no sean de papel ni de materias textiles
-21,210259,esponjas abrasivas para la cocina
-21,210260,freidoras no eléctricas
-21,210261,neveras portátiles no eléctricas
-21,210261,heladeras portátiles no eléctricas
-21,210262,duchas bucales
-21,210263,gamuzas para limpiar
-21,210264,aparatos no eléctricos para lustrar el calzado
-21,210265,campanas para queso
-21,210266,cestas para uso doméstico
-21,210267,bandejas para uso doméstico
-21,210267,charolas para uso doméstico
-21,210268,desechos de algodón para limpiar
-21,210269,tapas para platos y fuentes
-21,210270,salvamanteles [utensilios de mesa]
-21,210271,cántaros
-21,210271,jarros
-21,210272,recipientes de cocina
-21,210273,utensilios de cocina
-21,210274,utensilios de cocción no eléctricos
-21,210275,palilleros
-21,210276,cepillos de dientes eléctricos
-21,210277,aparatos desodorantes para uso personal
-21,210278,escobillas para limpiar recipientes
-21,210279,letreros de porcelana o vidrio
-21,210280,esponjas para uso doméstico
-21,210281,plumeros
-21,210282,paños [trapos] para quitar el polvo
-21,210282,trapos para quitar el polvo
-21,210283,fibras de silicio vitrificado que no sean para uso textil
-21,210284,fibras de vidrio que no sean para aislar ni para uso textil
-21,210285,figuras [estatuillas] de porcelana, cerámica, loza, barro cocido o vidrio
-21,210285,estatuillas de porcelana, cerámica, loza, barro cocido o vidrio
-21,210285,estatuillas de porcelana, cerámica, loza, barro cocido o cristal
-21,210286,hilos de vidrio que no sean para uso textil
-21,210287,cafeteras no eléctricas
-21,210288,coladores de té
-21,210289,frascos*
-21,210290,guantes para uso doméstico
-21,210291,picheles
-21,210292,juegos de aceitera y vinagrera
-21,210292,alcuzas
-21,210294,guantes para lustrar
-21,210295,apagavelas
-21,210301,bañeras portátiles para bebés
-21,210302,jaulas para animales de compañía
-21,210303,bayetas para el suelo
-21,210303,trapos de piso
-21,210304,cepillos para lavar la vajilla
-21,210305,terrarios de interior [cultivo de plantas]
-21,210306,bandejas higiénicas para animales de compañía
-21,210306,bandejas de arena higiénica para animales de compañía
-21,210308,sílice fundido [producto semielaborado] que no sea para la construcción
-21,210309,gofreras no eléctricas
-21,210309,planchas no eléctricas para hacer gofres
-21,210310,cajas para el pan
-21,210311,palillos chinos [utensilios de mesa]
-21,210312,estopa para limpiar
-21,210313,pinzas para la ropa
-21,210314,agitadores de cóctel
-21,210315,mangas de pastelero
-21,210316,cortapastas [moldes para pastas y galletas]
-21,210317,cajas para galletas
-21,210318,vasos de papel o materias plásticas
-21,210319,vasos para beber
-21,210320,hilo dental
-21,210321,guantes de jardinería
-21,210322,ollas no eléctricas para cocinar al vapor
-21,210323,bolsas isotérmicas
-21,210324,bandejas giratorias [utensilios de mesa]
-21,210325,portaviandas
-21,210326,cucharas para mezclar [utensilios de cocina]
-21,210327,aparatos para hacer tallarines [instrumentos de accionamiento manual]
-21,210328,cortadores de pastelería
-21,210329,desatascadores de ventosa
-21,210329,sopapas
-21,210330,espátulas de cocina
-21,210331,esponjas exfoliantes para la piel
-21,210332,prensaajos [utensilios de cocina]
-21,210333,platos desechables
-21,210334,toalleros de aro y de barra
-21,210335,portarrollos de papel higiénico
-21,210336,acuarios de interior
-21,210337,tapas para acuarios de interior
-21,210338,terrarios de interior [vivarios]
-21,210339,escurridores de mopas
-21,210339,escurridores de fregonas
-21,210339,estrujadores de fregonas
-21,210339,estrujadores de mopas
-21,210339,exprimidores de trapeadores
-21,210340,papeleras
-21,210341,jardineras para ventanas
-21,210342,pajillas para beber
-21,210342,pajitas para beber
-21,210342,popotes
-21,210343,cubreteteras
-21,210343,cubiertas para teteras
-21,210344,aparatos para desmaquillar
-21,210345,dispositivos eléctricos para atraer y eliminar insectos
-21,210346,tapetes para hornear
-21,210347,hormas para botas
-21,210348,petacas [botellas de bolsillo]
-21,210349,espátulas para uso cosmético
-21,210350,graseras
-21,210351,trampas para moscas
-21,210352,recipientes de vidrio para velas [portavelas]
-21,210353,vaporeras no eléctricas
-21,210354,esponjas para aplicar maquillaje
-21,210355,trituradoras no eléctricas para uso doméstico
-21,210356,agarradores de cocina
-21,210356,agarraderas de cocina
-21,210357,manoplas de cocina
-21,210357,manoplas de barbacoa
-21,210357,manoplas de horno
-21,210358,pinceles de cocina
-21,210359,pipetas de cocina
-21,210360,guantes para lavar coches
-21,210361,brochas y pinceles de maquillaje
-21,210362,cubos con escurridor para fregonas
-21,210362,cubos con escurridor para trapeadores
-21,210363,prensas no eléctricas para tortillas [utensilios de cocina]
-21,210364,cepillos para encerar esquís 
-21,210365,cepillos para pestañas
-21,210366,separadores de huevos no eléctricos para uso doméstico
-21,210367,separadores interdigitales de espuma para la pedicura
-21,210368,difusores de enchufe repelentes de mosquitos
-21,210369,acumuladores de frío para enfriar la comida y las bebidas
-21,210370,cubos de hielo reutilizables
-21,210371,salvamanteles que no sean de papel ni de materias textiles
-21,210372,manteles individuales que no sean de papel ni de materias textiles
-21,210373,etiquetas para decantadores
-21,210374,aireadores de vino
-21,210375,cabezales para cepillos de dientes eléctricos
-21,210376,huchas
-21,210376,alcancías
-21,210377,dispositivos quitapelusas eléctricos o no
-21,210377,dispositivos quitatimotas eléctricos o no
-21,210378,paños de pulido
-21,210379,cerdas de cerdo para fabricar cepillos
-21,210380,crin de caballo para fabricar cepillos
-21,210381,pinzas de hielo
-21,210382,pinzas de ensalada
-21,210383,cucharones de servir
-21,210384,pilones de cocina
-21,210385,morteros de cocina
-21,210386,cucharas de helado
-21,210387,cascanueces
-21,210387,rompenueces
-21,210388,pinzas para el azúcar
-21,210389,mangos de escoba
-21,210390,cucharones para vino
-21,210391,bañeras hinchables para bebés
-21,210391,bañeras inflables para bebés
-21,210392,soportes de bañeras portátiles para bebés
-21,210393,reposabolsas de té
-21,210394,boquillas de pastelería y repostería
-21,210395,tendederos giratorios
-21,210396,mallas de cocción que no sean para microondas
-21,210397,cuentagotas para uso cosmético
-21,210397,goteros para uso cosmético
-21,210398,cuentagotas para uso doméstico
-21,210398,goteros para uso doméstico
-21,210399,cuscuseras no eléctricas
-21,210400,cazuelas de tajín no eléctricas
-21,210401,separadores de yemas
-21,210402,tapas reutilizables de silicona para alimentos
-21,210403,guantes de aseo para animales
-21,210404,rasquetas de goma [instrumentos de limpieza]
-21,210404,escobillas de goma [instrumentos de limpieza]
-21,210405,escalfadores de huevos
-21,210406,difusores de aceites aromáticos, que no sean con varillas, eléctricos y no eléctricos
-21,210407,placas para la difusión de aceite aromático
-21,210408,máquinas para elaborar pastas alimenticias, accionadas manualmente
-21,210409,contenedores de pañales usados
-21,210409,cubos de basura para pañales
-21,210410,recipientes desechables de aluminio para uso doméstico
-21,210411,tubos peladores de ajos
-21,210412,exprimidores de tubos de pasta de dientes
-21,210413,vertedores de vino
-21,210414,comederos para animales de compañía
-21,210415,comederos de distribución automática para animales de compañía
-21,210416,calentadores de velas, eléctricos y no eléctricos
-21,210417,bayetas
-21,210417,trapos para lavar platos
-21,210418,guantes exfoliantes para la piel
+class|name
+21|Abrebotellas
+21|Abreguantes
+21|Abrevaderos mecánicos activados por el ganado
+21|Abrevaderos para aves de corral
+21|Abrevaderos para ganado
+21|Acuarios
+21|Acuarios de interior
+21|Adornos para acuarios
+21|Agitadores de cóctel
+21|Agitadores para revolver miel
+21|Aireadores de vino
+21|Alcachofas de regadera
+21|Alcancías no metálicas
+21|Alimentadores de mascotas activados por animales
+21|Almohadillas exfoliantes
+21|Anillas metálicas para la identificación de aves
+21|Anillos para aves de corral
+21|Apagavelas
+21|Apagavelas que no sean de metales preciosos
+21|Apagavelas y candelabros de metales preciosos
+21|Apagavelas y candelabros que no sean de metales preciosos
+21|Aparato para abrir huevos no eléctrico para uso doméstico
+21|Apoya palillos chinos
+21|Apoyacuchillos
+21|Arandelas de candelero
+21|Arandelas de candelero de metales preciosos
+21|Aros para tartas
+21|Autoclaves no eléctricas
+21|Azucareras de metales preciosos
+21|Bacinillas
+21|Baldes
+21|Baldes con pedal
+21|Baldes para el cuarto de baño
+21|Baldes para enjuagar
+21|Baldes para hielo
+21|Bandejas para la comida
+21|Bandejas para uso doméstico
+21|Bañeras de materias plásticas para niños
+21|Bañeras plegables para bebes
+21|Barredoras de alfombras (no eléctricas)
+21|Barredoras de migajas
+21|Basureros
+21|Basureros con pedal
+21|Baterías de cocina
+21|Batidoras de huevos no eléctricas
+21|Batidores no eléctricos
+21|Bayetas para el suelo
+21|Bebederos no mecanizados para mascotas que son dispensadores portátiles de agua y líquidos
+21|Bloques para cuchillos
+21|Boles
+21|Bolsas térmicas aislantes para comidas o bebidas
+21|Bombonas
+21|Bomboneras que no sean de metales preciosos
+21|Boquillas dosificadoras para botellas
+21|Boquillas para mangueras de riego
+21|Borlas de polvera
+21|Botellas aislantes
+21|Botellas de agua de acero inoxidable reutilizables y vacías
+21|Botellas de agua de plástico reutilizables y vacías
+21|Botellas de arena para decoración
+21|Botellas para servir sake (tokkuri)
+21|Botellas y termos aislados
+21|Botes de té
+21|Brochas de afeitar
+21|Cabezas de fregona
+21|Cacerolas
+21|Cafeteras de émbolo no eléctricas
+21|Cafeteras de filtro no eléctricas
+21|Cafeteras de metales preciosos no eléctricas
+21|Cafeteras de vacío no eléctricas
+21|Cafeteras no eléctricas
+21|Cafeteras no eléctricas ni de metales preciosos
+21|Cajas de arena higiénica automáticas para animales de compañía
+21|Cajas de metales preciosos para caramelos
+21|Cajas para el pan
+21|Cajas para galletas
+21|Cajones higiénicos con arena para gatos
+21|Calienta biberones no eléctricos
+21|Calzadores
+21|Campanas para tartas
+21|Canastas de basura
+21|Canastos de ropa sucia para uso doméstico
+21|Candelabros
+21|Candelabros con protección contra el viento
+21|Candelabros de metales preciosos
+21|Candelabros de vidrio
+21|Candelabros que no sean de metales preciosos
+21|Cántaros
+21|Cántaros que no sean de metales preciosos
+21|Caramañolas
+21|Cazos para la leche
+21|Cazuelas para mantequilla
+21|Cepillos de alambre para caballos
+21|Cepillos de champú
+21|Cepillos de dientes
+21|Cepillos de dientes de dedo para bebés
+21|Cepillos de dientes eléctricos
+21|Cepillos de dientes manuales
+21|Cepillos de dientes no eléctricos
+21|Cepillos de dientes para animales de compañía
+21|Cepillos de lengua
+21|Cepillos de limpieza para caños de tetera
+21|Cepillos de uñas
+21|Cepillos interdentales para limpiar los dientes
+21|Cepillos para animales de compañía
+21|Cepillos para bañera
+21|Cepillos para botellas
+21|Cepillos para calzado
+21|Cepillos para crines (peines para caballos)
+21|Cepillos para el baño
+21|Cepillos para el cabello
+21|Cepillos para el cabello, uñas y dientes
+21|Cepillos para el suelo
+21|Cepillos para el teñido del cabello
+21|Cepillos para la limpieza de ollas
+21|Cepillos para las cejas
+21|Cepillos para lavar
+21|Cepillos para lavar la vajilla
+21|Cepillos para limpiar barcos
+21|Cepillos para limpiar parrillas de barbacoas
+21|Cepillos para limpiar ruedas de automóviles
+21|Cepillos para maquillaje
+21|Cepillos para mesas de billar
+21|Cepillos para tetinas de biberones
+21|Cepillos para uso cosmético
+21|Cepillos para zapatos
+21|Cerdas de animales para cepillos
+21|Cestas clasificadoras de ropa para lavandería de uso doméstico
+21|Cestas de bambú para uso doméstico
+21|Cestas de lavandería para uso doméstico
+21|Cestas de metales comunes para uso en el hogar
+21|Cestas de vaporeras
+21|Cestas para plantas
+21|Coladores de cocina
+21|Coladores de vino
+21|Coladores para uso doméstico
+21|Comederos de animales que activan los propios animales
+21|Comederos para animales
+21|Comederos para animales pequeños
+21|Comederos para aves de corral
+21|Comederos para cerdos
+21|Comederos para pájaros
+21|Contenedores de cocina
+21|Contenedores para hacer cabritas al microondas
+21|Copas
+21|Copas de brandy
+21|Copas de champán
+21|Copas de espumante
+21|Copas de vino
+21|Cortadores de pastelería
+21|Crin de caballo para cepillos
+21|Cubiteras
+21|Cubos (baldes) plegables
+21|Cubos de basura
+21|Cubos para pañales
+21|Cubos para sauna
+21|Cubremacetas que no sean de papel
+21|Cucharas de servir
+21|Cucharas medidoras de café
+21|Cucharas para servir alimentos sólidos (utensilios para el hogar o la cocina)
+21|Cucharas perforadas (utensilios de cocina)
+21|Cucharones para cocina
+21|Cucharones planos para cocinar
+21|Cuencos
+21|Cuencos con ventosas
+21|Cuencos de beber para animales domésticos
+21|Cuencos de comida y bebida para animales domésticos
+21|Cuencos llanos
+21|Cuencos para afeitar
+21|Cuencos para el teñido del cabello
+21|Cuero para lustrar
+21|Decantadores
+21|Decantadores de vidrio
+21|Decantadores de vino
+21|Depósitos de agua para peces vivos
+21|Desatascadores de inodoro
+21|Desatascadores de ventosa
+21|Dispensadoras de toallas de papel de uso doméstico
+21|Dispensadores de bolas de algodón
+21|Dispensadores de masa manuales para uso doméstico (utensilios de cocina)
+21|Dispensadores de servilletas para uso doméstico
+21|Dispensadores de toallas fijos no metálicos
+21|Dispensadores fijos de servilletas no metálicos
+21|Dispositivos alimentadores no mecanizados para animales
+21|Distribuidores de desinfectantes
+21|Distribuidores de jabón
+21|Distribuidores de papel higiénico
+21|Distribuidores mecánicos de alimento activados por el ganado
+21|Embudos
+21|Embudos de cocina
+21|Ensaladeras
+21|Ensaladeras que no sean de metales preciosos
+21|Escobas
+21|Escobillas de baño
+21|Escobillas de mano para uso doméstico
+21|Escobillas para biberones
+21|Escobillas para el polvo
+21|Escobillas para limpiar instrumentos musicales
+21|Escobilleros de cuarto de baño
+21|Escudillas (recipientes para cocinar arroz)
+21|Espátulas para sartenes y ollas
+21|Espátulas para servir tartas
+21|Espetones de cocina
+21|Esponjas abrasivas para la cocina
+21|Esponjas de aseo personal
+21|Esponjas de cocina
+21|Esponjas faciales para aplicar maquillaje
+21|Esponjas limpiadoras faciales
+21|Esponjas naturales para uso doméstico
+21|Esponjas para aplicar polvos corporales
+21|Esponjas para fregado
+21|Esponjas para limpiar instrumentos médicos
+21|Esponjas para uso doméstico
+21|Espumadores de leche no eléctricos
+21|Esterillas para enrollar sushi
+21|Estropajos metálicos para limpiar
+21|Estropajos para cacerolas (incluidos de metal)
+21|Estropajos planos metálicos para limpieza
+21|Estuches para cepillos de dientes
+21|Estuches para palillos chinos
+21|Exprimidores de limón
+21|Fiambreras
+21|Fibras de vidrio que no sean ni para aislar ni para uso textil
+21|Figuritas de terracota
+21|Figuritas de vidrio de color
+21|Filtros de bola para té
+21|Filtros de bola para té que no sean de metales preciosos
+21|Filtros de té de metales preciosos
+21|Filtros de té que no sean de metales preciosos
+21|Filtros para uso doméstico
+21|Floreros y fuentes
+21|Forros de plástico a medida para cubiteras
+21|Forros de silicona para hornear magdalenas
+21|Frascos de vidrio (mason jars)
+21|Frascos para beber (para viajeros)
+21|Freidoras no eléctricas
+21|Fuentes (vajilla)
+21|Fuentes de vidrio para peces dorados vivos
+21|Fuentes para asar
+21|Fuentes para horno
+21|Fuentes para servir (hachi)
+21|Fuentes para servir sopa estilo japonés (wan)
+21|Fundas aislantes para tazas de bebidas
+21|Fundas de plumero desechables para limpieza
+21|Fundas para tablas de planchar
+21|Gamuzas para limpiar
+21|Guantes abrasivos para fregar vegetales
+21|Guantes de jardinería
+21|Guantes de sacudir
+21|Guantes exfoliantes
+21|Guantes para el acicalamiento de animales
+21|Guantes para lustrar
+21|Guantes para lustrar zapatos
+21|Guantes para uso doméstico
+21|Hábitats de hormigas
+21|Hervidores no eléctricos
+21|Hervidores que silban
+21|Hilo dental (hilos para uso dental)
+21|Hilos de vidrio que no sean para uso textil
+21|Hisopos para limpiar instrumentos médicos
+21|Hojas de vidrio que no sean para la construcción
+21|Hormas para botas (extensores)
+21|Huchas
+21|Hueveras
+21|Hueveras de materias plásticas para uso doméstico
+21|Hueveras de metales preciosos
+21|Hueveras que no sean de metales preciosos
+21|Inyectores de marinada (utensilios de uso culinario)
+21|Jaboneras
+21|Jaboneras de pared
+21|Jardineras (maceteros)
+21|Jarras para beber
+21|Jarras para siropes
+21|Jarras pequeñas
+21|Jarrones
+21|Jarrones de barro cocido
+21|Jarrones de metales preciosos
+21|Jarros
+21|Jaulas de pájaros
+21|Jaulas para animales de compañía
+21|Jaulas para pájaros domésticos
+21|Jaulas para transportar animales domésticos
+21|Jeringas para jardinería
+21|Jeringas para regar flores y plantas
+21|Juegos de tacitas de café compuestos de tazas y platillos
+21|Láminas de vidrio coloreado que no sean para la construcción
+21|Láminas de vidrio común (no para la construcción)
+21|Lana de acero
+21|Lana de acero para limpiar
+21|Latas vacías de uso doméstico para palomitas de maíz
+21|Lavabos (pilas, que no sean parte de instalaciones sanitarias)
+21|Lecheras (jarras)
+21|Letreros de porcelana o vidrio
+21|Licuadoras de comida no eléctricas (de uso doméstico)
+21|Macetas (tiestos)
+21|Macetas de porcelana para flores
+21|Macetas para flores
+21|Maceteros
+21|Manteles individuales de materias plásticas
+21|Manteles individuales de vinilo
+21|Matamoscas
+21|Menorahs
+21|Mezcladores de comida no eléctricos de uso doméstico
+21|Moldes de cocina
+21|Moldes de hierro para gofres (no eléctricos)
+21|Moldes de papel para hornear
+21|Moldes de pastelería de cartón desechables
+21|Moldes de repostería
+21|Moldes de silicona para hornear
+21|Moldes metálicos para pasteles
+21|Moldes para chocolate
+21|Moldes para empanadillas para uso doméstico
+21|Moldes para huevos fritos
+21|Moldes para magdalenas
+21|Moldes para pudines
+21|Molinillos de café accionados manualmente
+21|Molinillos de café no eléctricos
+21|Molinillos de café y pimienta accionados manualmente
+21|Molinillos de pimienta manuales
+21|Molinillos de sal manuales
+21|Molinillos de sal y pimienta
+21|Mondadientes
+21|Mopas
+21|Morteros para machacar fruta
+21|Neveras portátiles no eléctricas
+21|Obras de arte de porcelana
+21|Obras de arte de vidrio
+21|Odres (botas de vino)
+21|Ollas
+21|Ollas arroceras para su uso en hornos microondas
+21|Ollas calientes (no calentadas eléctricamente)
+21|Ollas de piedra
+21|Ollas no eléctricas para conservas (ollas a presión)
+21|Ollas no eléctricas para palomitas de maíz
+21|Ollas para cocer arroz que no sean eléctricas
+21|Ollas para servir te estilo japones (kyusu)
+21|Ollas y sartenes de cocina no eléctricos
+21|Ollas y sartenes portátiles para camping
+21|Orinales portátiles para niños
+21|Pajillas para beber
+21|Pajitas de arroz biodegradables para beber
+21|Palanganas (recipientes)
+21|Palas para alimento de perro
+21|Palas para arroz
+21|Palas para azúcar
+21|Palas para pizza
+21|Palas para tartas
+21|Paletas para servir arroz cocido
+21|Palilleros de metales preciosos
+21|Palilleros que no sean de metales preciosos
+21|Palillos chinos (utensilios de mesa)
+21|Palillos chinos de entrenamiento para niños
+21|Palillos chinos desechables
+21|Palillos para cake pops (pastelitos)
+21|Palitos para confites congelados
+21|Palitos para paletas de golosina
+21|Paneras de cocina
+21|Paños (trapos) para quitar el polvo
+21|Paños de limpieza
+21|Paños de limpieza y pulido
+21|Paños de microfibra para limpieza
+21|Paños para desempolvar muebles
+21|Paños para limpiar, desempolvar y pulir
+21|Paños para lustrar calzado
+21|Paños para sacudir o limpiar
+21|Papeleros
+21|Parrillas como utensilios de cocina
+21|Parrillas de camping
+21|Peines
+21|Peines de caballo
+21|Peines de dientes anchos
+21|Peines eléctricos para el cabello
+21|Peines para el cabello
+21|Peines para escarmenar
+21|Pelo de mapache para cepillos
+21|Peras de cocina
+21|Perchas para jaulas de pájaros
+21|Perchas para tender la ropa
+21|Picadoras de carne no eléctricas
+21|Picheles que no sean de metales preciosos
+21|Piedras para pizza
+21|Pimenteros
+21|Pinceles de labios
+21|Pinceles para tartas
+21|Pinchos para cóctel
+21|Pinchos para sujetar choclos (utensilios de cocina)
+21|Pinzas para barbacoa
+21|Pinzas para carne (utensilios de uso culinario)
+21|Placas de vidrio templado, no para la construcción
+21|Planchas a gas (aparatos de cocina)
+21|Planchas no eléctricas (utensilios de cocina)
+21|Platos
+21|Platos biodegradables
+21|Platos de canapé
+21|Platos de gel de sílice
+21|Platos de papel
+21|Platos de postre
+21|Platos desechables
+21|Platos para servir de porcelana seccionados en nueve (gujeolpan)
+21|Platos para tiestos
+21|Platos para velas cilíndricas
+21|Platos y vasos de papel
+21|Polveras de metales preciosos vacías
+21|Polveras vacías
+21|Portabotellas de neopreno con cremallera
+21|Portabotellas de vino
+21|Portabrochas de afeitar
+21|Portamazorcas de maíz
+21|Portarrollos de papel higiénico
+21|Portavelas de metales preciosos
+21|Portavelas que no sean de metales preciosos
+21|Portaviandas
+21|Portaviandas de materias plásticas
+21|Portaviandas metálicas
+21|Posabotellas y posavasos que no sean de papel ni ropa de mesa
+21|Posavasos absorbentes para té
+21|Prensas para galletas accionadas manualmente
+21|Pulverizadores para su uso con mangueras de jardín
+21|Quemadores de incienso
+21|Quemadores de perfume (pebeteros)
+21|Queseras
+21|Ralladores de cocina
+21|Ralladores giratorios para queso
+21|Ralladores para nuez moscada
+21|Ralladores para uso doméstico
+21|Rascadores de espalda
+21|Rascadores para el cuero cabelludo
+21|Ratoneras (trampas para ratones)
+21|Recipientes aislantes para latas de bebidas, para uso doméstico
+21|Recipientes de comida para animales de compañía
+21|Recipientes de metales preciosos para uso doméstico
+21|Recipientes de uso doméstico para compost
+21|Recipientes para hielo
+21|Recipientes para hornear pastelillos (cupcakes)
+21|Recipientes para jabón
+21|Recipientes para quemar incienso
+21|Recipientes para uso doméstico
+21|Recipientes para uso doméstico o culinario
+21|Recipientes portátiles de bebidas
+21|Recipientes térmicos para alimentos o bebidas
+21|Recogedores
+21|Regaderas
+21|Repelentes de plagas por ultrasonido
+21|Rodillos (adhesivos) para quitar pelusas de la ropa
+21|Rodillos de amasar (para cocinar)
+21|Rodillos quitapelusas
+21|Sacabotas
+21|Sacacorchos
+21|Sacudidoras de alfombras (que no sean máquinas)
+21|Saleros
+21|Saleros de metales preciosos
+21|Salseras
+21|Salvamanteles
+21|Samovares no eléctricos
+21|Sartenes
+21|Sartenes de cocina no eléctricos
+21|Sartenes no eléctricos
+21|Sartenes para sofritos
+21|Secadores (tendederos) de ropa
+21|Secadores de vajilla (escurreplatos)
+21|Servicios de café de cerámica
+21|Servicios de café de porcelana
+21|Servicios de té de metales preciosos
+21|Servidores de miel
+21|Servilleteros de aro
+21|Servilleteros de aro que no sean de metales preciosos
+21|Servilleteros de metales preciosos
+21|Servilleteros que no sean de metales preciosos
+21|Servilleteros y servilleteros de aro que no sean de metales preciosos
+21|Soportes de aceiteras y vinagreras
+21|Soportes de apoyo para palillos chinos
+21|Soportes de vinagreras
+21|Soportes de vinagreras de metales preciosos
+21|Soportes de vinagreras que no sean de metales preciosos
+21|Soportes para cupcakes (magdalenas)
+21|Soportes para esponja de maquillaje
+21|Soportes para planchas de ropa
+21|Soportes tipo árbol para tazones
+21|Tablas de cortar pan
+21|Tablas de planchar
+21|Tablas de planchar (kotedai)
+21|Tablas para cortar
+21|Tablas para queso
+21|Tamices para ceniza (utensilios domésticos)
+21|Tamices y tamizadores de cocina
+21|Tapas ajustables para cubos y baldes
+21|Tapas de olla
+21|Tapas de plástico para tiestos
+21|Tapas para acuario
+21|Tapas para acuarios de interior
+21|Tapas para platillos de mantequilla y queso
+21|Tapas para tazas y vasos
+21|Tapetes para hornear
+21|Tapones de vidrio
+21|Tapones de vidrio para botellas
+21|Tarros de vidrio para conservar alimentos
+21|Tazas
+21|Tazas de aprendizaje para bebés y niños
+21|Tazas de café, tazas de té y jarros para beber
+21|Tazas de cartón
+21|Tazas de doble pared
+21|Tazas de mezclado
+21|Tazas de te (yunomi)
+21|Tazas de viaje
+21|Tazas para café
+21|Tazas que no sean de metales preciosos
+21|Tazas térmicas
+21|Tazas y jarros para beber
+21|Tazones de arroz japoneses (chawan)
+21|Tazones de arroz japoneses de metales preciosos (chawan)
+21|Tazones de arroz japoneses que no sean de metales preciosos (chawan)
+21|Tazones de metales preciosos
+21|Tazones de mezclado
+21|Tazones de vidrio para fruta
+21|Tazones para fruta
+21|Tendederos de ropa
+21|Tendederos para lavandería ajustables en altura para montar en el cielo
+21|Tendederos para lavandería para montar en la pared
+21|Tenedores para servir pasta
+21|Tensores para prendas de vestir
+21|Termos dispensadores de cocina que no sean de metales preciosos
+21|Terrarios de interior
+21|Terrarios de interior para animales o insectos
+21|Terrarios de interior para plantas
+21|Teteras (no eléctricas)
+21|Teteras de hierro japonesas, no eléctricas (tetsubin)
+21|Teteras de metales preciosos
+21|Teteras no eléctricas de silicona plegables
+21|Teteras que no sean de metales precisos
+21|Tinas para lavar la ropa
+21|Toalleros de aro y de barra
+21|Toalleros de aro y de barra que no sean de metales preciosos
+21|Trampas de planaria para acuarios
+21|Trampas para insectos
+21|Trampas para ratas (cepos)
+21|Trapos de limpieza
+21|Trapos para pulir
+21|Trituradoras de hielo no eléctricas
+21|Urnas en forma de jarrones
+21|Utensilios de cocina para hacer sushi accionados manualmente
+21|Vajillas
+21|Vajillas de vidrio
+21|Vaporeras de cocina no eléctricas
+21|Varillas rociadoras para mangueras de jardín
+21|Varillas y barras de vidrio que no sean para la construcción
+21|Vasijas y recipientes de terracota
+21|Vasos de papel
+21|Vasos de papel y de materias plásticas
+21|Vasos de trago
+21|Vasos de whisky
+21|Vasos para beber pilsen
+21|Vasos que no sean de metales preciosos
+21|Vasos y platillos
+21|Vidrio decorativo que no sea para la construcción
+21|Vidrio en bruto o semielaborado, que no sean para la construcción
+21|Vidrio laminado modificado (no para la construcción)
+21|Vidrio luminoso (no para construcción)
+21|Vidrio para ventanas de vehículos (sin acabar)
+21|Vidrio plano laminado que no sea para la construcción
+21|Vidrio semielaborado
+21|Vidrio semielaborado (excepto vidrio de construcción)
+21|Vidrio templado que no sea para construcción
+21|Vidrios de ventanas para automóviles sin acabar
+21|Vinagreras
+21|Vinagreras de metales preciosos
+21|Vinagreras que no sean de metales preciosos
+21|Viveros para hormigas
+21|Volteadores para barbacoa
+21|Woks no eléctricos

--- a/lib/seeds/class_22_terms.csv
+++ b/lib/seeds/class_22_terms.csv
@@ -1,128 +1,106 @@
-class,reference_id,name
-22,220001,lonas de ventilación
-22,220002,lonas*
-22,220002,lonas alquitranadas
-22,220002,lonas enceradas
-22,220003,cintas para atar las vides
-22,220004,virutas de madera
-22,220005,lana de madera
-22,220006,serrín
-22,220006,aserrín
-22,220007,borra [relleno]
-22,220007,relleno [borra]
-22,220008,seda en bruto
-22,220008,adúcar
-22,220009,redes de camuflaje*
-22,220010,materias textiles fibrosas en bruto
-22,220011,redes de pesca
-22,220012,pelo de camello
-22,220013,fibras de cáñamo
-22,220014,estopa
-22,220015,cinchas de cáñamo
-22,220016,borra de seda [relleno]
-22,220016,desperdicios de seda [relleno]
-22,220018,fibra de coco
-22,220019,capullos de gusanos de seda
-22,220020,cuerdas no metálicas
-22,220021,cuerdas*
-22,220022,cuerdas de látigos [trallas]
-22,220022,cuerdas de fusta
-22,220023,escalas de cuerda
-22,220025,algodón en bruto
-22,220026,estopa de algodón
-22,220027,crin de caballo*
-22,220028,plumón [plumas]
-22,220029,edredón [plumas]
-22,220030,materiales de relleno que no sean de caucho, materias plásticas, papel o cartón
-22,220030,materiales de acolchado que no sean de caucho, materias plásticas, papel o cartón
-22,220031,materiales de embalaje [relleno] que no sean de caucho, materias plásticas, papel o cartón
-22,220032,cordeles de embalaje
-22,220033,lana de relleno
-22,220033,lana de acolchado
-22,220033,lana de tapicería [acolchado]
-22,220035,cordeles
-22,220036,drizas
-22,220037,fibras de sílice vitrificada para uso textil
-22,220038,cordeles de papel
-22,220039,hilos de red
-22,220040,copos de seda
-22,220041,copos de lana
-22,220042,hilos no metálicos para agavillar
-22,220043,hamacas [redes]
-22,220044,hierbas de relleno
-22,220045,cintas de persianas venecianas
-22,220046,yute
-22,220047,kapoc [miraguano]
-22,220047,miraguano [kapoc]
-22,220048,lazos [trampas]
-22,220048,redes [trampas]
-22,220049,redecillas*
-22,220050,lana en bruto o tratada
-22,220051,lana cardada
-22,220052,lana peinada
-22,220054,líber
-22,220055,hilos encerados de zapatero
-22,220056,lino crudo [agramado]
-22,220056,lino en bruto [agramado]
-22,220057,plumas para accesorios de cama [relleno]
-22,220058,toldos de materiales textiles
-22,220059,velas de navegación
-22,220060,guata de filtrado
-22,220061,guata de relleno o acolchado [tapicería]
-22,220062,paja de relleno [tapicería]
-22,220064,plumas de relleno [tapicería]
-22,220065,crin*
-22,220065,pelo de animales
-22,220066,fibras de ramio
-22,220067,rafia
-22,220068,sacos de gran capacidad para transportar y almacenar productos a granel
-22,220069,bolsas [sobres, bolsitas] de materias textiles para empaquetar
-22,220069,sacos [sobres, bolsitas] de materias textiles para empaquetar
-22,220070,fibras de esparto
-22,220071,tiendas de campaña*
-22,220072,vellón [lana]
-22,220073,lana esquilada
-22,220074,algas marinas utilizadas como relleno
-22,220075,cubiertas no ajustables para vehículos
-22,220076,fibras textiles
-22,220077,sisal
-22,220078,cintas no metálicas para envolver o atar
-22,220079,hilos no metálicos para envolver o atar
-22,220080,embalajes de paja para botellas
-22,220080,envolturas de paja para botellas
-22,220080,fundas de paja para botellas
-22,220081,arneses no metálicos para manipular cargas
-22,220081,tirantes no metálicos para manipular cargas
-22,220082,correas no metálicas para manipular cargas
-22,220083,eslingas no metálicas para manipular cargas
-22,220084,cables no metálicos
-22,220085,lonas de camuflaje
-22,220086,ataduras no metálicas para uso agrícola
-22,220087,fibras de carbono para uso textil
-22,220088,cordones de ventana de guillotina
-22,220089,cordones para colgar cuadros
-22,220090,desperdicios de algodón [borra]
-22,220090,desechos de algodón [borra] [relleno y acolchado]
-22,220091,cuerdas de embalaje
-22,220092,fibras de materias plásticas para uso textil
-22,220093,fibras de vidrio para uso textil
-22,220094,redes*
-22,220101,pelusa de algodón
-22,220102,toldos de materiales sintéticos
-22,220103,cuerdas para remolcar vehículos
-22,220104,sacas postales
-22,220105,velas para el esquí de vela
-22,220106,bolsas de malla para lavar la ropa
-22,220107,bolsas para cadáveres
-22,220108,redes de cerco
-22,220109,corrales de red para la piscicultura
-22,220110,lonas para velas de navegación
-22,220111,persianas de exterior de materias textiles
-22,220112,ataduras no metálicas
-22,220112,ligaduras no metálicas
-22,220113,redes para alimentar animales
-22,220114,cerdas de cerdo*
-22,220115,sábanas guardapolvo
-22,220116,bolsas de tela especiales para guardar pañales
-22,220117,sacos de vivac tipo tienda
-22,220118,bolsas para la ropa sucia
+class|name
+22|Amarres plásticos de uso doméstico
+22|Amarres plásticos para uso en el jardín
+22|Bolsas de algodón para uso industrial
+22|Bolsas de fibra química para uso industrial
+22|Bolsas de materias textiles para embalar
+22|Bolsas de paja de arroz (tawara)
+22|Bolsas de yute para uso industrial
+22|Bolsas protectoras de tela para conservación de bolsos cuando no se usan
+22|Bramante de embalar
+22|Bramante para atar hecho de fibras textiles naturales
+22|Bramantes
+22|Cables no metálicos
+22|Capullos de gusanos de seda
+22|Cordaje
+22|Cordeles
+22|Cordones hechos de fibras textiles
+22|Corrales de red para la piscicultura
+22|Correas no metálicas para manipular cargas
+22|Crin
+22|Crin de caballo que no sea para uso textil ni para cepillos
+22|Cuerda
+22|Cuerdas
+22|Cuerdas de anclaje
+22|Cuerdas de montañismo
+22|Cuerdas de paja
+22|Cuerdas de pasamanos
+22|Cuerdas de remolque para automóviles
+22|Cuerdas elásticas
+22|Cuerdas para remolcar vehículos
+22|Cuerdas para uso marino
+22|Cuerdas y cuerdas sintéticas
+22|Edredón (plumas)
+22|Embalajes de paja para botellas
+22|Eslingas de carga hechas de tela
+22|Eslingas de carga no metálicas
+22|Fibra de cáñamo
+22|Fibra de cáñamo en bruto
+22|Fibra de carbón para uso textil
+22|Fibra de rafia (en bruto)
+22|Fibra de sisal en bruto
+22|Fibra de yute (en bruto)
+22|Fibras de algodón
+22|Fibras de cáñamo
+22|Fibras de lino en bruto
+22|Fibras de seda
+22|Fibras de sílice vitrificado para uso textil
+22|Fibras de textiles en bruto
+22|Fibras de vidrio para uso textil
+22|Fibras químicas para uso textil
+22|Fibras semisintéticas para uso textil
+22|Fibras sintéticas (de uso textil)
+22|Fibras sintéticas para uso textil
+22|Filamentos textiles
+22|Fundas no ajustables para embarcaciones y vehículos acuáticos
+22|Guata de algodón para futones
+22|Guata de algodón para prendas de vestir
+22|Hamacas (redes)
+22|Kapoc (miraguano)
+22|Lana (materia prima)
+22|Lana de madera (virutas de madera)
+22|Lonas
+22|Lonas impermeables para el suelo
+22|Lonas para barcos
+22|Lonas que no sean para barcos
+22|Lonas universales de materias plásticas
+22|Madejas de seda cruda
+22|Mantas de materias textiles para curar hormigón
+22|Material de embalaje hecho de arpillera para plantas
+22|Pelo áspero de animal
+22|Pelo de alpaca
+22|Pelo de angora
+22|Pelo de cabra de Angora
+22|Pelo de mapache (no para uso textil ni para cepillos)
+22|Plumas y plumones
+22|Plumones para material de relleno
+22|Recipientes de materias textiles para embalaje para uso industrial
+22|Redes de algodón
+22|Redes de camuflaje para la caza
+22|Redes de camuflaje para uso de radares
+22|Redes de camuflaje para uso visual
+22|Redes de cáñamo
+22|Redes de fibra de vidrio
+22|Redes de fibra química
+22|Redes de pesca
+22|Redes de pesca comerciales
+22|Redes de seda
+22|Redes para peces
+22|Redes que no sean metálicas ni de amianto
+22|Sacos para transportar y almacenar productos a granel
+22|Sogas hechas de cáñamo
+22|Tela para velas
+22|Telas de vinilo para el suelo
+22|Tiendas hechas de materias textiles
+22|Tiras para envolver o atar
+22|Toldos de lona alquitranada
+22|Toldos hechos de materiales recubiertos de plástico
+22|Trampas de red
+22|Velas de navegación
+22|Velas para catamaranes
+22|Velas para tablas de windsurf
+22|Velas para yates
+22|Vellón (lana)
+22|Virutas de madera
+22|Virutas de madera para relleno
+22|Yute

--- a/lib/seeds/class_23_terms.csv
+++ b/lib/seeds/class_23_terms.csv
@@ -1,23 +1,55 @@
-class,reference_id,name
-23,230001,hilos*
-23,230002,hilos de algodón
-23,230003,hilos para bordar
-23,230004,hilos de lana
-23,230005,hilos de cáñamo
-23,230006,hilos de coco
-23,230007,hilos de seda
-23,230008,algodón hilado
-23,230009,hilos de coser
-23,230010,hilados*
-23,230011,hilos de yute
-23,230012,lana hilada
-23,230013,hilos de lino
-23,230014,hilos de rayón
-23,230015,hilos de zurcir
-23,230016,seda hilada
-23,230017,hilos de fibra de vidrio para uso textil
-23,230018,hilos de caucho para uso textil
-23,230019,hilos elásticos para uso textil
-23,230020,hilos de materias plásticas para uso textil
-23,230031,hilos de felpilla
-23,230032,canutillos
+class|name
+23|Algodón para zurcir
+23|Fibras metálicas para uso textil
+23|Hilados
+23|Hilados de algodón
+23|Hilados e hilos termoestables
+23|Hilados hechos de seda
+23|Hilados para tejer a mano
+23|Hilo con base de algodón mezclado
+23|Hilo con base de cáñamo mezclado
+23|Hilo con base de fibra inorgánica mezclado
+23|Hilo con base de fibra química mezclado
+23|Hilo con base de lana mezclado
+23|Hilo con base de seda mezclado
+23|Hilo de algodón trenzado
+23|Hilo de angora
+23|Hilo de cáñamo trenzado
+23|Hilo de caucho para uso textil
+23|Hilo de fibra sintética
+23|Hilo de lana trenzado
+23|Hilo de lino
+23|Hilo de papel para uso textil
+23|Hilo de seda de la variedad dupioni
+23|Hilo de seda hilada a mano
+23|Hilo de seda silvestre
+23|Hilo de seda trenzado
+23|Hilo e hilado de cáñamo en bruto
+23|Hilo e hilado de fibra regenerada para uso textil
+23|Hilo e hilado de fibra semisintética (hilado de fibra natural químicamente tratado)
+23|Hilo e hilado recubierto de caucho para uso textil
+23|Hilo en bobinas
+23|Hilo mezclado trenzado
+23|Hilos de algodón
+23|Hilos de cachemira
+23|Hilos de cáñamo
+23|Hilos de coser
+23|Hilos de edredón
+23|Hilos de fibra de vidrio para uso textil
+23|Hilos de fibra química para uso textil
+23|Hilos de fibras de vidrio
+23|Hilos de hilados mixtos
+23|Hilos de lana
+23|Hilos de lino
+23|Hilos de ramio
+23|Hilos de seda
+23|Hilos de yute
+23|Hilos de zurcir
+23|Hilos e hilados de residuos desengrasados
+23|Hilos e hilados para zurcir
+23|Hilos para bordar
+23|Hilos para uso textil
+23|Hilos textiles
+23|Hilos trenzados
+23|Lanas para tejer a mano
+23|Residuos de hilo de algodón

--- a/lib/seeds/class_24_terms.csv
+++ b/lib/seeds/class_24_terms.csv
@@ -1,134 +1,176 @@
-class,reference_id,name
-24,240001,tejidos termoadhesivos
-24,240002,telas impermeables al gas para globos aerostáticos
-24,240003,tejidos que imitan la piel de animales
-24,240004,telas para tapizar muebles
-24,240004,tejidos para tapizar mobiliario
-24,240005,ropa de baño, excepto prendas de vestir
-24,240006,banderolas de materias textiles o de materias plásticas
-24,240007,tapetes de mesas de billar
-24,240007,paños para mesas de billar
-24,240008,tejidos*
-24,240009,estameña para cedazos
-24,240010,bucarán
-24,240011,brocados
-24,240012,materias textiles
-24,240013,telas*
-24,240015,cañamazo para tapicería o bordado
-24,240016,cañamazo [tela de cáñamo]
-24,240017,tejidos de cáñamo
-24,240018,tela de cáñamo
-24,240019,forros de sombrero
-24,240020,tejidos de forro para el calzado
-24,240021,tejidos para el calzado
-24,240022,caminos de mesa que no sean de papel
-24,240023,cheviot [tela]
-24,240025,hules [manteles]
-24,240026,terciopelo
-24,240027,fieltro*
-24,240028,tejidos de algodón
-24,240029,colchas
-24,240029,cobertores
-24,240029,cubrecamas
-24,240029,cubrecamas acolchados
-24,240029,cubrepiés
-24,240030,fundas de colchón
-24,240031,dril
-24,240031,terliz
-24,240032,colchas de papel para camas
-24,240033,manteles que no sean de papel
-24,240033,tapetes de mesa que no sean de papel
-24,240034,mantas de viaje
-24,240035,crepé [tejido]
-24,240036,crespón
-24,240037,damasco [tejido]
-24,240038,tejidos para lencería
-24,240039,forros y entretelas
-24,240040,sábanas*
-24,240041,sudarios
-24,240042,banderas de materias textiles o plásticas
-24,240043,banderines de materias textiles o plásticas
-24,240044,droguete
-24,240045,edredones [cobertores de plumas]
-24,240046,tejidos elásticos
-24,240047,alzapaños de materias textiles para cortinas
-24,240048,paños para secar vasos
-24,240049,telas con motivos impresos para bordar
-24,240050,franela [tela]
-24,240052,frisa [tela]
-24,240053,telas para hacer queso
-24,240054,bombasí
-24,240054,fustán
-24,240055,guantes de aseo personal
-24,240056,gasa [tela]
-24,240057,telas engomadas que no sean artículos de papelería
-24,240058,crinolina
-24,240058,tela de pelo animal
-24,240059,fundas para muebles
-24,240060,tejidos de seda para patrones de imprenta
-24,240061,indiana [tela]
-24,240062,jersey [tejido]
-24,240063,tejidos de yute
-24,240064,tejidos de lana
-24,240064,telas de lana
-24,240067,tejidos de lino
-24,240068,ropa de cama
-24,240069,telas adamascadas
-24,240070,ropa de mesa que no sea de papel
-24,240071,ropa de hogar
-24,240072,toallas de materias textiles
-24,240073,marabú [tela]
-24,240074,cutí [tela de colchón]
-24,240074,tela de colchón [cutí]
-24,240075,revestimientos de materias plásticas para muebles
-24,240076,servilletas de materias textiles
-24,240077,molesquín [tejido]
-24,240078,pañuelos de bolsillo de materias textiles
-24,240079,mosquiteros [colgaduras]
-24,240080,fundas de almohada
-24,240081,materias plásticas [sucedáneos de tejidos]
-24,240082,antepuertas [cortinas]
-24,240082,cortinas de puerta
-24,240083,tejidos de ramio
-24,240084,tejidos de rayón
-24,240085,cortinas de materias textiles o plásticas
-24,240087,toallitas de tocador de materias textiles para la cara
-24,240088,tejidos de seda
-24,240089,tul
-24,240090,tejidos de esparto
-24,240091,tafetán [tejido]
-24,240092,tejidos de punto
-24,240093,visillos
-24,240094,céfiro [tejido]
-24,240095,calicó
-24,240096,posabotellas y posavasos de materias textiles
-24,240097,salvamanteles de materias textiles
-24,240098,materias textiles no tejidas
-24,240100,sábanas para sacos de dormir
-24,240101,toallitas para desmaquillar
-24,240102,etiquetas de materias textiles
-24,240103,tapizados murales de materias textiles
-24,240104,tejidos de fibra de vidrio para uso textil
-24,240105,materias textiles filtrantes
-24,240106,mantillas de imprenta de materias textiles
-24,240111,tejidos de felpilla
-24,240112,fundas decorativas para almohadones de cama
-24,240113,manteles individuales de materias textiles
-24,240114,mantas de cama
-24,240114,cobijas de cama
-24,240115,fundas de cojín
-24,240115,fundas de almohadón
-24,240116,tejidos para uso textil
-24,240117,revestimientos de materias textiles para muebles
-24,240118,fundas para tapas de inodoro
-24,240119,cortinas de ducha de materias textiles o plásticas
-24,240120,cambiadores de tela para bebés
-24,240121,mantas para animales de compañía
-24,240122,sacos de dormir para bebés
-24,240123,nanas [ropa de cama]
-24,240124,sacos de dormir
-24,240125,faldones de cama
-24,240126,protectores de cuna [ropa de cama]
-24,240127,muselina [tejido]
-24,240128,fundas de vivac para sacos de dormir
-24,240129,mantas de picnic
+class|name
+24|Arpillera
+24|Banderas con brocado
+24|Banderas de plástico
+24|Banderas de tela
+24|Banderines y banderas de materias textiles
+24|Bayetas de baño
+24|Blondas de tela
+24|Caminos de mesa de materiales plásticos
+24|Cañamazo para tapicería o bordado
+24|Cenefas de tela
+24|Cobertores
+24|Cobertores (edredones)
+24|Cobertores de felpa
+24|Cobertores de materias textiles
+24|Colchas
+24|Colchas de felpa
+24|Cortinajes
+24|Cortinajes (telones tupidos)
+24|Cortinas
+24|Cortinas de baño
+24|Cortinas de ducha
+24|Cortinas de materias plásticas
+24|Cortinas de materias textiles
+24|Cortinas de materias textiles o plásticas
+24|Cortinas de vinilo
+24|Cortinas para exteriores e interiores
+24|Cubiertas de edredón
+24|Cubrecamas (mantas)
+24|Cubrecolchones
+24|Doseles de cama
+24|Edredones
+24|Edredones (cubrecamas acolchados)
+24|Edredones de punto
+24|Edredones de tela de toalla
+24|Edredones para futones
+24|Edredones rellenos de seda
+24|Etiquetas de materiales textiles para identificación de prendas de vestir
+24|Etiquetas de materias textiles
+24|Etiquetas de tela
+24|Etiquetas textiles impresas
+24|Faldones de cama
+24|Fibras de poliéster para uso textil
+24|Fieltro de prensa
+24|Fieltro tejido
+24|Fieltro y telas textiles no tejidas
+24|Fieltros
+24|Filtros de sonido hechos de paño, para aparatos de radio
+24|Forros adaptados para canastas metálicas
+24|Forros de tela para calzado
+24|Fundas de almohada
+24|Fundas de cojín
+24|Fundas de edredón
+24|Fundas para cojines
+24|Fundas para colchones ajustables
+24|Guantes de baño
+24|Mantas
+24|Mantas de lana
+24|Mantas de regazo
+24|Mantas de seda
+24|Mantas de viaje
+24|Mantas para bebés
+24|Mantas para el regazo
+24|Mantas para niños
+24|Mantas para uso en exteriores
+24|Manteles de materias textiles
+24|Manteles individuales de materias textiles
+24|Manteles individuales que no sean de papel
+24|Manteles que no sean de papel
+24|Materiales textiles sucedáneos hechos de materias sintéticas
+24|Materias textiles
+24|Materias textiles no tejidas
+24|Materias textiles tejidas que imitan pieles de animales
+24|Molesquín
+24|Mosquiteros (colgaduras)
+24|Paño para mesas de billar (fieltro)
+24|Pañuelos de bolsillo de materias textiles
+24|Posavasos textiles
+24|Redes contra mosquitos tratadas con insecticida
+24|Revestimientos de materias plásticas para muebles
+24|Ropa blanca para uso doméstico, incluidas la toallitas de tocador
+24|Ropa de baño
+24|Ropa de cama
+24|Ropa de cama y mesa
+24|Ropa de cama y ropa de mesa
+24|Ropa de mesa
+24|Ropa de mesa de materias textiles
+24|Ropa de mesa que no sea de papel
+24|Ropa de mesa y cama
+24|Sábanas
+24|Sábanas ajustables
+24|Sábanas de cama de plástico ( que no sean sábanas de incontinencia)
+24|Sabanas de cuna
+24|Servilletas de materias textiles
+24|Tapetes de mesa de encaje que no sean de papel
+24|Tapizados de materias textiles
+24|Tapizados murales de materias textiles
+24|Tejido de fibra semisintética
+24|Tejido de gasa
+24|Tejido de seda hilado a mano
+24|Tejidos adhesivos termo-activados
+24|Tejidos con base de algodón mezclado
+24|Tejidos con base de cáñamo mezclado
+24|Tejidos con base de lana mezclado
+24|Tejidos de fibra de vidrio para uso textil
+24|Tejidos de fibra química
+24|Tejidos de fibra sintética
+24|Tejidos de hilo de cáñamo
+24|Tejidos de lana
+24|Tejidos de lana hilada
+24|Tejidos de lino
+24|Tejidos de pelo
+24|Tejidos de punto
+24|Tejidos de punto de hilo de algodón
+24|Tejidos de punto de hilo de fibra química
+24|Tejidos de punto de hilo de lana
+24|Tejidos de punto de hilo de seda
+24|Tejidos de punto para vestir
+24|Tejidos de ramio
+24|Tejidos de residuos de algodón
+24|Tejidos de seda
+24|Tejidos de viscosa
+24|Tejidos de yute
+24|Tejidos elásticos mezclados
+24|Tejidos elásticos para ropa de vestir
+24|Tejidos estrechos
+24|Tejidos mezclados con una base de seda
+24|Tejidos mezclados de cáñamo y algodón
+24|Tejidos mezclados de cáñamo y lana
+24|Tejidos mezclados de cáñamo y seda
+24|Tejidos para decoración de interiores
+24|Tejidos para lencería
+24|Tejidos para uso textil
+24|Tejidos textiles para lencería
+24|Tela ahulada
+24|Tela de lana
+24|Tela vaquera
+24|Telas ahuladas
+24|Telas con motivos impresos para bordar
+24|Telas de algodón
+24|Telas de fibra mixta
+24|Telas de hilo de caucho recubierto para uso textil
+24|Telas de hilo de fibra regenerada
+24|Telas de lino
+24|Telas de mezcla de fibra inorgánica
+24|Telas de mezcla de lana y algodón
+24|Telas de mezcla de seda y algodón
+24|Telas de mezcla de seda y lana
+24|Telas de pana
+24|Telas de seda de hilado
+24|Telas de tapicería
+24|Telas impermeables engomadas
+24|Telas pre-cortadas para costura
+24|Telas tejidas de malla
+24|Terciopelo
+24|Textiles de satén
+24|Textiles de tapicería
+24|Textiles para impresión digital
+24|Textiles utilizados como forro para prendas de vestir
+24|Textiles y fieltros no tejidos
+24|Toalla turca
+24|Toallas (textiles) para su uso en la cocina
+24|Toallas de algodón japonesas (tenugui)
+24|Toallas de baño
+24|Toallas de cara de materias textiles
+24|Toallas de felpa
+24|Toallas de golf
+24|Toallas de manos
+24|Toallas de materias textiles
+24|Toallas de materias textiles para manos
+24|Toallas de playa
+24|Toallas grandes para baño
+24|Toallas para niños
+24|Toallas tipo turbante para secar el cabello
+24|Toallitas faciales
+24|Visillos

--- a/lib/seeds/class_25_terms.csv
+++ b/lib/seeds/class_25_terms.csv
@@ -1,227 +1,521 @@
-class,reference_id,name
-25,250001,antideslizantes para el calzado
-25,250002,ropa para automovilistas
-25,250003,calzado*
-25,250004,sandalias de baño
-25,250005,zapatillas de baño
-25,250005,pantuflas de baño
-25,250006,medias*
-25,250007,medias absorbentes del sudor
-25,250008,refuerzos de talón para medias
-25,250009,boinas
-25,250010,batas [guardapolvos]
-25,250010,guardapolvos [batas]
-25,250011,boas [bufandas]
-25,250012,gorras
-25,250013,prendas de calcetería
-25,250013,prendas de mediería
-25,250014,botas*
-25,250015,botas de media caña
-25,250016,punteras de calzado
-25,250017,sobaqueras
-25,250018,tirantes*
-25,250018,tiradores [prendas de vestir]
-25,250019,borceguís
-25,250019,botas con cordones
-25,250020,cuellos
-25,250021,cubrecuellos
-25,250021,chalinas
-25,250021,bragas para el cuello
-25,250022,cubrecorsés
-25,250023,calzoncillos bóxer
-25,250024,solideos
-25,250025,camisolas
-25,250026,ropa interior
-25,250026,lencería
-25,250027,capuchas
-25,250028,armaduras de sombreros
-25,250030,viseras para gorras
-25,250031,cinturones [prendas de vestir]
-25,250032,chales
-25,250033,batas [saltos de cama]
-25,250033,batines
-25,250033,saltos de cama
-25,250034,suéteres
-25,250035,casullas
-25,250036,calcetines*
-25,250036,soquetes [calcetines]
-25,250037,ligas para calcetines
-25,250038,ligas [ropa interior]
-25,250039,ligueros
-25,250039,portaligas
-25,250040,cañas de botas
-25,250041,plantillas*
-25,250042,camisas*
-25,250043,pecheras de camisa
-25,250044,camisas de manga corta
-25,250045,prendas de vestir*
-25,250045,ropa*
-25,250045,vestimenta
-25,250046,sombreros
-25,250048,herrajes para el calzado
-25,250049,pieles [prendas de vestir]
-25,250050,cuellos postizos
-25,250051,pantis
-25,250052,trajes de esquí acuático
-25,250053,conjuntos de vestir
-25,250054,ropa interior absorbente del sudor
-25,250055,corseletes
-25,250056,trajes*
-25,250057,ropa de confección
-25,250058,bragas para bebés
-25,250058,blúmers para bebés
-25,250058,bombachas para bebés
-25,250058,calzones para bebés
-25,250058,pantaletas para bebés
-25,250059,orejeras [prendas de vestir]
-25,250060,corbatas
-25,250061,palas de calzado
-25,250062,polainas
-25,250063,pantalones bombachos
-25,250064,pantalones
-25,250065,ropa para ciclistas
-25,250066,ropa exterior
-25,250067,guantes [prendas de vestir]
-25,250068,forros confeccionados [partes de prendas de vestir]
-25,250069,fulares*
-25,250069,bufandas
-25,250070,fajines
-25,250071,prendas de punto
-25,250072,canesúes de camisa
-25,250073,alpargatas
-25,250074,estolas [pieles]
-25,250075,botas de fútbol
-25,250075,botines de fútbol
-25,250076,sombreros de copa
-25,250077,gabardinas [prendas de vestir]
-25,250078,corsés [ropa interior]
-25,250079,fajas [ropa interior]
-25,250080,galochas
-25,250080,chanclos
-25,250082,chalecos
-25,250083,trabillas de polainas
-25,250084,tocas [prendas de vestir]
-25,250085,zapatillas de gimnasia
-25,250086,abrigos
-25,250086,tapados
-25,250087,prendas de vestir impermeables
-25,250087,impermeables
-25,250088,calentadores de piernas
-25,250089,jerseys [prendas de vestir]
-25,250090,faldas
-25,250090,polleras
-25,250092,ajuares de ropa para bebés
-25,250093,libreas
-25,250094,camisetas de deporte
-25,250095,puños [prendas de vestir]
-25,250096,delantales [prendas de vestir]
-25,250097,manguitos [prendas de vestir]
-25,250098,manípulos [ropa litúrgica]
-25,250099,mitones
-25,250100,mitras [ropa litúrgica]
-25,250101,pantuflas
-25,250101,escarpines
-25,250101,patucos
-25,250101,zapatillas de interior
-25,250102,pelerinas
-25,250103,pellizas
-25,250104,ropa de playa
-25,250105,calzado de playa
-25,250106,bolsillos de prendas de vestir
-25,250108,pijamas
-25,250109,vestidos
-25,250110,zuecos [calzado]
-25,250111,sandalias
-25,250112,slips
-25,250114,sostenes
-25,250114,ajustadores [ropa interior]
-25,250114,corpiños [ropa interior]
-25,250114,sujetadores [ropa interior]
-25,250115,gabanes
-25,250115,paletós
-25,250115,sobretodos
-25,250116,alzas de talón para el calzado
-25,250117,togas
-25,250118,viras de calzado
-25,250119,uniformes
-25,250120,chaquetones
-25,250121,chaquetas
-25,250122,ropa de papel
-25,250123,velos
-25,250124,gorros de baño
-25,250125,calzones de baño
-25,250125,shorts de baño
-25,250126,trajes de baño [bañadores]
-25,250126,bañadores
-25,250126,mallas [bañadores]
-25,250127,albornoces
-25,250127,salidas de baño
-25,250128,baberos que no sean de papel
-25,250128,babadores que no sean de papel
-25,250129,suelas de calzado
-25,250130,zapatos
-25,250131,tacones
-25,250132,zapatillas de deporte
-25,250133,folgos que no estén calentados eléctricamente
-25,250134,tacos para botas de fútbol
-25,250134,tapones para botines de fútbol
-25,250141,botas de deporte
-25,250142,bandas para la cabeza [prendas de vestir]
-25,250143,parkas
-25,250144,enaguas
-25,250145,botas de esquí
-25,250146,combinaciones [ropa interior]
-25,250147,bodis [ropa interior]
-25,250148,bandanas [pañuelos para el cuello]
-25,250149,ropa de gimnasia
-25,250150,ropa de cuero de imitación
-25,250151,ropa de cuero
-25,250152,mantillas
-25,250153,trajes de disfraces
-25,250154,saris
-25,250155,camisetas
-25,250156,turbantes
-25,250157,pañuelos de cuello de hombre
-25,250158,gorros de ducha
-25,250159,chaquetas de pescador
-25,250160,cinturones monedero [prendas de vestir]
-25,250161,pañuelos de bolsillo [prendas de vestir]
-25,250162,sombreros de papel [prendas de vestir]
-25,250163,antifaces para dormir
-25,250164,faldas short
-25,250165,ponchos
-25,250166,sarongs [pareos]
-25,250166,pareos
-25,250167,guantes de esquí
-25,250168,mallas [leggings]
-25,250168,calzas [leggings]
-25,250168,leggings [pantalones]
-25,250169,pichis
-25,250170,viseras en cuanto artículos de sombrerería
-25,250171,bragas*
-25,250171,pantaletas*
-25,250171,blúmers*
-25,250171,bombachas*
-25,250172,camisetas de deporte sin mangas
-25,250173,valenki [botas de fieltro]
-25,250174,albas
-25,250175,botines
-25,250176,calcetines absorbentes del sudor
-25,250177,capas de peluquería
-25,250178,uniformes de karate
-25,250179,uniformes de judo
-25,250180,leotardos
-25,250181,kimonos
-25,250182,baberos con mangas que no sean de papel
-25,250183,prendas de vestir que contienen sustancias adelgazantes
-25,250184,prendas de vestir bordadas
-25,250185,protectores de tacón para zapatos
-25,250186,artículos de sombrerería
-25,250187,manoplas*
-25,250188,ropa de látex
-25,250189,camisetas de protección [rashguards]
-25,250190,ropa con LED incorporado
-25,250191,pañuelos para la cabeza
-25,250192,sujetadores adhesivos
-25,250192,sostenes adhesivos
-25,250193,polainas bajas
+class|name
+25|Abrigo de mezclilla
+25|Abrigos coreanos (durumagi)
+25|Abrigos de algodón
+25|Abrigos de cuero
+25|Abrigos de lona
+25|Abrigos para hombres y mujeres
+25|Abrigos y chaquetas de piel
+25|Albornoces con capucha
+25|Alpargatas
+25|Anoraks (parkas)
+25|Antifaces para dormir
+25|Artículos de sombrerería
+25|Artículos de sombrerería de cuero
+25|Artículos de sombrerería para niños
+25|Atuendo básico superior tradicional coreano (vestimenta) (jeogori)
+25|Baberos de tela
+25|Bañador (pantalón corto)
+25|Bandanas
+25|Bandas antisudor
+25|Bandas de sujeción para fajas de kimono (obiage)
+25|Bandas faja para quimonos (obi)
+25|Bandas para la cabeza
+25|Bandas para la cabeza como prenda de vestir
+25|Bandas para la cabeza contra el sudor
+25|Batas
+25|Batas con capucha
+25|Batas de dormir japonesas (nemaki)
+25|Batas para hombre
+25|Batas y batas de baño
+25|Bikinis
+25|Blazers
+25|Blusas
+25|Blusas sin mangas
+25|Blusones
+25|Bodys para infantes y niños pequeños
+25|Boinas escocesas
+25|Boleros
+25|Bolsillos de prendas de vestir
+25|Botas de descanso para después de esquiar
+25|Botas de equitación
+25|Botas de fútbol
+25|Botas de fútbol y sus tacos
+25|Botas de gimnasio
+25|Botas de invierno
+25|Botas de lluvia
+25|Botas de montaña (botas de montañismo)
+25|Botas de montañismo
+25|Botas de motociclista
+25|Botas japonesas de trabajo con separación para el dedo gordo (jikatabi)
+25|Botas militares
+25|Botas para damas
+25|Botas para deporte
+25|Botas para la nieve
+25|Botas para motociclista
+25|Botines
+25|Botines de fútbol
+25|Boxers (calzoncillos)
+25|Bragas
+25|Bufandas
+25|Bufandas de seda
+25|Burkas (vestimenta)
+25|Buzos (vestimenta)
+25|Caftanes
+25|Calcetines
+25|Calcetines antitranspirantes
+25|Calcetines de dedos
+25|Calcetines de lana
+25|Calcetines estilo japonés (tabi)
+25|Calcetines para hombres
+25|Calcetines para yoga
+25|Calcetines y medias
+25|Calzado
+25|Calzado con cierre de gancho y rizo
+25|Calzado de madera
+25|Calzado de playa
+25|Calzado excepto calzado ortopédico
+25|Calzado hecho de vinilo
+25|Calzado japonés de paja de arroz (waraji)
+25|Calzado para atletismo de pista y campo
+25|Calzado para caballeros
+25|Calzado para hombres y mujeres
+25|Calzado para mujeres
+25|Calzado que no sea para deportes
+25|Calzas y polainas
+25|Calzoncillos
+25|Calzoncillos térmicos
+25|Calzones
+25|Calzones, shorts y calzoncillos
+25|Camisas
+25|Camisas con botones
+25|Camisas con cuello
+25|Camisas de barbero
+25|Camisas de cuello abierto
+25|Camisas de deporte
+25|Camisas de deporte con mangas cortas
+25|Camisas de dormir
+25|Camisas de golf
+25|Camisas de manga larga
+25|Camisas de pana
+25|Camisas de punto
+25|Camisas de ramio
+25|Camisas de vestir
+25|Camisas hawaianas con botones
+25|Camisas manga corta
+25|Camisas para trajes
+25|Camisas tipo polo
+25|Camisas y camisas de manga corta
+25|Camisas y pantalones cortos a juego (lencería)
+25|Camisas-chaqueta
+25|Camisetas
+25|Camisetas de deporte transpirables
+25|Camisetas de manga corta o larga
+25|Camisetas de punto
+25|Camisetas de rugby
+25|Camisetas de yoga
+25|Camisetas interiores de manga larga
+25|Camisetas interiores para quimonos (juban)
+25|Camisetas interiores para quimonos (koshimaki)
+25|Camisetas ombligueras
+25|Camisolas interiores
+25|Camisolines
+25|Camisones
+25|Canguros (suéteres con capucha)
+25|Capas
+25|Capas impermeables (vestuario)
+25|Capuchas
+25|Casullas
+25|Cazadoras tipo bomber (chaquetas)
+25|Chadors (vestimenta)
+25|Chalecos cortaviento
+25|Chalecos de deporte
+25|Chalecos de mujer tradicionales coreanos (baeja)
+25|Chalecos resistentes al viento
+25|Chales de punto
+25|Chales y estolas
+25|Chales y pañuelos de cabeza
+25|Chaqués
+25|Chaqueta de plumón
+25|Chaquetas
+25|Chaquetas acolchadas (prendas de vestir)
+25|Chaquetas con o sin mangas
+25|Chaquetas coreanas (magoja)
+25|Chaquetas cortaviento
+25|Chaquetas de cuero
+25|Chaquetas de deporte
+25|Chaquetas de esquí
+25|Chaquetas de forro polar
+25|Chaquetas de motociclista
+25|Chaquetas de pescador
+25|Chaquetas de plumas
+25|Chaquetas de punto
+25|Chaquetas impermeables
+25|Chaquetas largas
+25|Chaquetas para esquí en tabla
+25|Chaquetas rompevientos
+25|Chaquetas vaqueras
+25|Chaquetas y calcetines
+25|Chaquetas, abrigos, pantalones y chalecos de caballero y de señora
+25|Chaquetones
+25|Chubasqueros (cortavientos)
+25|Cintas para absorber el sudor de la frente
+25|Cintas para el sudor
+25|Cinturones
+25|Cinturones (prendas de vestir)
+25|Cinturones de cuero
+25|Cinturones de cuero (prendas de vestir)
+25|Cinturones de cuero de imitación
+25|Cinturones de materias textiles
+25|Cinturones de tela
+25|Cinturones para envolver para quimonos (datemaki)
+25|Conjunto de dos piezas (twin sets)
+25|Corbatas
+25|Corbatas (prendas de vestir)
+25|Corbatas de cordón
+25|Corpiños
+25|Correas de dedo para zuecos de madera de estilo japonés
+25|Correas de pantalón
+25|Corsé (vestidos, prendas de corsetería)
+25|Corsés
+25|Corsés (prendas de corsetería)
+25|Cortavientos
+25|Cubrezapatos
+25|Cuellos
+25|Cuellos separables para kimonos (haneri)
+25|Cuerdas de ajuste para quimonos (datejime)
+25|Cuerdas de cintura para quimonos (koshihimo)
+25|Delantales desechables
+25|Disfraces para Halloween (víspera de Todos los Santos)
+25|Empeines de ratán tejido para sandalias de estilo japonés
+25|Empeines de sandalias de estilo japonés
+25|Enaguas cortas
+25|Enteritos
+25|Esmóquines
+25|Estolas
+25|Estructura de madera para zuecos de estilo japonés
+25|Fajas (ropa interior)
+25|Fajas de esmóquines
+25|Fajas para nudos obi (obiage-shin)
+25|Faldas escocesas
+25|Faldas pantalón
+25|Faldas plisadas
+25|Faldas plisadas para quimonos formales (hakama)
+25|Faldas y vestidos
+25|Fezes (gorros tradicionales de origen turco)
+25|Gabán corto para quimono (haori)
+25|Gabanes
+25|Gabardinas
+25|Gabardinas trench
+25|Gorras de béisbol
+25|Gorras de golf
+25|Gorras de punto
+25|Gorras de visera
+25|Gorras militares
+25|Gorras para ciclistas
+25|Gorras y sombreros de béisbol
+25|Gorras y sombreros de deporte
+25|Gorros
+25|Gorros (sombrerería)
+25|Gorros de baño
+25|Gorros de dormir
+25|Gorros de ducha
+25|Gorros tipo pescador
+25|Guantes como prenda de vestir
+25|Guantes con yemas conductoras que pueden ser usados para manipular aparatos electrónicos con pantallas táctiles
+25|Guantes de manejo
+25|Guantes de motociclista
+25|Guantes de punto
+25|Guantes de snowboard
+25|Guantes sin dedos
+25|Herrajes metálicos para zuecos estilo japonés
+25|Indumentaria de aikido
+25|Jerséis de manga larga
+25|Jerséis deportivos y pantalones para el deporte
+25|Jerséis sin manga
+25|Jerséis sin mangas
+25|Juegos de top y culote (ropa)
+25|Kimonos
+25|Lencería
+25|Leotardos
+25|Leotardos y pantis de nylon, algodón u otras materias textiles para mujeres, hombres y niños
+25|Ligas para calcetines
+25|Ligueros
+25|Ligueros de caballero
+25|Ligueros nupciales
+25|Ligueros para señora
+25|Maillots
+25|Mallas (bodys)
+25|Mallas atléticas
+25|Mallas con tirantes
+25|Mañanitas
+25|Manguitos de piel
+25|Mantos
+25|Medias
+25|Medias (absorbentes de la transpiración)
+25|Medias de cuerpo entero
+25|Medias de deporte
+25|Minifaldas
+25|Mocasines
+25|Monokinis
+25|Monos cortos (ropa)
+25|Mukluks (botas de piel)
+25|Nicabs (velos faciales)
+25|Orejeras como prenda de vestir
+25|Overoles
+25|Overoles de trabajo
+25|Pajaritas
+25|Pañoletas
+25|Pantalón bermudas
+25|Pantalones bombachos tipo golf
+25|Pantalones cortos de baño
+25|Pantalones cortos de boxeo
+25|Pantalones cortos de chándal
+25|Pantalones cortos de gimnasia
+25|Pantalones cortos tipo chándal
+25|Pantalones de chándal
+25|Pantalones de chándal tipo sudadera
+25|Pantalones de cuero
+25|Pantalones de esquí
+25|Pantalones de golf
+25|Pantalones de jogging
+25|Pantalones de lluvia
+25|Pantalones de mezclilla
+25|Pantalones de montar
+25|Pantalones de niños
+25|Pantalones de pana
+25|Pantalones de pista
+25|Pantalones de sudadera
+25|Pantalones de vestir
+25|Pantalones de yoga
+25|Pantalones largos
+25|Pantalones para ciclistas
+25|Pantalones para esquí en tabla
+25|Pantalones tipo pescador
+25|Pantalones vaqueros
+25|Pantalones y chaquetas impermeables
+25|Pantalones, camisas y faldas para golf
+25|Pantimedia
+25|Pantis
+25|Pantis de lana
+25|Pantuflas
+25|Pantuflas de cuero
+25|Pantuflas de gomaespuma para pedicura
+25|Pantuflas desechables
+25|Pañuelos cuadrados para la cabeza
+25|Pañuelos de cuello
+25|Pareos
+25|Pareos de baño
+25|Parkas
+25|Pasamontañas
+25|Pelerinas
+25|Pellizas
+25|Petos de entrenamiento
+25|Piezas de tacón para zapatos
+25|Pijamas
+25|Pijamas de punto
+25|Plantillas
+25|Plantillas para calzado
+25|Plantillas para zapatos y botas
+25|Polainas
+25|Polainas (prendas de vestir)
+25|Polerones
+25|Polerones de cuello subido
+25|Polos
+25|Polos de punto
+25|Ponchos
+25|Prendas de calcetería
+25|Prendas de vestir para jugar a tenis
+25|Prendas de vestir para la práctica del judo
+25|Prendas de vestir para niños pequeños
+25|Prendas de vestir, a saber, camisas
+25|Prendas inferiores (ropa)
+25|Prendas para cubrir trajes de baño
+25|Pretinas
+25|Pulóveres
+25|Puños (prendas de vestir)
+25|Punteras de calzado
+25|Quimonos largos (nagagi)
+25|Rebecas
+25|Rompevientos
+25|Rompevientos (ropa)
+25|Ropa de bebé para la parte superior del cuerpo
+25|Ropa de dormir
+25|Ropa de playa
+25|Ropa impermeable
+25|Ropa interior
+25|Ropa interior absorbente de transpiración
+25|Ropa interior de punto
+25|Ropa interior modeladora
+25|Ropa interior para damas
+25|Ropa interior para mujeres
+25|Ropa interior tejida o de punto
+25|Ropa interior térmica
+25|Ropa para correr
+25|Ropa para hacer footing
+25|Ropa para la lluvia
+25|Ropa para ski
+25|Salidas de baño
+25|Sandalias de baño
+25|Sandalias de cuero estilo japonés
+25|Sandalias de estilo japonés (zori)
+25|Sandalias de fieltro estilo japonés
+25|Sandalias japonesas de correa de dedo (asaura-zori)
+25|Sandalias y zapatos de playa
+25|Sarapes
+25|Saris
+25|Sarongs (pareos)
+25|Shorts
+25|Shorts de rugby
+25|Shorts de surf
+25|Slips
+25|Sobaqueras
+25|Sobrepantalones
+25|Sobretodos
+25|Soleras (prendas de vestir)
+25|Solideos
+25|Sombreros
+25|Sombreros cloché
+25|Sombreros de ala ancha
+25|Sombreros de copa
+25|Sombreros de fiesta (vestimenta)
+25|Sombreros de juncia (sugegasa)
+25|Sombreros de lana
+25|Sombreros de lluvia
+25|Sombreros de papel para su uso como prendas de vestir
+25|Sombreros de piel
+25|Sombreros de playa
+25|Sombreros pequeños
+25|Soquetes (calcetines)
+25|Sostenes
+25|Sostenes deportivos
+25|Sostenes sin tirantes
+25|Sotanas
+25|Sudaderas
+25|Sudaderas con capucha
+25|Sudarios de lino (vestimenta)
+25|Suecos
+25|Suelas (internas)
+25|Suelas de caucho para botas japonesas jikatabi
+25|Suelas de zapatillas
+25|Suelas para reparación de zapatos
+25|Suelas para sandalias estilo japonés
+25|Suelas para zapatos
+25|Suéteres
+25|Suéteres con cuello en V
+25|Suéteres de cuello redondo
+25|Sujeciones de cuerda para haoris (haori-himo)
+25|Sujeciones de madera para zuecos de madera de estilo japonés
+25|Sujetadores sin aros (ropa interior)
+25|Tacos para botas de fútbol
+25|Tangas
+25|Tankinis
+25|Tapados (vestimenta)
+25|Tirantes (suspensores)
+25|Tocas (prendas de vestir)
+25|Tops (prendas de vestir)
+25|Tops tipo tubo
+25|Trabillas de pie para pantalones
+25|Trajes chaqueta
+25|Trajes de baile
+25|Trajes de baño
+25|Trajes de baño (bañadores)
+25|Trajes de baño con copas de sostén
+25|Trajes de baño para caballero y señora
+25|Trajes de baño para hombre
+25|Trajes de baño para mujeres
+25|Trajes de calentamiento
+25|Trajes de chándal
+25|Trajes de chaqueta informales
+25|Trajes de cuero
+25|Trajes de entrenamiento
+25|Trajes de esquí
+25|Trajes de esquí para competencia
+25|Trajes de falda
+25|Trajes de judo
+25|Trajes de karate
+25|Trajes de kendo
+25|Trajes de lluvia
+25|Trajes de marinero
+25|Trajes de neopreno para esquí acuático
+25|Trajes de neopreno para surf
+25|Trajes de pista
+25|Trajes de plumas
+25|Trajes de taekwondo
+25|Trajes de una pieza
+25|Trajes de vestir
+25|Trajes para dama
+25|Trajes para el baño
+25|Trajes para hombres
+25|Trajes para hombres y trajes para mujeres
+25|Trajes para nieve
+25|Trajes para skí en tabla
+25|Trajes para usar en juegos de rol
+25|Trencas
+25|Uniformes de béisbol
+25|Uniformes de deportes
+25|Uniformes deportivos
+25|Uniformes escolares
+25|Uniformes para deportes de combate
+25|Vestidos
+25|Vestidos de boda
+25|Vestidos de ceremonia para mujeres
+25|Vestidos de cocktail
+25|Vestidos de noche
+25|Vestidos de tenis
+25|Vestidos hechos de pieles
+25|Vestidos para damas de honor
+25|Vestimenta (tops) para yoga
+25|Vestuario para juegos de lucha libre
+25|Viseras (artículos de sombrerería)
+25|Zapatillas de ballet
+25|Zapatillas de baloncesto
+25|Zapatillas de clavos
+25|Zapatillas de tenis
+25|Zapatillas plegables de señora para estar por casa
+25|Zapatos de alpinismo
+25|Zapatos de baile
+25|Zapatos de baile de salón
+25|Zapatos de ballet
+25|Zapatos de balonmano
+25|Zapatos de basquetbol
+25|Zapatos de béisbol
+25|Zapatos de boliche
+25|Zapatos de boxeo
+25|Zapatos de ciclismo
+25|Zapatos de cuero
+25|Zapatos de deporte
+25|Zapatos de entrenamiento
+25|Zapatos de esquí
+25|Zapatos de fútbol
+25|Zapatos de golf
+25|Zapatos de goma
+25|Zapatos de hockey
+25|Zapatos de lona
+25|Zapatos de madera (calzado)
+25|Zapatos de montañismo
+25|Zapatos de montar
+25|Zapatos de mujer
+25|Zapatos de pescador
+25|Zapatos de pista y campo
+25|Zapatos de rugby
+25|Zapatos de senderismo
+25|Zapatos de tenis
+25|Zapatos de vestir
+25|Zapatos de voleibol
+25|Zapatos para bebés de punto
+25|Zapatos para correr
+25|Zapatos para el agua
+25|Zapatos para el ocio
+25|Zapatos para esquís y para tablas de esquí y sus partes
+25|Zapatos sin cordones
+25|Zapatos tejidos para bebés
+25|Zapatos y botas de niños
+25|Zapatos y botas de trabajo
+25|Zuecos
+25|Zuecos altos para la lluvia (ashida)
+25|Zuecos bajos de madera (koma-geta)
+25|Zuecos de madera bajos (hiyori-geta)
+25|Zuecos de madera de estilo japonés (geta)
+25|Zuecos y sandalias estilo japonés
+25|Zuecos-sandalias

--- a/lib/seeds/class_26_terms.csv
+++ b/lib/seeds/class_26_terms.csv
@@ -1,161 +1,120 @@
-class,reference_id,name
-26,260001,hebillas para el calzado
-26,260002,agujas*
-26,260003,agujas de zapatero
-26,260004,agujas de coser
-26,260005,agujas para cardadoras de lana
-26,260006,agujas de encuadernación
-26,260007,agujas de zurcir
-26,260008,agujas de guarnicionero
-26,260008,agujas de talabartero
-26,260009,agujas de tejer
-26,260009,agujas de hacer punto
-26,260010,cierres para prendas de vestir
-26,260011,plumas de avestruz [complementos de vestir]
-26,260012,ballenas de corsé
-26,260012,varillas de corsé
-26,260013,bandas para el cabello
-26,260013,vinchas para el cabello
-26,260014,barbas postizas
-26,260015,pinzas para el cabello
-26,260015,horquillas para el cabello
-26,260016,artículos de pasamanería para sombreros
-26,260018,ribetes para prendas de vestir
-26,260018,bieses para prendas de vestir
-26,260019,galones para bordar
-26,260020,huevos de zurcir
-26,260021,botones*
-26,260022,broches de presión
-26,260022,automáticos [broches]
-26,260023,cintas elásticas para subir las mangas
-26,260024,brazales [brazaletes]
-26,260024,brazaletes [brazales]
-26,260026,elementos de sujeción para tirantes
-26,260026,broches para tirantes
-26,260026,elementos de sujeción para tiradores [prendas de vestir]
-26,260027,broches [complementos de vestir]
-26,260028,bordados
-26,260028,adornos bordados
-26,260031,cierres de cinturón
-26,260032,números o letras para marcar la ropa blanca
-26,260032,monogramas para marcar la ropa blanca
-26,260033,ganchos para zapatos
-26,260034,cordones de zapatos
-26,260034,agujetas [cordones] de zapatos
-26,260035,artículos de pasamanería para el calzado
-26,260036,ojetes para el calzado
-26,260037,felpilla [pasamanería]
-26,260038,artículos de adorno para el cabello
-26,260039,horquillas para rizar el cabello
-26,260040,pasadores para el cabello
-26,260040,hebillas para el cabello
-26,260041,horquillas para recogidos
-26,260042,redecillas para el cabello
-26,260043,cabello postizo
-26,260044,trenzas de cabello
-26,260045,números para marcar la ropa blanca
-26,260046,pasadores para cuellos postizos
-26,260047,cordoncillos para prendas de vestir
-26,260048,corchetes de blusas
-26,260049,costureros
-26,260050,dedales para coser
-26,260051,agujas de ganchillo
-26,260051,agujas de croché
-26,260051,agujetas de croché
-26,260052,corchetes [mercería]
-26,260053,cremalleras [mercería]
-26,260055,alfileteros [acericos]
-26,260055,almohadillas para alfileres
-26,260056,dobladillos postizos
-26,260057,festones [bordados]
-26,260058,lanzaderas para tejer redes de pesca
-26,260059,flores artificiales
-26,260060,flecos
-26,260061,frutas artificiales
-26,260062,cordones*
-26,260062,galones
-26,260062,sutás [trencillas]
-26,260062,trenzas*
-26,260063,borlas [pasamanería]
-26,260064,orlas [pasamanería]
-26,260065,guirnaldas artificiales
-26,260066,chorreras [encajes]
-26,260067,cordones de lana
-26,260068,pasamanería
-26,260068,encajes
-26,260069,letras para marcar la ropa blanca
-26,260070,artículos de mercería*, excepto hilos
-26,260071,lentejuelas de mica
-26,260072,bigotes postizos
-26,260073,ojales de prendas de vestir
-26,260074,plumas de pájaro [complementos de vestir]
-26,260076,cintas de mercería
-26,260077,lentejuelas para prendas de vestir
-26,260078,acericos [almohadillas para agujas]
-26,260078,cojines para agujas [acericos]
-26,260079,pelucas
-26,260080,puntillas [encajes]
-26,260081,parches termoadhesivos para reparar artículos textiles
-26,260082,plumas [complementos de vestir]
-26,260083,pompones
-26,260084,volantes de faldas y vestidos
-26,260085,rosetas [pasamanería]
-26,260085,escarapelas [pasamanería]
-26,260086,frunces de tul o encaje para prendas de vestir
-26,260087,cremalleras para bolsas
-26,260087,cierres relámpago para bolsas
-26,260088,hebillas de zapatos
-26,260089,tupés
-26,260090,pasacintas
-26,260090,pasacordones
-26,260091,estuches de agujas
-26,260092,alfileteros [estuches]
-26,260093,bordados de hilos de plata
-26,260094,bordados de hilos de oro
-26,260095,cintas elásticas
-26,260096,cordoncillos para ribetear
-26,260096,trencillas para ribetear
-26,260097,hebillas [complementos de vestir]
-26,260098,corchetes de corsés
-26,260099,coronas de flores artificiales
-26,260100,alfileres que no sean artículos de joyería
-26,260101,insignias que no sean de metales preciosos
-26,260111,parches termoadhesivos para adornar artículos textiles [mercería]
-26,260112,dorsales
-26,260112,números para competidores [dorsales]
-26,260113,chapas de adorno
-26,260113,insignias de adorno
-26,260114,lazos para el cabello
-26,260115,gorros para hacer mechas
-26,260116,cintas autoadherentes [artículos de mercería]
-26,260116,cintas autoadhesivas de gancho y rizo [artículos de mercería]
-26,260117,bandas [insignias]
-26,260118,hombreras para prendas de vestir
-26,260119,pinzas para pantalones de ciclista
-26,260120,cintas para fruncir cenefas de cortinas
-26,260121,tiras de papel para rizar el cabello
-26,260122,ganchos para tejer alfombras
-26,260123,cuentas que no sean para confeccionar joyas
-26,260124,bobinas para enrollar hilo de bordar o lana [que no sean partes de máquinas]
-26,260125,extensiones de cabello
-26,260126,cabello
-26,260127,bigudís eléctricos o no
-26,260128,bordados de sobrepuesto [artículos de mercería]
-26,260129,plantas artificiales, que no sean árboles de Navidad
-26,260130,kits de costura
-26,260131,alfileres entomológicos
-26,260132,agujas de bordar
-26,260133,dijes, que no sean para artículos de joyería y llaveros
-26,260134,enhebradores de agujas
-26,260135,guirnaldas de Navidad artificiales
-26,260136,guirnaldas de Navidad artificiales con luces integradas
-26,260137,coronas de Navidad artificiales
-26,260138,coronas de Navidad artificiales con luces integradas
-26,260139,cintas de sombrero
-26,260140,cintas para el cabello
-26,260141,cintas y lazos, que no sean de papel para envolver regalos
-26,260142,lazos de mercería
-26,260143,alfileres de sombrero que no sean de joyería
-26,260143,prendedores de sombrero que no sean de joyería
-26,260144,cintas adhesivas para levantar el pecho
-26,260145,cintas adhesivas de doble cara para prendas de vestir
+class|name
+26|Adornos para el cabello
+26|Adornos para el cabello en forma de borlas para peinados de estilo japonés (negake)
+26|Adornos para el cabello en forma de peineta
+26|Adornos que no sean de metales preciosos para calzado
+26|Agujas
+26|Agujas de coser
+26|Agujas de costura de ojo oval
+26|Agujas de lienzos
+26|Agujas de tejer
+26|Agujas de telares de calcetería
+26|Agujas de zurcir
+26|Agujas metálicas para montar insectos
+26|Agujas para encaje
+26|Agujas para máquinas de costura
+26|Agujas para tatamis
+26|Alfileres con cabezal de vidrio
+26|Alfileres de gancho (imperdibles)
+26|Alfileres para gorros que no sean de metales preciosos
+26|Alfileres para marcar
+26|Alfileres para ropa
+26|Artículos de adorno para el cabello
+26|Ballenas para cuellos
+26|Barbas postizas
+26|Bigotes postizos
+26|Bigudíes de espuma
+26|Bonsáis artificiales
+26|Bordes y ribetes para ropa
+26|Botones
+26|Botones de fantasía
+26|Botones para prendas de vestir
+26|Broches a presión (remaches)
+26|Broches para vestimenta
+26|Cabello humano
+26|Cabello postizo
+26|Cabello postizo para peinados de estilo japonés (kamoji)
+26|Cajas de metales preciosos para agujas
+26|Cierres relámpago
+26|Cintas
+26|Cintas autoadherentes (artículos de mercería)
+26|Cintas de materias textiles
+26|Cintas de moños para peinados estilo coreano (daeng-gi)
+26|Cintas decorativas
+26|Cintas para el cabello
+26|Cintas y cordones
+26|Clips tipo almeja para el cabello
+26|Cojines para agujas y alfileres
+26|Coleteros y cintas para el cabello
+26|Corchetes para prendas de vestir
+26|Cordones
+26|Cordones de borlas para peinados de estilo japonés (motoyui)
+26|Cordones de zapatos
+26|Cordones para calzado
+26|Costureros
+26|Cremallera y sus partes
+26|Cremalleras
+26|Cremalleras (artículos de mercería)
+26|Cuentas para artesanías
+26|Cursores de cremallera
+26|Dedales para coser
+26|Diademas (cintillos, no de joyería ni bisutería)
+26|Elásticos para el cabello
+26|Encaje
+26|Encaje de bolillos
+26|Encaje y bordados
+26|Encajes (excepto los encajes de bordado)
+26|Encajes Jacquard
+26|Estuches de agujas para coser de metales preciosos
+26|Estuches de agujas que no sean de metales preciosos
+26|Extensiones de cabello
+26|Flores artificiales
+26|Flores artificiales de materias plásticas
+26|Flores artificiales de materias textiles
+26|Flores artificiales de papel
+26|Flores artificiales para fijar en la ropa
+26|Flores de seda
+26|Follaje artificial para exteriores
+26|Frutas artificiales
+26|Gomas para el cabello
+26|Hebillas de cinturón
+26|Hebillas de cinturón de metales preciosos
+26|Hebillas de cinturón de metales preciosos para prendas de vestir
+26|Hebillas de correa
+26|Hebillas de metales preciosos (complementos de prendas de vestir)
+26|Hebillas metálicas para zapatos y botas
+26|Hebillas para el cabello
+26|Hebillas para prendas de vestir
+26|Horquillas de adorno para el cabello destinadas a peinados de estilo japonés (kogai)
+26|Horquillas para el cabello orientales
+26|Horquillas para el pelo
+26|Horquillas y pasadores para el cabello
+26|Huevos de zurcir
+26|Lanzaderas para tejer redes de pesca
+26|Lazos para el cabello para peinados de estilo japonés (tegara)
+26|Ojales de prendas de vestir
+26|Ojetes para calzado
+26|Parches de bordado para ropa
+26|Parches para la ropa
+26|Pasacintas
+26|Pasadores (pinzas para el cabello)
+26|Pasadores para el pelo
+26|Pasadores para fijar el cabello postizo en la parte trasera destinados a peinados de estilo japonés (tabodome)
+26|Peines decorativos para peinados de estilo japonés (marugushi)
+26|Pelucas
+26|Pelucas de payaso
+26|Pinches ornamentales para el cabello coreanos (binyer)
+26|Pinzas de faja especiales para obi (obi-dome) trajes de japonesa
+26|Pinzas para el cabello
+26|Pinzas para pantalones de ciclista
+26|Plantas artificiales
+26|Postizos
+26|Postizos de cabello y pelucas
+26|Postizos para peinados de estilo japonés (kamishin)
+26|Ramilletes de flores artificiales
+26|Redecillas para el cabello
+26|Redes para barba
+26|Rulos no eléctricos
+26|Sujetadores de cremalleras
+26|Tupés (cabello postizo)
+26|Vegetales artificiales

--- a/lib/seeds/class_27_terms.csv
+++ b/lib/seeds/class_27_terms.csv
@@ -1,37 +1,61 @@
-class,reference_id,name
-27,270001,alfombrillas de baño
-27,270001,tapetes de baño
-27,270002,revestimientos de suelos
-27,270002,revestimientos de pisos
-27,270003,césped artificial
-27,270003,pasto artificial
-27,270004,colchonetas de gimnasia
-27,270006,esteras*
-27,270007,papel pintado
-27,270007,empapelados
-27,270007,papel tapiz
-27,270008,felpudos
-27,270008,limpiabarros [felpudos]
-27,270008,tapetes de puerta [felpudos]
-27,270009,esteras de junco
-27,270010,alfombrillas para automóviles
-27,270010,tapetes para automóviles
-27,270011,alfombras*
-27,270011,tapetes [alfombras]
-27,270012,alfombras antideslizantes
-27,270012,tapetes [alfombras] antideslizantes
-27,270013,tapices murales que no sean de materias textiles
-27,270014,linóleo
-27,270014,tela encerada [linóleo]
-27,270015,bajo alfombras
-27,270016,revestimientos de vinilo para suelos
-27,270016,revestimientos de vinilo para pisos
-27,270017,alfombras de cuerda trenzada para pistas de esquí
-27,270018,papel pintado de materias textiles
-27,270018,empapelados de materias textiles
-27,270018,papel tapiz de materias textiles
-27,270019,alfombras ignífugas para chimeneas y barbacoas
-27,270020,esteras de yoga
-27,270020,tapetes de yoga
-27,270021,tatamis
-27,270022,revestimientos murales de materias textiles
+class|name
+27|Acolchados de subsuelo para césped artificial
+27|Alfombras
+27|Alfombras de área
+27|Alfombras de baño de diatomita
+27|Alfombras de cuerda trenzada para pistas de esquí
+27|Alfombras orientales no tejidas (mosen)
+27|Alfombras y tapetes
+27|Alfombrillas antideslizantes para duchas
+27|Alfombrillas de baño
+27|Alfombrillas de baño de materias plásticas
+27|Alfombrillas de baño de tela
+27|Alfombrillas de paja
+27|Alfombrillas para vehículos
+27|Bajo alfombras
+27|Bases antideslizantes para alfombras
+27|Césped artificial
+27|Colchonetas (esterillas) de gimnasia
+27|Colchonetas de gimnasia
+27|Colchonetas de lucha
+27|Esteras (goza)
+27|Esteras de corcho
+27|Esteras de goma
+27|Esteras de junco
+27|Esteras de junco con motivos florales (hana-mushiro)
+27|Esteras de paja (mushiro)
+27|Esteras de paja de arroz japonesa (tatamis)
+27|Esteras para suelos de establos
+27|Felpudos
+27|Felpudos para orar
+27|Hierba artificial para poner en la superficie de áreas recreativas
+27|Limpiabarros de materias textiles
+27|Linóleo
+27|Linóleo para pisos
+27|Moqueta cortada en baldosas
+27|Moqueta de textiles en baldosas
+27|Moqueta en baldosas para cubrir suelos
+27|Papel pintado
+27|Papel pintado con revestimiento de materias textiles
+27|Papel pintado de vinilo
+27|Papel pintado que no sea de materias textiles
+27|Papel tapiz con efectos visuales en 3D
+27|Papeles pintados
+27|Pistas de esgrima
+27|Recubrimiento mural a modo de papel, hecho de corcho
+27|Recubrimientos murales a modo de papel, hechos de plástico
+27|Revestimientos antideslizantes de suelos para su uso en escaleras
+27|Revestimientos de corcho para paredes
+27|Revestimientos de materias plásticas para paredes
+27|Revestimientos de materias textiles para paredes
+27|Revestimientos de papel para paredes
+27|Revestimientos de suelos
+27|Revestimientos de suelos para suelos existentes
+27|Revestimientos de vinilo para suelos
+27|Revestimientos murales de vinilo
+27|Revestimientos para paredes que no sean de materias plásticas
+27|Tapetes de baño antideslizantes
+27|Tapetes de piel
+27|Tapetes para baño de materias textiles
+27|Tapetes para vehículos
+27|Tapizados murales que no sean de materias textiles

--- a/lib/seeds/class_28_terms.csv
+++ b/lib/seeds/class_28_terms.csv
@@ -1,298 +1,569 @@
-class,reference_id,name
-28,280001,cámaras de aire para balones de juego
-28,280002,cebos artificiales para la pesca
-28,280003,cápsulas para pistolas de juguete
-28,280004,juguetes para animales de compañía
-28,280005,juegos de anillas
-28,280006,árboles de Navidad de materiales sintéticos
-28,280007,arcos de tiro
-28,280008,material para tiro con arco
-28,280009,cantos de esquís
-28,280010,columpios
-28,280011,balones de juego
-28,280011,pelotas de juego
-28,280012,globos para fiestas
-28,280013,bandas para mesas de billar
-28,280014,caballitos de balancín [juguetes]
-28,280015,guantes de bateador [accesorios para juegos]
-28,280016,biberones para muñecas
-28,280016,mamaderas para muñecas
-28,280017,bicicletas estáticas de ejercicio
-28,280019,bolas de billar
-28,280020,tiza para tacos de billar
-28,280021,marcadores de puntos para billares
-28,280022,bolos
-28,280023,canicas para jugar
-28,280024,juguetes*
-28,280025,bloques de construcción [juguetes]
-28,280026,bobsleighs [trineos de carreras]
-28,280027,envoltorios sorpresa de Navidad [Christmas crackers]
-28,280029,portavelas para árboles de Navidad
-28,280030,bolas de juego
-28,280031,maquinaria y aparatos para juegos de bolos
-28,280032,guantes de boxeo
-28,280033,cuerdas de tripa para raquetas
-28,280034,palos de golf
-28,280035,cañas de pescar
-28,280036,cometas
-28,280036,barriletes [cometas]
-28,280036,papalotes
-28,280037,carretes para cometas
-28,280037,carretes para barriletes [cometas]
-28,280037,carretes para papalotes
-28,280038,blancos de tiro
-28,280038,dianas
-28,280039,campanitas para árboles de Navidad
-28,280040,fichas para juegos
-28,280041,juegos de construcción
-28,280042,cuerdas para raquetas
-28,280043,aparatos para ejercicios físicos
-28,280044,aparatos de culturismo
-28,280044,aparatos de entrenamiento físico
-28,280045,artículos de cotillón
-28,280046,espinilleras [artículos de deporte]
-28,280046,canilleras [artículos de deporte]
-28,280047,bolsas de críquet
-28,280048,palos de hockey
-28,280049,juegos de damas
-28,280050,dados [juegos]
-28,280051,extensores para pectorales
-28,280052,discos de lanzamiento [artículos de deporte]
-28,280054,juegos de dominó
-28,280055,juegos de ajedrez
-28,280056,tableros de ajedrez
-28,280057,dameros
-28,280058,pistolas de juguete
-28,280059,rodillos para bicicletas estáticas de ejercicio
-28,280060,salabardos de pesca
-28,280060,jamos de pesca
-28,280061,bolsas de golf, con o sin ruedas
-28,280062,artículos de broma
-28,280064,redes [artículos de deporte]
-28,280065,redes de tenis
-28,280066,fijaciones de esquís
-28,280067,dardos
-28,280069,boyas de pesca
-28,280070,fútbol de mesa [juegos]
-28,280071,fusiles lanzaarpones [artículos de deporte]
-28,280072,guantes [accesorios para juegos]
-28,280074,cubiletes para dados
-28,280075,barras con pesas [pesas de gimnasia]
-28,280076,anzuelos
-28,280077,sonajeros
-28,280078,juegos de sociedad
-28,280079,juegos*
-28,280080,lanzadoras [trampas] para tiro de pichón
-28,280081,raquetas
-28,280082,señuelos de caza o pesca
-28,280083,aparejos de pesca
-28,280084,líneas de pesca
-28,280085,camas de muñecas
-28,280086,casas de muñecas
-28,280087,marionetas
-28,280088,muñecas
-28,280089,máscaras de teatro
-28,280090,máscaras de carnaval
-28,280091,modelos de vehículos a escala
-28,280092,carretes de pesca
-28,280093,aletas de natación
-28,280094,nasas [artes de pesca]
-28,280094,nasas [artículos de pesca]
-28,280095,piscinas [artículos de juego]
-28,280095,albercas de natación [artículos de juego]
-28,280095,piletas de natación [artículos de juego]
-28,280096,nieve artificial para árboles de Navidad
-28,280097,tejos
-28,280098,patines de ruedas
-28,280099,patines de hielo
-28,280100,pieles de foca [revestimientos de esquís]
-28,280101,pichones de arcilla [blancos de tiro]
-28,280102,tablas de surf
-28,280103,ropa de muñecas
-28,280104,cuartos de muñecas
-28,280105,aparatos de prestidigitación
-28,280106,bolos [juegos]
-28,280107,sedales de pesca
-28,280109,revestimientos de esquís
-28,280110,esquís
-28,280111,mesas para tenis de mesa
-28,280111,mesas para pimpón
-28,280112,peonzas [juguetes]
-28,280112,trompos [juguetes]
-28,280113,trineos [artículos de deporte]
-28,280114,juegos de backgammon
-28,280114,juegos de chaquete
-28,280115,patinetes [juguetes]
-28,280115,patinetas [juguetes]
-28,280116,volantes para juegos de raqueta
-28,280117,pistolas de aire comprimido de juguete
-28,280118,cebos fulminantes [juguetes]
-28,280118,cápsulas fulminantes [juguetes]
-28,280118,cápsulas detonantes [juguetes]
-28,280119,adornos para árboles de Navidad, excepto artículos de iluminación y productos de confitería
-28,280120,soportes para árboles de Navidad
-28,280121,tacos de billar
-28,280122,suelas para tacos de billar
-28,280122,zapatillas para tacos de billar
-28,280123,mesas de billar
-28,280124,mesas de billar que funcionan con monedas
-28,280125,kayaks de mar
-28,280126,tablas de windsurf
-28,280127,alas delta
-28,280128,aparatos para juegos
-28,280129,aparatos de gimnasia
-28,280129,aparatos de físicoculturismo
-28,280130,armas de esgrima
-28,280131,caretas de esgrima
-28,280132,guantes de esgrima
-28,280141,guantes de béisbol
-28,280142,arneses de escalada
-28,280143,coderas [artículos de deporte]
-28,280144,rodilleras [artículos de deporte]
-28,280145,móviles de juguete
-28,280146,parapentes
-28,280147,protectores acolchados [partes de ropa de deporte]
-28,280148,monopatines
-28,280148,patinetas
-28,280149,toboganes [artículos de juego]
-28,280150,trampolines [artículos de deporte]
-28,280151,osos de peluche
-28,280152,esquís náuticos
-28,280153,guantes de golf
-28,280154,indicadores de picada [aparejos de pesca]
-28,280155,sensores de picada [aparejos de pesca]
-28,280156,juegos de mesa
-28,280157,tiovivos
-28,280157,calesitas
-28,280157,carruseles [tiovivos]
-28,280158,discos voladores [juguetes]
-28,280159,juegos de herraduras
-28,280160,juegos de Mahjong
-28,280161,juguetes de peluche
-28,280161,peluches [juguetes]
-28,280162,juguetes para hacer pompas de jabón
-28,280163,vehículos de juguete
-28,280164,bastones de majorette
-28,280165,mangas para cazar mariposas
-28,280166,fundas especiales para esquís
-28,280167,arneses para tablas de windsurf
-28,280168,rompecabezas [puzles]
-28,280168,puzles
-28,280169,mástiles para tablas de windsurf
-28,280170,pistolas de pintura [artículos de deporte]
-28,280170,pistolas de paintball [artículos de deporte]
-28,280171,bolas de pintura [municiones para pistolas de paintball]
-28,280172,correas para tablas de surf
-28,280173,aparatos para lanzar pelotas de tenis
-28,280174,tacos y plataformas de salida para competiciones deportivas
-28,280174,plataformas de salida para competiciones deportivas
-28,280174,tacos de salida para competiciones deportivas
-28,280175,globos de nieve
-28,280175,esferas de nieve
-28,280176,cinturones de halterofilia
-28,280176,cinturones de levantamiento de pesas [artículos de deporte]
-28,280177,tablas de bodyboard
-28,280178,cartones de bingo
-28,280179,herramientas arreglapiques [accesorios de golf]
-28,280180,reclamos de caza
-28,280181,ruletas
-28,280182,patines en línea
-28,280183,piñatas
-28,280184,sacos de boxeo
-28,280185,vehículos teledirigidos [juguetes]
-28,280185,vehículos de control remoto
-28,280186,colofonia para deportistas
-28,280187,raquetas de nieve
-28,280188,tirachinas [artículos de deporte]
-28,280188,hondas [artículos de deporte]
-28,280189,máquinas de juego automáticas que funcionan con monedas
-28,280190,caleidoscopios
-28,280191,naipes
-28,280191,barajas de cartas
-28,280192,confetis
-28,280192,papel picado
-28,280193,blancos de tiro electrónicos
-28,280193,dianas electrónicas
-28,280194,señuelos olfativos de caza y pesca
-28,280195,pantallas de camuflaje [artículos de deporte]
-28,280196,suspensorios para deportistas
-28,280197,tablas de snowboard
-28,280198,kits de modelos a escala [juguetes]
-28,280198,modelos a escala para armar [juguetes]
-28,280199,juegos de pachinko
-28,280201,ascendedores [material de montañismo]
-28,280202,máquinas para juegos de apuestas
-28,280203,tragaperras
-28,280203,tragamonedas
-28,280204,sombreros de papel para fiestas [artículos de cotillón]
-28,280205,tablas de natación
-28,280206,fichas para juegos de apuestas
-28,280207,billetes de lotería para rascar
-28,280207,billetes de lotería para raspar
-28,280208,juguetes rellenos
-28,280209,camas elásticas
-28,280210,pértigas para la práctica del salto con pértiga
-28,280210,garrochas para la práctica del salto con garrocha
-28,280211,manguitos de natación
-28,280211,brazaletes de natación
-28,280211,flotadores de brazo para nadar
-28,280212,cinturones de natación
-28,280213,chalecos de natación
-28,280214,máquinas de videojuegos
-28,280215,juegos portátiles con pantalla de cristal líquido
-28,280216,máquinas de videojuegos electrónicos para salas de juego
-28,280217,mandos para consolas de juego
-28,280218,modelos [juguetes]
-28,280218,maquetas [juguetes]
-28,280219,figuras [juguetes]
-28,280220,máquinas lanzadoras de pelotas
-28,280221,mancuernas [pesas de gimnasia]
-28,280222,máscaras [juguetes]
-28,280223,matrioskas [muñecas rusas]
-28,280224,mandos para juguetes
-28,280224,controles para juguetes
-28,280225,carritos para bolsas de golf
-28,280226,tablas de surf de remo [paddleboards]
-28,280227,giroscopios y estabilizadores de vuelo para modelos a escala de aeronaves
-28,280228,palancas de mando [joysticks] para videojuegos
-28,280229,láminas protectoras para pantallas de juegos portátiles
-28,280230,drones [juguetes]
-28,280231,robots de juguete
-28,280232,agujas de infladores para balones de juego 
-28,280233,infladores especiales para balones de juego
-28,280234,mantas de actividades para bebés
-28,280234,gimnasios para bebés [mantas de actividades]
-28,280235,mantitas de apego [dudús]
-28,280236,triciclos para niños pequeños [juguetes]
-28,280237,cosméticos de imitación, de juguete
-28,280238,objetos hinchables para flotar en piscinas
-28,280238,objetos inflables para flotar en piscinas
-28,280239,cintas de gimnasia rítmica
-28,280240,lanzadores de serpentinas y confetis
-28,280241,masilla de modelar de juguete
-28,280242,pasta de modelar de juguete
-28,280243,juegos y juguetes portátiles con funciones de telecomunicaciones integradas
-28,280244,bumeranes
-28,280245,tarjetas de intercambio para juegos
-28,280246,cinturones de ejercicio para reducir la cintura
-28,280247,aletas de buceo
-28,280248,aletas de mano
-28,280248,guantes palmeados de natación
-28,280249,juegos hinchables para piscinas
-28,280249,juegos inflables para piscinas
-28,280250,esquís de ruedas
-28,280251,palos de esquí
-28,280251,bastones de esquí
-28,280252,palos de esquí para esquís de ruedas
-28,280252,bastones de esquí para esquís de ruedas
-28,280253,columpios de yoga
-28,280254,tiendas de campaña de juguete
-28,280254,carpas de juguete
-28,280255,consolas de videojuegos
-28,280256,consolas de videojuegos portátiles
-28,280257,casas de juego para niños
-28,280258,coquillas de protección para deportes
-28,280259,etiquetas para bolsas de golf
-28,280260,trineos de skeleton
-28,280261,fundas especiales para tablas de surf
-28,280262,juguetes antiestrés
+class|name
+28|Acolchados de seguridad para postes de tenis
+28|Ajedrez chino
+28|Alas flotadoras para nadar
+28|Aletas de natación
+28|Alimentos de juguete
+28|Almohadillas de patada para Taekwondo
+28|Amortiguadores de vibraciones para raquetas de tenis
+28|Animales de juguete
+28|Animales de juguete rellenos
+28|Anteojos prismáticos de juguete
+28|Anzuelo con luces para peces
+28|Anzuelos
+28|Aparatos de aeróbica con escalones
+28|Aparatos de entrenamiento físico
+28|Aparatos de entrenamiento físico, a saber, ejercitadores de manos y dedos
+28|Aparatos de entretenimiento adaptados para su uso exclusivo con receptores de televisión
+28|Aparatos de tirolesa para uso recreativo
+28|Aparatos para recoger pelotas de golf
+28|Aparatos recogepelotas para tenis
+28|Aparejos de pesca
+28|Árboles de Navidad artificiales
+28|Árboles de Navidad de juguete
+28|Árboles de Navidad de materiales sintéticos
+28|Arcos de tiro
+28|Arcos de tiro japonés (yumi)
+28|Areneros (Equipamiento para área de juegos)
+28|Armas de esgrima
+28|Armónicas de juguete
+28|Arneses de pesca
+28|Arneses para tablas de windsurf
+28|Aros para gimnasia
+28|Arpones activados con resortes (equipos de submarinismo deportivo)
+28|Artículos de ropa para juguetes
+28|Artículos de sombrerería para muñecas
+28|Atriles hacer sentadillas con barras de pesas
+28|Aviones de juguete
+28|Aviones de juguete a control remoto
+28|Aviones de juguete con lanzador elástico
+28|Bajos de línea de pesca
+28|Balones de baloncesto
+28|Balones de balonmano
+28|Balones de fútbol americano
+28|Balones de tonificación para pilates
+28|Balones de water polo
+28|Balones para ejercicios de alivio del estrés
+28|Balones y pelotas de juego
+28|Bancas para hacer abdominales
+28|Bancos para su uso en gimnasia
+28|Bandas elásticas para su uso en ejercicios de acondicionamiento físico
+28|Bandas para mesas de billar
+28|Barajadoras de naipes
+28|Barajas de cartas
+28|Barajas de cartas comunes
+28|Barajas de cartas japonesas (hanafuda)
+28|Barajas de cartas karuta (juego de cartas japonés)
+28|Barras asimétricas para gimnasia
+28|Barras con resorte para ejercicios físicos
+28|Barras de danza portátiles
+28|Barras de equilibrio para gimnasia
+28|Barras de puerta para hacer flexiones
+28|Barras fijas para gimnasia
+28|Barras para levantar pesas
+28|Barras paralelas para gimnasia
+28|Barreras para pistas de bolos
+28|Barriles de dardos
+28|Bases de béisbol
+28|Bastones de esquí
+28|Bastones de majorette
+28|Bastones hinchables para animar
+28|Bastones inflables para animar
+28|Bastones provistos de luces LED (juguetes)
+28|Bates de béisbol
+28|Bates de cricket
+28|Bates de juegos
+28|Bates de sóftbol
+28|Biberones para muñecas
+28|Bicheros para la pesca
+28|Bicicletas de juguete para niños que no sean para transporte
+28|Biombos protectores para lanzadores de béisbol (artículos de deporte)
+28|Blancos de tiro
+28|Bloque de yoga
+28|Bloques de arranque (pistas deportivas)
+28|Bloques de construcción de juguete que pueden interconectarse
+28|Bloques de construcción imantados (juguetes)
+28|Bloques de juguete para aprender el lenguaje braille
+28|Bobsleighs (trineos de carreras)
+28|Bolas de billar
+28|Bolas de boliche
+28|Bolas de hockey sobre hierba
+28|Bolas para el lanzamiento de peso
+28|Bolas para jugar dodgeball (quemadas)
+28|Bolos (juegos)
+28|Bolos de bolera
+28|Bolsas adaptadas para palos de lacrosse
+28|Bolsas con o sin ruedas para palos de golf
+28|Bolsas de boliche
+28|Bolsas de esquí
+28|Bolsas de golf
+28|Bolsas especialmente diseñadas para tablas de surf
+28|Bolsas para cebo vivo
+28|Bolsas para palos de golf
+28|Bolsas para palos de hockey sobre hielo
+28|Bombas especialmente adaptadas para su uso con pelotas para juegos
+28|Botes con piezas de piedra para jugar al go (botes goke)
+28|Botes de juguete
+28|Boyas de pesca
+28|Broches de juguete
+28|Caballetes para gimnasia
+28|Caballitos de balancín (juguetes)
+28|Cabezas de palos de golf
+28|Cajas de salto
+28|Cajas para cebos de pesca (aparejos de pesca)
+28|Cajitas musicales de juguete (artículos de juego)
+28|Cámaras de juguete
+28|Campanitas para árboles de Navidad
+28|Cañas de dardo
+28|Cañas de palos de golf
+28|Cañas de pesca
+28|Cañas de pescar
+28|Canastas de baloncesto
+28|Canicas
+28|Canicas para jugar
+28|Cantos de esquís
+28|Carillones de juguete
+28|Carnada artificial para pesca
+28|Carretes de pesca
+28|Carriles de carreras (aparatos de natación)
+28|Cartas de juego coreanas (hwatoo)
+28|Cartas para jugar (naipes)
+28|Casas de juguete
+28|Casas de juguete modulares
+28|Casas de muñecas
+28|Cascos para muñecos
+28|Cebo artificial para la pesca
+28|Cebos artificiales de pesca
+28|Cebos para la caza de aves acuáticas
+28|Chalecos de natación
+28|Cinta de tensión para deportes de equilibrio (artículos deportivos)
+28|Cintas de correr para el ejercicio físico
+28|Cintas de sujeción para empuñaduras de palos de golf
+28|Cintas de sujeción para empuñaduras de palos de hockey sobre hielo
+28|Cintas de sujeción para empuñaduras de raquetas
+28|Cinturones de levantamiento de pesas (artículos de deporte)
+28|Cinturones de natación
+28|Cochecitos de juguete
+28|Coches de juguete
+28|Coderas de fútbol americano
+28|Cohetes de juguete
+28|Columpios
+28|Cometas
+28|Cometas flexibles (parafoils)
+28|Conos de disco para fútbol
+28|Consolas de videojuegos
+28|Coronas y guirnaldas artificiales
+28|Correas de sujeción para tablas de bodyboard
+28|Correas de yoga
+28|Correas para tablas de surf
+28|Cromos (juegos de cartas)
+28|Cuartos de muñecas
+28|Cubiertas de cabezas para palos de golf
+28|Cubiletes para dados
+28|Cucharillas (cebos) giratorias para la pesca
+28|Cuchillas de patines para hielo
+28|Cuerdas de arco
+28|Cuerdas de saltar
+28|Cuerdas de tripa para raquetas de tenis o bádminton
+28|Cuerdas para palos de lacrosse
+28|Cuerdas para raquetas
+28|Cuerdas para saltar
+28|Cuerdas para saltar que incorporan contadores digitales
+28|Dactileras para tiro con arco
+28|Dados (juegos)
+28|Damas chinas (juegos)
+28|Dameros
+28|Dianas electrónicas para juegos y deportes
+28|Dianas para dardos
+28|Dientes de vampiro de broma
+28|Dinero de juguete
+28|Discos de hockey
+28|Discos de lanzamiento (artículos de deporte)
+28|Discos para deportes de campo
+28|Discos para el juego del tejo
+28|Discos para levantamiento de pesas (artículos de deporte)
+28|Dominó coreano (glopae)
+28|Dreidels (trompos judíos)
+28|Ejes de mancuernas para levantamiento de pesas
+28|Empuñaduras de palos de golf
+28|Encordadores para arcos de tiro
+28|Epee (armas de esgrima)
+28|Equipos para billar
+28|Escalones de aeróbic
+28|Escudos para las patadas de karate
+28|Escudos protectores de kendo para el torso
+28|Espadas de bambú para kendo
+28|Espadas de madera para kendo
+28|Espinilleras para fútbol
+28|Espumillón para decorar árboles de Navidad
+28|Esquís
+28|Esquís alpinos
+28|Esquís náuticos
+28|Esteras para la práctica de lanzamientos (instrumento para golf)
+28|Estructuras de barras para parques (equipos para jugar)
+28|Estructuras de construcción de juguete y pistas para vehículos de juguete
+28|Estuches de esquís
+28|Estuches de protección especialmente adaptados para videojuegos de mano
+28|Estuches de raquetas para tenis o bádminton
+28|Estuches en forma de carcaj para artículos deportivos
+28|Estuches para bates de béisbol
+28|Estuches para cañas de pescar
+28|Estuches para pelotas de tenis
+28|Estuches para raquetas de tenis de mesa
+28|Extensores para pectorales
+28|Faldones para árboles de Navidad
+28|Fichas para juegos
+28|Figuras de acción de juguete
+28|Figuras de juguete
+28|Fijaciones de esquís
+28|Fijaciones de esquís alpinos
+28|Flechas para tiro con arco
+28|Floretes (armas de esgrima)
+28|Floretes de esgrima
+28|Flotadores inflables para nadar
+28|Flotadores para nadar
+28|Fundas adaptadas de cabezas de palos de golf
+28|Fundas de esquís
+28|Fundas para palos de golf
+28|Fundas para tacos de billar
+28|Fundas protectoras para raquetas
+28|Globos de juego
+28|Globos de juguete
+28|Guanteletes (guantes de tiro con arco)
+28|Guantes de balonmano
+28|Guantes de bateo
+28|Guantes de béisbol
+28|Guantes de billar
+28|Guantes de boliche
+28|Guantes de boxeo
+28|Guantes de esquí acuático
+28|Guantes de fútbol
+28|Guantes de fútbol americano
+28|Guantes de golf
+28|Guantes de halterofilia
+28|Guantes de kote
+28|Guantes de lacrosse
+28|Guantes de sóftbol
+28|Guantes de Taekwondo
+28|Guantes para windsurf
+28|Helicópteros a escala (juguetes)
+28|Indicadores de picada (aparejos de pesca)
+28|Jabalinas
+28|Jabalinas para deportes de campo
+28|Jaulas de insectos de juguete
+28|Joysticks para videojuegos
+28|Juego de damas
+28|Juego de los dados japonés (sugoroku)
+28|Juegos adaptados para uso con receptores de televisión
+28|Juegos de ajedrez
+28|Juegos de backgammon
+28|Juegos de baloncesto de mesa
+28|Juegos de cartas (naipes)
+28|Juegos de construcción
+28|Juegos de dados
+28|Juegos de dardos
+28|Juegos de dominó
+28|Juegos de figuras de acción
+28|Juegos de herraduras
+28|Juegos de lógica manipulables
+28|Juegos de Mahjong
+28|Juegos de mano con pantallas de cristal líquido
+28|Juegos de mesa coreanos (Yut Nori)
+28|Juegos de ordenador accionados con pilas y con pantalla de cristal líquido
+28|Juegos de sociedad
+28|Juegos de tiro de baloncesto arcade
+28|Juegos electrónicos para la enseñanza de niños
+28|Juegos electrónicos que no se utilicen con televisores
+28|Juegos go
+28|Juegos para parques de atracciones
+28|Juguetes de acción de palanca
+28|Juguetes de acción eléctricos
+28|Juguetes de acción electrónicos
+28|Juguetes de construcción para entrelazar
+28|Juguetes de cuerda de plástico
+28|Juguetes de cuerda metálicos
+28|Juguetes de cuerda que andan
+28|Juguetes de figuras de acción
+28|Juguetes de goma inflables
+28|Juguetes de infantes
+28|Juguetes de peluche
+28|Juguetes de soga para animales de compañía
+28|Juguetes didácticos electrónicos
+28|Juguetes giratorios antiestrés (fidget spinners)
+28|Juguetes hinchables para cabalgar sobre ellos
+28|Juguetes inflables
+28|Juguetes musicales
+28|Juguetes para animales domésticos
+28|Juguetes para apilar
+28|Juguetes para apretar
+28|Juguetes para cajones de arena
+28|Juguetes para la arena
+28|Juguetes para la bañera
+28|Juguetes para perros
+28|Juguetes que lanzan chorros de agua
+28|Juguetes rellenos
+28|Juguetes sonoros de fantasía para fiestas
+28|Kits de modelos a escala (juguetes)
+28|Lanzadoras (trampas) para tiro de pichón
+28|Líneas de pesca
+28|Luges (trineos de descenso)
+28|Mangas para cazar mariposas
+28|Mangos de cometa
+28|Manoplas (para esgrima)
+28|Manoplas de artes marciales
+28|Manoplas para ejercitar manos
+28|Maquetas de campos de fútbol de juguete
+28|Máquina horizontal de pinball japonés (máquinas smartball)
+28|Maquinaria y aparatos para juegos de bolos
+28|Máquinas de juego con pantallas de cristal líquido (LCD)
+28|Máquinas de juego tipo grúa
+28|Máquinas de pachinko (máquina vertical de pinball japonés)
+28|Máquinas de pinball horizontales (máquinas de juegos de korinto)
+28|Máquinas de remo
+28|Máquinas de vapor a escala de juguete
+28|Máquinas de videojuegos electrónicos para salas de juego
+28|Máquinas de videojuegos para el hogar
+28|Máquinas lanzapelotas para tenis de mesa
+28|Máquinas montadoras de bolos en boleras
+28|Máquinas para trotar
+28|Máquinas recreativas accionadas con monedas
+28|Marcadores de puntos para billares
+28|Marcadores para pelotas de golf
+28|Marionetas
+28|Marionetas manuales
+28|Martillos para uso deportivo
+28|Masa de juguete para modelar
+28|Máscaras de carnaval
+28|Máscaras de disfraz
+28|Máscaras de Halloween
+28|Mascaras de juguete
+28|Máscaras de kendo
+28|Máscaras de teatro
+28|Mascaras faciales de natación
+28|Masilla luminosa de juguete
+28|Mástiles de vela
+28|Mástiles para tablas de windsurf
+28|Material para tiro con arco estilo japonés y occidental
+28|Mazas de gimnasia
+28|Mazas para malabarismo
+28|Mesas automáticas para jugar mahjong
+28|Mesas de billar
+28|Mesas de tenis de mesa
+28|Mesas para fútbol de mesa
+28|Mesas para tenis de mesa
+28|Microscopios de juguete
+28|Modelos a escala de aviones
+28|Modelos de aviones a escala
+28|Modelos de vehículos a escala
+28|Modelos de vehículos a escala controlados por radio
+28|Molinillos de juguete
+28|Monoesquís
+28|Monopatines (equipos recreativos)
+28|Moscas artificiales para su uso en la pesca
+28|Móviles para cuna en forma de pájaros sobre un columpio
+28|Muebles de juguete
+28|Muebles para casas de muñecas
+28|Muñecas
+28|Muñecas con trajes tradicionales occidentales
+28|Muñecas de festival para niñas y sus piezas
+28|Muñecas de navidad
+28|Muñecas de trapo
+28|Muñecas en posición sentada (muñecas osuwari)
+28|Muñecas estilo europeo
+28|Muñecas japonesas tradicionales
+28|Muñecas kokeshi
+28|Muñecas para jugar
+28|Muñecas parlantes
+28|Muñecas sakura
+28|Muñecas y animales de peluche
+28|Muñecas y ropa para muñecas
+28|Muñecos bodhidharma con las pupilas sin dibujar (menashi-daruma)
+28|Muñecos con cabeza de resorte (bobble-head)
+28|Muñecos de ventrílocuo
+28|Muñequeras para levantamiento de pesas
+28|Muñequeras para uso deportivo
+28|Naipes de juego para trucos de magia
+28|Nasas de pesca
+28|Palos de floorball
+28|Palos de golf
+28|Palos de hockey
+28|Palos de lacrosse
+28|Palos para el juego de tejo
+28|Parapentes
+28|Paredes de escalada artificiales
+28|Patines de bota
+28|Patines de hielo
+28|Patines de ruedas
+28|Patines de ruedas y de hielo
+28|Patines en línea
+28|Pedales de monopatín
+28|Pelotas de béisbol
+28|Pelotas de deporte
+28|Pelotas de floorball
+28|Pelotas de golf
+28|Pelotas de goma
+28|Pelotas de goma para béisbol
+28|Pelotas de lacrosse
+28|Pelotas de netball
+28|Pelotas de pádel tenis
+28|Pelotas de petanca
+28|Pelotas de playa inflables
+28|Pelotas de racketball
+28|Pelotas de semillas de juguete (otedama)
+28|Pelotas de sepak takraw (voleibol de puntapié)
+28|Pelotas de softbol
+28|Pelotas de tenis (duras)
+28|Pelotas de tenis de mesa
+28|Pelotas de tenis suaves
+28|Pelotas de tenis y volantes de bádminton
+28|Pelotas de voleibol
+28|Pelotas para deportes
+28|Pelotas para jugar bochas
+28|Pelotas para jugar pádelbol
+28|Pelotas para malabares
+28|Pelotas y balones de juego
+28|Peluches (juguetes)
+28|Peonzas
+28|Peras de boxeo (para práctica de boxeo)
+28|Pértigas para salto de altura
+28|Pesas de ejercicio
+28|Pesas de halterofilia
+28|Pesas de tungsteno para pescar
+28|Pesas rusas
+28|Petos protectores para fútbol americano
+28|Pianos de juguete
+28|Piedras de juego go
+28|Piezas de ajedrez
+28|Piezas de ajedrez coreano (jang-gi)
+28|Piezas de madera para juegos de shogi (koma)
+28|Piscinas inflables de natación (artículos de juego)
+28|Pistolas de agua (juguetes)
+28|Pistolas de juguete
+28|Plomos de pesca
+28|Plumas de dardos
+28|Poleas de entrenamiento físico
+28|Pompones para animadoras de equipos deportivos
+28|Portavelas para árboles de Navidad
+28|Porterías de fútbol
+28|Porterías de hockey
+28|Postes para redes de mesas de tenis
+28|Protector de dedos para baloncesto
+28|Protectores abdominales para uso deportivo
+28|Protectores corporales para fútbol americano
+28|Protectores de brazo para béisbol
+28|Protectores de brazo para deportes
+28|Protectores de cadera para uso deportivo
+28|Protectores de cuchillas de patines sobre hielo
+28|Protectores de empeine para atletas
+28|Protectores de pierna para atletismo
+28|Protectores para palmas de la mano para uso deportivo
+28|Protectores para porteros de hockey sobre hielo
+28|Protectores pectorales para béisbol
+28|Protectores pectorales para hockey
+28|Puentes de descanso para tacos de billar
+28|Putters de golf
+28|Raquetas (hagoita)
+28|Raquetas de bádminton
+28|Raquetas de tenis
+28|Raquetas para tenis de mesa
+28|Raquetas para tenis o bádminton
+28|Raquetas y cuerdas para raquetas
+28|Reclamos (señuelos)
+28|Reclamos para venado
+28|Redes (artículos de deporte)
+28|Redes de camuflaje (artículos de deporte)
+28|Redes de porterías para hockey sobre hielo
+28|Redes de voleibol
+28|Redes para insectos de juguete
+28|Redes para jaulas de bateo de béisbol
+28|Redes para juegos de pelota
+28|Redes para práctica de golf
+28|Redes y postes de tenis
+28|Relojes de juguete
+28|Revestimientos de esquís
+28|Rodilleras para fútbol americano
+28|Rodillos a ruedas abdominales para hacer ejercicio
+28|Rodillos para bicicletas estáticas de ejercicio
+28|Rompecabezas
+28|Rompecabezas (puzles)
+28|Rompecabezas de lógica manipulables
+28|Rompecabezas de mosaico
+28|Rompecabezas en forma de cubos
+28|Ropa de muñecas
+28|Ropa para muñecas europeas
+28|Ropa para muñecas japonesas tradicionales
+28|Ruedas de hámsteres
+28|Ruedas de lotería
+28|Ruedas para vehículos de juguete
+28|Sables (arma de esgrima)
+28|Sacos de boxeo
+28|Salabardos de pesca
+28|Saltadores pogo
+28|Saquitos rellenos en forma de artículos de juego
+28|Sedales de pesca
+28|Sensores de picada (aparejos de pesca)
+28|Señuelos de caza o pesca
+28|Señuelos de pesca
+28|Señuelos olfativos de caza y pesca
+28|Señuelos para la caza
+28|Sets de herramientas de carpintero de juguete
+28|Silbatos de juguete
+28|Sombreros para fiestas
+28|Sonajeros de bebé
+28|Soportes de bateo para pelotas de béisbol
+28|Soportes de palos de billar
+28|Soportes especialmente adaptados para palos de golf
+28|Soportes para hacer flexiones de brazos
+28|Soportes para patear balones (rugby)
+28|Soportes protectores para hombros y codos (artículos de deporte)
+28|Subibajas
+28|Submarinos de juguete teledirigidos
+28|Sujeciones de esquí acuático
+28|Suspensorios para deportistas
+28|Tablas de esquí acuático
+28|Tablas de kiteboarding
+28|Tablas de kneeboard
+28|Tablas de natación
+28|Tablas de skimboard
+28|Tablas de surf
+28|Tablas de wakeskate
+28|Tablas de windsurf
+28|Tablas para la práctica de deportes acuáticos
+28|Tableros de ajedrez
+28|Tableros de ajedrez coreano (jang-gin)
+28|Tableros de baloncesto
+28|Tableros de juego go
+28|Tableros para juegos de shogi
+28|Taburetes para la pesca
+28|Tacos de billar
+28|Tarjetas de keno
+28|Tees de golf
+28|Tejos
+28|Telescopios de juguete
+28|Tippets para la pesca
+28|Títeres de dedos
+28|Tiza para tacos de billar
+28|Toboganes de agua
+28|Toboganes de aguas
+28|Tragamonedas
+28|Trampolines (artículos de deporte)
+28|Trampolines para gimnasia
+28|Trenes de juguete a escala
+28|Triángulos de billar
+28|Triángulos para bolas de billar
+28|Triquitraques (petardos de juguete)
+28|Túneles para jugar
+28|Utensilios de juguete para cocinar
+28|Vallas de atletismo
+28|Varillas de redes de voleibol
+28|Varillas luminosas de juguete
+28|Vehículos automóviles de juguete
+28|Vendas para las manos para uso deportivo
+28|Visores para cascos de juguete
+28|Volantes chinos (Jianzi)
+28|Volantes de bádminton
+28|Volantes para juegos de raqueta
+28|Volantes para jugar hagoita
+28|Xilófonos de juguete
+28|Zancos con fines recreativos
+28|Zapatos de muñecas

--- a/lib/seeds/class_29_terms.csv
+++ b/lib/seeds/class_29_terms.csv
@@ -1,299 +1,512 @@
-class,reference_id,name
-29,290001,albúmina para uso culinario
-29,290002,extractos de algas para uso alimenticio
-29,290003,gelatina*
-29,290005,grasas comestibles
-29,290006,anchoas que no estén vivas
-29,290007,mantequilla de cacahuete
-29,290007,mantequilla de cacahuate
-29,290007,mantequilla de maní
-29,290008,mantequilla
-29,290008,manteca [mantequilla]
-29,290009,manteca de cacao para uso alimenticio
-29,290010,mantequilla de coco
-29,290011,crema de mantequilla
-29,290011,crema de manteca [mantequilla]
-29,290012,clara de huevo
-29,290013,morcillas
-29,290013,morongas
-29,290014,caldos
-29,290015,preparaciones para hacer caldo
-29,290016,caviar
-29,290017,frutas en conserva
-29,290018,productos de charcutería
-29,290019,patatas fritas
-29,290019,papas fritas
-29,290020,chucrut
-29,290021,coco deshidratado
-29,290022,aceite de colza para uso alimenticio
-29,290023,concentrados de caldo
-29,290024,confituras
-29,290025,frutas congeladas
-29,290026,sopas
-29,290026,consomés
-29,290027,pasas [uvas]
-29,290028,pepinillos
-29,290029,verduras, hortalizas y legumbres en conserva
-29,290030,verduras, hortalizas y legumbres cocidas
-29,290031,verduras, hortalizas y legumbres secas
-29,290032,aceites para uso alimenticio
-29,290033,nata
-29,290033,crema [producto lácteo]
-29,290034,quesos
-29,290035,frutas confitadas
-29,290035,frutas cristalizadas
-29,290035,frutas escarchadas
-29,290036,croquetas
-29,290037,crustáceos que no estén vivos
-29,290038,dátiles
-29,290039,leche
-29,290040,cangrejos de río que no estén vivos
-29,290040,acamayas que no estén vivas
-29,290041,filetes de pescado
-29,290042,cuajo
-29,290043,frutas estofadas
-29,290044,jaleas de fruta
-29,290044,gelatinas de fruta
-29,290045,pulpa de fruta
-29,290046,carne
-29,290047,pescado
-29,290048,jaleas comestibles
-29,290049,gelatinas de carne
-29,290050,carne de caza
-29,290051,mermelada de jengibre
-29,290052,granos de soja en conserva para uso alimenticio
-29,290052,granos de soya en conserva para uso alimenticio
-29,290053,materias grasas para fabricar grasas alimenticias
-29,290054,mezclas que contienen grasa para untar
-29,290055,arenques [pescado]
-29,290057,bogavantes que no estén vivos
-29,290058,aceite de maíz para uso alimenticio
-29,290059,aceite de nuez de palma para uso alimenticio
-29,290060,aceite de sésamo para uso alimenticio
-29,290061,ostras que no estén vivas
-29,290061,ostrones que no estén vivos
-29,290062,cola de pescado para uso alimenticio
-29,290063,jamón
-29,290064,yema de huevo
-29,290065,yogur
-29,290066,sopas juliana
-29,290066,sopas vegetales
-29,290067,jugos vegetales para uso culinario
-29,290068,extractos de carne
-29,290070,kéfir
-29,290071,kumis
-29,290072,bebidas lácteas en las que predomina la leche
-29,290073,suero de leche
-29,290074,productos lácteos
-29,290075,langostas que no estén vivas
-29,290076,panceta ahumada
-29,290076,beicon
-29,290076,tocino
-29,290077,lentejas en conserva
-29,290078,margarina
-29,290079,mermeladas
-29,290081,tuétano para uso alimenticio
-29,290081,caracú para uso alimenticio
-29,290082,mariscos que no estén vivos
-29,290083,mejillones que no estén vivos
-29,290084,aceite de palma para uso alimenticio
-29,290085,frutos secos preparados
-29,290086,huevos*
-29,290087,huevos en polvo
-29,290088,patés de hígado
-29,290089,cebollas en conserva
-29,290090,aceitunas en conserva
-29,290091,aceite de oliva para uso alimenticio
-29,290092,aceite de hueso para uso alimenticio
-29,290093,pectina para uso culinario
-29,290095,encurtidos
-29,290096,guisantes en conserva
-29,290096,arvejas en conserva
-29,290096,chícharos en conserva
-29,290097,salchichas
-29,290097,salchichones
-29,290098,salazones
-29,290098,cecinas [salazones]
-29,290099,preparaciones para hacer sopa
-29,290101,puré de tomate
-29,290102,ensaladas de verduras, hortalizas y legumbres
-29,290103,manteca [grasa] de cerdo
-29,290103,grasa de cerdo
-29,290104,ensaladas de frutas
-29,290104,macedonias de frutas
-29,290106,sardinas [pescado]
-29,290107,salmón [pescado]
-29,290108,sebo para uso alimenticio
-29,290109,atún [pescado]
-29,290110,jugo de tomate para uso culinario
-29,290111,aceite de girasol para uso alimenticio
-29,290112,tripas [callos]
-29,290112,mondongo [tripas]
-29,290113,trufas en conserva
-29,290114,carne de ave
-29,290115,cáscaras de fruta
-29,290115,cortezas de fruta
-29,290116,alginatos para uso culinario
-29,290117,almendras molidas
-29,290118,cacahuetes preparados
-29,290118,cacahuates preparados
-29,290118,maníes preparados
-29,290120,champiñones en conserva
-29,290120,hongos en conserva
-29,290120,setas en conserva
-29,290121,grasa de coco
-29,290122,aceite de coco para uso alimenticio
-29,290123,habas en conserva
-29,290123,alubias en conserva
-29,290123,frijoles en conserva
-29,290123,judías en conserva
-29,290123,porotos en conserva
-29,290124,hígado
-29,290125,alimentos a base de pescado
-29,290131,rodajas de fruta deshidratada
-29,290132,almejas que no estén vivas
-29,290133,frutas conservadas en alcohol
-29,290134,polen preparado para uso alimenticio
-29,290135,langostinos que no estén vivos
-29,290136,pescado en conserva
-29,290137,carne en conserva
-29,290138,gambas que no estén vivas
-29,290138,camarones que no estén vivos
-29,290139,huevos de caracol para uso alimenticio
-29,290140,tofu
-29,290141,nata montada
-29,290141,crema batida
-29,290142,carne de cerdo
-29,290143,nidos de pájaro para uso alimenticio
-29,290144,pescado enlatado [conservas]
-29,290145,harina de pescado para la alimentación humana
-29,290146,fruta enlatada [conservas]
-29,290147,carne enlatada [conservas]
-29,290148,buñuelos de patata
-29,290148,buñuelos de papa
-29,290149,pescado en salazón
-29,290149,pescado en salmuera
-29,290150,pepinos de mar [cohombros de mar] que no estén vivos
-29,290151,crisálidas de gusano de seda para la alimentación humana
-29,290152,verduras, hortalizas y legumbres enlatadas [conservas]
-29,290153,salchichas rebozadas
-29,290154,copos de patata
-29,290154,copos de papa
-29,290154,hojuelas de papa
-29,290155,compota de manzana
-29,290155,puré de manzana
-29,290156,compota de arándanos
-29,290157,tahini
-29,290158,hummus
-29,290159,algas nori [porphyra] en conserva
-29,290160,refrigerios a base de fruta
-29,290161,cuajada
-29,290162,kimchi
-29,290163,leche de soja
-29,290163,leche de soya
-29,290164,batidos de leche
-29,290165,pimientos en conserva
-29,290166,semillas de girasol preparadas
-29,290167,mousse de pescado
-29,290168,bebida a base de huevo sin alcohol
-29,290169,mousse de verduras y hortalizas
-29,290170,huevas de pescado preparadas
-29,290171,semillas preparadas*
-29,290172,aloe vera preparado para la alimentación humana
-29,290173,ajo en conserva
-29,290174,leche albuminosa
-29,290175,aceite de linaza para uso alimenticio
-29,290175,aceite de lino para uso alimenticio
-29,290176,patatas fritas con bajo contenido en grasa
-29,290176,papas fritas con bajo contenido en grasa
-29,290177,lecitina para uso culinario
-29,290178,fermentos lácteos para uso culinario
-29,290179,compotas
-29,290180,leche condensada
-29,290181,smetana
-29,290182,leche fermentada y horneada
-29,290183,leche agria
-29,290184,concentrado de tomate
-29,290185,pasta de calabacín
-29,290186,pasta de berenjena
-29,290187,leche de cacahuete para uso culinario
-29,290187,leche de cacahuate para uso culinario
-29,290187,leche de maní para uso culinario
-29,290188,leche de almendras para uso culinario
-29,290189,leche de arroz
-29,290190,alcachofas en conserva
-29,290191,arreglos de frutas procesadas
-29,290192,leche en polvo*
-29,290193,yakitori
-29,290194,bulgogi
-29,290195,frutos secos confitados
-29,290196,frutos secos aromatizados
-29,290197,avellanas preparadas
-29,290198,bayas en conserva
-29,290199,guacamole
-29,290200,aros de cebolla rebozados
-29,290200,anillos de cebolla rebozados
-29,290201,falafel
-29,290202,zumo de limón para uso culinario
-29,290202,jugo de limón para uso culinario
-29,290203,carne liofilizada
-29,290204,leche de avena
-29,290205,crema a base de verduras, hortalizas y legumbres
-29,290206,verduras, hortalizas y legumbres liofilizadas
-29,290207,aceite de oliva virgen extra para uso alimenticio
-29,290209,larvas de hormiga comestibles, preparadas
-29,290210,insectos comestibles que no estén vivos
-29,290211,maíz dulce procesado
-29,290212,pastas para untar a base de frutos secos
-29,290213,bolas de masa guisada a base de patata
-29,290214,salchichas para perritos calientes
-29,290214,salchichas para perros calientes
-29,290215,banderillas de salchicha
-29,290216,aceite de soja para uso alimenticio
-29,290217,sucedáneos de la leche
-29,290218,leche de almendras
-29,290219,leche de cacahuete
-29,290220,leche de coco
-29,290221,leche de coco para uso culinario
-29,290222,bebidas a base de leche de coco
-29,290223,leche de arroz para uso culinario
-29,290224,bebidas a base de leche de almendras
-29,290225,bebidas a base de leche de cacahuete
-29,290225,bebidas a base de leche de cacahuate
-29,290225,bebidas a base de leche de maní
-29,290226,tripas para embutidos, naturales o artificiales
-29,290227,bacalao seco salado [clipfish]
-29,290228,buñuelos de requesón
-29,290229,pasta de fruta prensada
-29,290230,piel de soja
-29,290230,nata de soja
-29,290231,hamburguesas de soja
-29,290232,hamburguesas de tofu
-29,290233,tajín [plato preparado a base de carne, pescado o verduras]
-29,290234,tempeh
-29,290235,saté
-29,290236,verduras, hortalizas y legumbres procesadas
-29,290237,frutas procesadas
-29,290238,ratatouille
-29,290239,confits de pato
-29,290240,andouillettes
-29,290241,morcillas blancas
-29,290242,cassoulet
-29,290243,chucrut con guarnición
-29,290244,tortitas de patata
-29,290245,tortillas francesas
-29,290245,omelettes
-29,290246,rollitos de col rellenos de carne
-29,290247,concentrados a base
-de verduras, hortalizas y legumbres para cocinar
-29,290248,concentrados a base de frutas para cocinar
-29,290249,pastas para untar a base de verduras, hortalizas y legumbres
-29,290250,agar-agar para uso culinario
-29,290251,moluscos que no estén vivos
-29,290252,queso quark
-29,290253,queso cottage
-29,290254,bebidas de ácidos lácticos
-29,290255,flores comestibles secas
-29,290256,jengibre cristalizado
-29,290257,jengibre en conserva
-29,290258,jengibre en vinagre
+class|name
+29|Aceite comestible
+29|Aceite de cacahuate para uso alimenticio
+29|Aceite de canola
+29|Aceite de colza
+29|Aceite de colza (para alimentación)
+29|Aceite de fibra de arroz (para alimentación)
+29|Aceite de girasol para uso alimenticio
+29|Aceite de huesos comestible
+29|Aceite de huesos para uso alimenticio
+29|Aceite de maíz
+29|Aceite de oliva para uso alimenticio
+29|Aceite de palma (producto alimenticio)
+29|Aceite de palma para uso alimenticio
+29|Aceite de salvado de arroz para uso alimenticio
+29|Aceite de semilla de uva
+29|Aceite de semillas de chía para uso alimentario
+29|Aceite de sésamo
+29|Aceite de sésamo para uso alimenticio
+29|Aceite de soja
+29|Aceite de soja para uso alimenticio
+29|Aceite y grasa de ballena para uso alimenticio
+29|Aceite y grasa de coco para uso alimenticio
+29|Aceites comestibles
+29|Aceites curtidos (aceite hidrogenado para alimentos)
+29|Aceites de oliva
+29|Aceites y grasas animales para uso alimenticio
+29|Aceites y grasas comestibles
+29|Aceites y grasas en polvo para uso alimenticio
+29|Aceites y grasas para uso alimenticio
+29|Aceites y grasas preparadas para uso alimenticio
+29|Aceites y grasas vegetales para uso alimenticio
+29|Aceitunas en conserva, secas y cocinadas
+29|Aceitunas enlatadas
+29|Aceitunas preparadas
+29|Aceitunas preparadas enlatadas
+29|Alas de pollo
+29|Albóndigas de carne
+29|Albóndigas de pollo
+29|Alga condimentada (jaban-gim)
+29|Algas deshidratadas comestibles (hoshi-wakame)
+29|Algas nori (porphyra) tostadas
+29|Algas preparadas para consumo humano
+29|Almendra molida
+29|Almendras preparadas
+29|Ancas de rana congeladas
+29|Anguilas, no vivas
+29|Arándanos secos
+29|Arrollado de huaso (embutidos)
+29|Aspic
+29|Atunes que no estén vivos
+29|Bacalao (que no esté vivo)
+29|Ballenas que no estén vivas
+29|Barritas a base de semillas y frutos secos
+29|Batatas procesadas
+29|Batidos de leche
+29|Bebidas a base de leche
+29|Bebidas a base de productos lácteos
+29|Bebidas a base de soya utilizadas como sucedáneos de la leche
+29|Bebidas a base de yogur
+29|Bebidas de leche con alto contenido de leche
+29|Bebidas de leche con cacao
+29|Bebidas de leche que contengan frutas
+29|Bebidas de yogur
+29|Bebidas hechas de yogurt
+29|Bebidas lácteas con sabor a cacao
+29|Bebidas que consisten principalmente en leche
+29|Bloques de bonito cocido, ahumado y seco (katsuobushi)
+29|Bocadillos a base de vegetales
+29|Bogavantes que no estén vivos
+29|Brotes de bambú deshidratados
+29|Brotes de bambú fermentado y preservados en sal (menma)
+29|Brotes de lirios de día comestibles deshidratados
+29|Bulbos de lirios comestibles, secos
+29|Butifarras
+29|Caballa española seca encurtida
+29|Caballa española, no viva
+29|Cacahuates preparados
+29|Calamar seco
+29|Calamares (preparados)
+29|Caldillo de congrio (sopa a base de pescado y verduras)
+29|Caldo de carne picante (yukgaejang)
+29|Caldo de hueso de buey (seolleongtang)
+29|Caldo de pescado
+29|Caldo de pollo granulado
+29|Caldo de ternera
+29|Caldos de carne
+29|Caldos preparados
+29|Camarones al coco
+29|Cangrejos de nieve, no vivos
+29|Capelán, no vivo
+29|Caquis secos (got-gam)
+29|Caracoles cocinados
+29|Caracoles de mar en rodajas
+29|Caracoles enlatados
+29|Carbonada (sopa a base de carne y verduras)
+29|Carne cocinada embotellada
+29|Carne cocinada enlatada
+29|Carne congelada
+29|Carne de ave
+29|Carne de ave y carne de caza
+29|Carne de camarón en polvo
+29|Carne de cangrejo
+29|Carne de caza
+29|Carne de cerdo deshidratada
+29|Carne de pescado en polvo
+29|Carne de ternera lechal
+29|Carne en conserva
+29|Carne enlatada
+29|Carne envasada
+29|Carne frita
+29|Carne hervida en salsa de soya (tsukudani meat)
+29|Carne preparada
+29|Carne rebanada
+29|Carne seca
+29|Carne seca (cecina)
+29|Carne y extractos de carne
+29|Carne y pescado en conserva
+29|Carne, carne de ave y carne de caza
+29|Carne, carne de ave y carne de caza en conserva
+29|Carne, pescado, fruta, verduras, hortalizas y legumbres en conserva
+29|Carne, pescado, frutas, verduras, hortalizas y legumbres enlatadas
+29|Carnes curadas
+29|Carnes y salchichas en conserva
+29|Carpas plateadas (no vivas)
+29|Carpines, no vivos
+29|Cáscaras de fruta
+29|Castañas de cajú saladas
+29|Castañas salteadas con azúcar
+29|Caviar
+29|Cazuela (sopa a base de carne o pollo, verduras y arroz)
+29|Cebollas preparadas
+29|Cebolletas encurtidas
+29|Cerdo enlatado
+29|Chalotes procesados (usados como vegetales, no como aliños)
+29|Champiñones shiitake secos
+29|Charquicán (guiso a base de charqui y verduras)
+29|Charquis (salazones) de yak (buey)
+29|Chícharos en conserva
+29|Chiles en conserva
+29|Chiles en conserva (que no sean saborizantes ni condimentos)
+29|Chips de camote morado
+29|Chips de verduras y hortalizas
+29|Chirivías procesadas
+29|Chuletas de cerdo
+29|Chunchules (interiores)
+29|Ciruelas en conserva
+29|Ciruelas pasas
+29|Claras de huevo
+29|Coco deshidratado
+29|Coco en polvo
+29|Coco rallado
+29|Codillo de jamón
+29|Col china seca
+29|Coles de Bruselas procesadas
+29|Coles de brusselas procesados
+29|Colirrábanos en escabeche
+29|Compota
+29|Compotas
+29|Concentrados de caldo
+29|Confituras y mermeladas
+29|Conservas de fruta
+29|Consomés
+29|Copos de carne de pescado secos (kezuri-bushi)
+29|Copos de kiwi
+29|Copos de melocotón
+29|Copos de papas
+29|Copos secos de alga laver para esparcir sobre arroz en agua caliente (ochazuke-nori)
+29|Corvinas amarillas, no vivas
+29|Crema artificial (sucedáneos lácteos)
+29|Crema de cacahuate para untar
+29|Crema de zapallo (hobak-juk)
+29|Crema en polvo
+29|Crema fresca
+29|Cremas de queso para untar
+29|Cremas lácteas
+29|Cremas no-lácteas
+29|Cremas para bebidas
+29|Crisálidas de gusano de seda para la alimentación humana
+29|Crustáceos que no estén vivos
+29|Cuajada
+29|Cuajo
+29|Cubitos de caldo
+29|Cubitos de sopa
+29|Curanto (plato a base de mariscos cocidos)
+29|Damasco turco
+29|Dátiles deshidratados
+29|Dátiles secos
+29|Dulce de alcayota (mermelada)
+29|Duraznos procesados
+29|Durianes secos
+29|Encurtidos
+29|Ensalada Cesar
+29|Ensalada de huevas de mújol
+29|Ensaladas antipasto
+29|Ensaladas de frutas y ensaladas de verduras, hortalizas y legumbres
+29|Ensaladas de frutas, verduras, hortalizas y legumbres
+29|Ensaladas de legumbres
+29|Escamoles (larvas de hormiga comestibles preparadas)
+29|Estofado instantáneo o precocinado
+29|Extractos de carne
+29|Extractos de carne de ave
+29|Extractos de tomate
+29|Extractos para sopas
+29|Fiambres
+29|Filete en barbacoa trozado y aliñado (bulgogi)
+29|Filetes de cerdo
+29|Filetes de pescado a la parrilla
+29|Filetes de ternera
+29|Flores de gardenia deshidratadas comestibles
+29|Foie gras
+29|Fresas secas
+29|Frittatas (tortillas italianas)
+29|Fruta confitada
+29|Fruta seca o aromatizada
+29|Frutas cocidas
+29|Frutas confitadas
+29|Frutas congeladas
+29|Frutas conservadas en alcohol
+29|Frutas cristalizadas
+29|Frutas cristalizadas, congeladas y en conserva
+29|Frutas en conserva
+29|Frutas en polvo
+29|Frutas encurtidas
+29|Frutas enlatadas
+29|Frutas enlatadas o embotelladas
+29|Frutas fermentadas
+29|Frutas secas
+29|Frutas, verduras, hortalizas y legumbres cocinadas
+29|Frutas, verduras, hortalizas y legumbres deshidratadas
+29|Frutas, verduras, hortalizas y legumbres en conserva
+29|Frutas, verduras, hortalizas y legumbres enlatadas
+29|Frutas, verduras, hortalizas y legumbres preparadas
+29|Frutos secos preparados
+29|Frutos secos tostados
+29|Gambas que no estén vivas
+29|Gambas secas
+29|Gírgolas, secas
+29|Grasa de cerdopara uso alimenticio
+29|Guisantes elaborados
+29|Harina de pescado para la alimentación humana
+29|Hígado de cerdo
+29|Hígado de rape
+29|Hojas de col verde procesadas
+29|Hojas tostadas de algas (yaki-nori)
+29|Hojuelas de mandioca
+29|Hongo velo de novia alargado seco
+29|Huevas de cangrejo, preparadas
+29|Huevas de pescado procesadas
+29|Huevas de salmonete, preparadas
+29|Huevos
+29|Huevos con sabor a té
+29|Huevos congelados
+29|Huevos de codorniz
+29|Huevos de codorniz en lata
+29|Huevos de gallina
+29|Huevos de pato
+29|Huevos en polvo
+29|Huevos marinados
+29|Huevos preparados
+29|Jalea hecha de raíz de lengua del diablo (konnyaku)
+29|Jaleas (para el pan)
+29|Jaleas comestibles
+29|Jaleas de frutas (no de confitería)
+29|Jaleas y confituras
+29|Jamón
+29|Jengibre escarchado
+29|Jugos vegetales para uso culinario
+29|Kéfir
+29|Kimchi de pepino (oi-sobagi)
+29|Kimchi de rábanos en cubos (kkakdugi)
+29|Láminas de algas secas (hoshi-nori)
+29|Langostas que no estén vivas
+29|Langostinos que no estén vivos
+29|Langostinos secos
+29|Leche
+29|Leche acidófila
+29|Leche condensada
+29|Leche de cabra
+29|Leche de cabra en polvo
+29|Leche de oveja
+29|Leche de soja
+29|Leche de soja (leche de soya)
+29|Leche de soya en polvo
+29|Leche de vaca
+29|Leche deshidratada
+29|Leche deshidratada para uso alimenticio
+29|Leche en polvo
+29|Leche en polvo para uso alimenticio
+29|Leche evaporada
+29|Leche fermentada
+29|Leche orgánica
+29|Leche saborizada
+29|Lenguados, no vivos
+29|Lentejas secas
+29|Lichis secos
+29|Liebres de mar deshidratadas (mariscos)
+29|Longan seco
+29|Maíz dulce congelado
+29|Maíz en conserva
+29|Malaya (embutidos)
+29|Mangos deshidratados
+29|Maní japonés (maní preparado)
+29|Manteca (grasa) de cerdo
+29|Mantequilla
+29|Mantequilla clarificada
+29|Mantequilla de cacahuete
+29|Mantequilla de miel
+29|Mantequillas de cacahuete en polvo
+29|Manzanas procesadas
+29|Margarina
+29|Margarina, aceites y grasas comestibles
+29|Marisco procesado
+29|Mariscos enlatados
+29|Mariscos hervidos en salsa de soya (tsukudani)
+29|Mariscos que no estén vivos
+29|Medusas saladas
+29|Mermelada de arándano
+29|Mermeladas
+29|Mermeladas de arándanos
+29|Mermeladas y jaleas
+29|Mezcla de aceite para uso alimenticio
+29|Mezcla de frutas secas
+29|Mezclas para elaborar caldos
+29|Mezclas para elaborar sopa
+29|Mezclas para sopas
+29|Mollejas de pato
+29|Mollejas de pollo
+29|Mortadela
+29|Mousse de pollo
+29|Muslos de pollo
+29|Nabo deshidratado
+29|Ñames chinos secos
+29|Naranjas en conserva y aplastadas
+29|Naranjas procesadas
+29|Nata montada
+29|Nueces confitadas
+29|Nueces de macadamia preparadas
+29|Nueces de pecan, preparadas
+29|Nueces de torreya china preparadas
+29|Nueces preparadas
+29|Nuggets de pollo
+29|Okra deshidratada
+29|Paila marina (sopa a base de pescado y mariscos)
+29|Panceta ahumada
+29|Panceta de cerdo grillada (samgyeopsal)
+29|Papas dulces procesadas (camote)
+29|Papas fritas
+29|Papas peladas
+29|Papas rellenas
+29|Papayas secas
+29|Pasas rubias
+29|Pasta de frijol aliñada
+29|Pasta de gambas
+29|Pasta de garbanzo (humus)
+29|Pastas de aceituna
+29|Pastas para hacer sopa
+29|Pastas para untar hechas a base de legumbres
+29|Pastel de choclo (plato en base a pasta de maíz relleno con carne o pollo y huevo)
+29|Pastelera de choclo (plato en base a pasta de maíz)
+29|Pasteles de carne preparados
+29|Pasteles de pescado
+29|Pastrami
+29|Patas de cerdo encurtidas
+29|Patas de pato para consumo humano
+29|Patas de pollo para consumo humano
+29|Patatas fritas
+29|Patatas fritas con bajo contenido en grasas
+29|Patatas fritas en forma de gofre
+29|Patés de hígado
+29|Patos salados prensados
+29|Pepinos de mar (cohombros de mar) que no estén vivos
+29|Percas, no vivas
+29|Pescado
+29|Pescado ahumado
+29|Pescado embotellado
+29|Pescado en conserva
+29|Pescado enlatado
+29|Pescado procesado
+29|Piel de tofu
+29|Piezas de jalea de agar secas (kanten)
+29|Piezas de tofu fritas (abura age)
+29|Piezas de tofu liofilizadas (kohri dofu)
+29|Piñas secas
+29|Piñones confitados
+29|Piñones preparados
+29|Pistachos preparados
+29|Platijas (pescado), no vivas
+29|Plato cocinado consistente en carne frita y salsa de soya fermentada (sogalbi)
+29|Platos cocinados consistentes en pollo frito y pasta de pimentones fermentada (dak-galbi)
+29|Platos cocinados elaborados con carne
+29|Polen de pino preparado para uso alimenticio
+29|Polen preparado para uso alimenticio
+29|Porotos cocidos
+29|Porotos de soya en conserva de uso alimenticio
+29|Preparaciones de legumbres como sucedáneos de la carne para hamburguesas
+29|Preparaciones para elaborar sopas
+29|Preparaciones para sopas
+29|Prietas (embutidos)
+29|Productos cárnicos procesados
+29|Prosciutto (jamón)
+29|Pulpa de fruta
+29|Pulpas de fruta
+29|Pupas de abejas procesadas para consumo humano
+29|Puré de aceitunas preparado
+29|Puré de champiñones
+29|Puré de verduras, hortalizas y legumbres
+29|Purés de patata
+29|Queso blanco
+29|Queso blanco curado suave
+29|Queso blanco suave
+29|Queso cheddar
+29|Queso crema
+29|Queso curado
+29|Queso de oveja
+29|Queso en polvo
+29|Queso madurado
+29|Queso madurado en moho
+29|Queso mezclado
+29|Queso preparado
+29|Quesos
+29|Quesos de pasta blanda
+29|Quesos frescos sin madurar
+29|Quesos madurados
+29|Quesos madurados con mohos
+29|Ragú de carne de vacuno
+29|Ratatouille (hortalizas guisadas)
+29|Refrigerios a base de maíz dulce
+29|Rellenos a base de frutas para pasteles y tartas
+29|Requesón de soja
+29|Rodajas de carne
+29|Rodajas de manzana
+29|Rodajas de plátano o banana
+29|Salami
+29|Salazones
+29|Salchicha blanca
+29|Salchichas
+29|Salchichas polacas
+29|Salchichas secadas al aire
+29|Salchichas sin cocinar
+29|Salchichas vegetarianas
+29|Sebo vacuno paras uso alimenticio
+29|Semillas de chía procesadas para alimentación
+29|Semillas de girasol procesadas
+29|Semillas de sandía procesadas
+29|Semillas de sésamo cocidas, que no sean condimentos ni saborizantes
+29|Semillas de sésamo tostadas y molidas
+29|Shashliks (brochetas de carne)
+29|Sólidos de leche
+29|Solla, no viva
+29|Sopa de miso
+29|Sopa de miso instantánea o precocinada
+29|Sopa instantánea o precocinada
+29|Sopas y preparaciones para hacer sopas
+29|Soya fermentada (natto)
+29|Sucedáneos de carne de cangrejo
+29|Sucedáneos de la carne, a saber carne a base de verduras
+29|Sucedáneos de la leche a base de plantas
+29|Sucedáneos de leche para café consistentes principalmente de productos lácteos
+29|Sucedáneos de queso
+29|Sucedáneos de yogur hechos a base de frutas
+29|Sucedáneos de yogur hechos a base de frutos secos
+29|Sucedáneos de yogur hechos a base de vegetales
+29|Sucedáneos no lácteos de la leche
+29|Suero de leche
+29|Suero de leche seco
+29|Ternera
+29|Tofu
+29|Tofu fermentado
+29|Tofu no coagulado (Tofu nao)
+29|Tomate en conserva
+29|Tomates enlatados
+29|Tomates pelados
+29|Tomaticán (guiso de carne con tomates, maíz y otras verduras)
+29|Tortas al vapor de pescado molido y batata (hampen)
+29|Tortas al vapor o tostadas de pasta de pescado (kamaboko)
+29|Tortas de pasta de pescado ahumado en forma de tubos (chikuwa)
+29|Tortilla de patata dorada
+29|Tortillas francesas (omelettes)
+29|Tortillas hechas a base de verduras
+29|Tripa de cerdo
+29|Tripas de salchicha
+29|Tripas de ternera
+29|Trozos de tocino
+29|Truchas, no vivas
+29|Trufas en conserva
+29|Trufas secas (hongos comestibles)
+29|Urechis unicinctus (lombrices de mar) comestibles, no vivos
+29|Vegetales en vinagre
+29|Vegetales enlatados o embotellados
+29|Vegetales fermentados (kimchi)
+29|Vegetales instantáneos congelados
+29|Vejigas de pescado
+29|Verduras en polvo
+29|Verduras fermentadas
+29|Verduras saladas
+29|Verduras, hortalizas y legumbres cocidas
+29|Verduras, hortalizas y legumbres congeladas
+29|Verduras, hortalizas y legumbres deshidratadas
+29|Verduras, hortalizas y legumbres en conserva
+29|Verduras, hortalizas y legumbres en conserva de aceite
+29|Verduras, hortalizas y legumbres en conserva, secas y cocinadas
+29|Verduras, hortalizas y legumbres encurtidas
+29|Verduras, hortalizas y legumbres enlatadas
+29|Vieiras secas
+29|Virutas comestibles de alga marina seca (tororo-kombu)
+29|Vísceras para hacer envolturas de embutidos
+29|Yemas de huevo
+29|Yogur
+29|Yogur para beber
+29|Yogures tipo natilla
+29|Zanahorias peladas

--- a/lib/seeds/class_2_terms.csv
+++ b/lib/seeds/class_2_terms.csv
@@ -1,139 +1,185 @@
-class,reference_id,name
-2,020001,pinturas*
-2,020002,mordientes*
-2,020003,barnices*
-2,020004,colorantes para bebidas
-2,020005,colorantes para alimentos
-2,020005,colorantes alimentarios
-2,020006,colorantes de alizarina
-2,020007,pinturas de aluminio
-2,020008,aluminio en polvo para pintar
-2,020009,pinturas de amianto
-2,020009,pinturas de asbesto
-2,020010,preparaciones anticorrosivas
-2,020011,fijadores para acuarelas
-2,020014,plata en pasta
-2,020015,emulsiones de plata [pigmentos]
-2,020016,polvos para platear
-2,020017,barnices de asfalto
-2,020018,auramina
-2,020019,pinturas bactericidas
-2,020020,estuco
-2,020021,cintas anticorrosivas
-2,020022,bálsamo del Canadá
-2,020023,colorantes para mantequilla
-2,020023,colorantes para manteca [mantequilla]
-2,020024,colorantes para cerveza
-2,020025,barnices de betún
-2,020026,enlucidos para madera [pinturas]
-2,020027,mordientes para madera
-2,020028,tintes para madera
-2,020029,tierra de Siena
-2,020031,lacas para broncear
-2,020032,polvo de bronce para pintar
-2,020033,tintas para el cuero
-2,020034,caramelo [colorante alimentario]
-2,020035,malta acaramelada [colorante alimentario]
-2,020036,enlucidos para fieltro de techado [pinturas]
-2,020037,pinturas para cerámica
-2,020037,pinturas cerámicas
-2,020038,cerusa
-2,020039,negro de carbón [pigmento]
-2,020040,revestimientos de protección para chasis de vehículos
-2,020040,revestimientos de base para chasis de vehículos
-2,020041,tintes para el calzado
-2,020042,lechada de cal
-2,020043,pastas de imprenta [tintas]
-2,020044,óxido de cobalto [colorante]
-2,020045,carmín de cochinilla
-2,020046,colofonia*
-2,020047,colorantes*
-2,020047,materias tintóreas
-2,020048,colorantes de malta
-2,020048,malta tostada [colorante]
-2,020049,productos para conservar la madera
-2,020050,copal
-2,020052,colorantes de anilina
-2,020053,diluyentes para pinturas
-2,020054,diluyentes para lacas
-2,020055,espesantes para pinturas
-2,020056,creosota para conservar la madera
-2,020057,mordientes para el cuero
-2,020057,tinturas para el cuero
-2,020058,tintes*
-2,020059,pigmentos
-2,020060,cúrcuma [colorante]
-2,020061,resinas naturales en bruto
-2,020062,pinturas al temple
-2,020062,témperas
-2,020064,esmaltes [barnices]
-2,020065,esmaltes para pintar
-2,020065,pinturas al esmalte
-2,020066,tintas de imprenta
-2,020067,tintas para marcar animales
-2,020068,secantes [agentes de secado] para pinturas
-2,020070,enlucidos [pinturas]
-2,020072,fijadores [barnices]
-2,020073,negro de humo [pigmento]
-2,020074,fustete [colorante]
-2,020075,vidriados [barnices vítreos]
-2,020076,gutagamba para pintura
-2,020077,goma laca
-2,020078,gomorresinas
-2,020079,grasas antiherrumbre
-2,020080,tintas para grabado
-2,020081,óxido de zinc [pigmento]
-2,020081,gris de zinc [pigmento]
-2,020082,aceites para conservar la madera
-2,020083,aceites antiherrumbre
-2,020085,pinturas ignífugas
-2,020086,añil [colorante]
-2,020087,aglutinantes para pinturas
-2,020088,colorantes para licores
-2,020089,litargirio
-2,020089,minio anaranjado
-2,020089,óxido de plomo [litargirio]
-2,020090,metales en polvo para la pintura, la decoración, la imprenta y trabajos artísticos
-2,020091,mástique [resina natural]
-2,020092,metales en hojas para la pintura, la decoración, la imprenta y trabajos artísticos
-2,020093,productos contra el deslustre de los metales
-2,020094,productos para proteger metales
-2,020095,minio
-2,020095,plomo rojo
-2,020096,papel para teñir huevos de Pascua
-2,020098,bija
-2,020098,achiote [materia tintórea]
-2,020099,azafrán [colorante]
-2,020100,sandáraca [resina]
-2,020101,hollín [colorante]
-2,020102,zumaque para barnices
-2,020106,anhídrido titánico [pigmento]
-2,020106,dióxido de titanio [pigmento]
-2,020107,preparaciones antiherrumbre
-2,020108,pinturas de imprimación
-2,020110,blanco de cal
-2,020111,madera colorante
-2,020111,palo de Campeche
-2,020111,madera de tinte
-2,020112,extractos de madera colorante
-2,020112,extractos de madera de tinte
-2,020112,extractos de palo de Campeche
-2,020113,carbonilo para conservar la madera
-2,020114,barniz de copal
-2,020115,lacas*
-2,020121,tinta para impresoras y fotocopiadoras
-2,020122,pinturas antiincrustantes
-2,020122,pinturas antisuciedad
-2,020123,cartuchos de tóner llenos para impresoras y fotocopiadoras
-2,020124,trementina [diluyente para pinturas]
-2,020125,pintura en parches reubicables
-2,020126,acuarelas para trabajos artísticos
-2,020127,pinturas al óleo para trabajos artísticos
-2,020128,tintas comestibles
-2,020129,cartuchos de tinta comestible llenos para impresoras
-2,020130,colorantes en forma de marcadores para restaurar muebles
-2,020131,pinturas antigrafiti
-2,020132,tóner para impresoras y fotocopiadoras
-2,020133,cartuchos de tinta rellenos para impresoras y fotocopiadoras
-2,020134,vitrificadores para suelos de madera
-2,020135,pinturas antiorines
+class|name
+2|Aceites antioxidantes
+2|Aceites para conservar la madera
+2|Aceites Tung para la preservación de la madera
+2|Achiote (urucú u onoto)
+2|Agentes abrillantadores fluorescentes (tintes)
+2|Agentes de secado para pinturas y masillas
+2|Aglutinantes para pinturas
+2|Aglutinantes para pinturas y masillas
+2|Aluminio en polvo para pinturas
+2|Añil
+2|Añil como colorante
+2|Anticorrosivos en forma de revestimiento
+2|Azul de Prusia
+2|Barnices
+2|Barnices para uso en ebanistería
+2|Barnices que no sean barnices aislantes
+2|Bermellón
+2|Bernices para protección de pisos
+2|Blanco de cal
+2|Blanco titanio
+2|Brillantina
+2|Carmín de cochinilla
+2|Cartuchos de chorro de tinta (llenos)
+2|Cartuchos llenos de toner para impresoras y fotocopiadoras
+2|Cerusa
+2|Colorantes
+2|Colorantes ácidos
+2|Colorantes alimentarios
+2|Colorantes de anilina
+2|Colorantes directos
+2|Colorantes para fabricación de bebidas
+2|Colorantes para hormigón
+2|Colorantes para la fabricación de alimentos
+2|Colorantes para la fabricación de cosméticos
+2|Colorantes sintéticos
+2|Colorantes solubles en aceite
+2|Colorantes textiles
+2|Colores de aceite
+2|Conservante para cemento
+2|Copal
+2|Cúrcuma para uso como colorante
+2|Diluyentes para colores
+2|Diluyentes para lacas
+2|Diluyentes para pintura
+2|Esmaltes de cerámica
+2|Esmaltes para pintar
+2|Esmaltes vítreos
+2|Espesantes para colores
+2|Espesantes para pinturas
+2|Extracto de palo campeche (tintes)
+2|Extractos de palo de Campeche
+2|Goma laca
+2|Goma laca para pulido francés
+2|Grasas antioxidantes
+2|Hojas de metal para su uso por decoradores
+2|Imprimaciones
+2|Imprimaciones para preparar superficies que van a pintarse
+2|Laca japonesa (urushi)
+2|Lacas
+2|Lacas para impresión
+2|Lacas para la madera
+2|Lacas para pintores
+2|Lacas para revestir papeles
+2|Madera para su uso como tinte
+2|Materias tintóreas
+2|Metales en hoja y polvo para pintores
+2|Metales en hoja y polvo para pintores y decoradores
+2|Metales en hoja y polvo para pintores, decoradores, impresores y artistas
+2|Metales en hojas y polvos para pintores, decoradores, impresores y artistas
+2|Metales no ferrosos en hoja o polvo para para pintores, decoradores, impresores y artistas
+2|Metales preciosos en hoja o en polvo para pintores, decoradores y artistas
+2|Metales preciosos en hoja para pintores, decoradores y artistas
+2|Metales preciosos en polvo para pintores, decoradores, impresores y artistas
+2|Minio
+2|Mordientes para tintorería
+2|Negro de carbón (pigmento)
+2|Óxido de cobalto como colorante
+2|Papeles anticorrosivos
+2|Pastas de imprenta (tintas)
+2|Pigmentos
+2|Pigmentos colorantes
+2|Pigmentos fosforescentes
+2|Pigmentos fotocromáticos
+2|Pigmentos inorgánicos
+2|Pigmentos orgánicos
+2|Pigmentos para su uso en la preparación de tintas
+2|Pigmentos termocrómicos
+2|Pintura a prueba de fuego
+2|Pintura base para superficies que se van a pintar
+2|Pintura de imprimación
+2|Pintura en parches reubicables
+2|Pintura para artistas
+2|Pintura para suelos
+2|Pintura para suelos de hormigón
+2|Pintura sin disolventes
+2|Pinturas
+2|Pinturas a prueba de productos químicos
+2|Pinturas acrílicas
+2|Pinturas acrílicas para artistas
+2|Pinturas al temple
+2|Pinturas anticorrosivas
+2|Pinturas arquitectónicas
+2|Pinturas bactericidas
+2|Pinturas como revestimientos para madera
+2|Pinturas de aceite
+2|Pinturas de esmalte
+2|Pinturas de imprimación
+2|Pinturas de resina sintética
+2|Pinturas en polvo
+2|Pinturas en pulverizador
+2|Pinturas fluorescentes
+2|Pinturas ignífugas
+2|Pinturas impermeabilizantes
+2|Pinturas impermeables
+2|Pinturas luminosas
+2|Pinturas mezcladas
+2|Pinturas para automóviles
+2|Pinturas para camuflar equipo militar
+2|Pinturas para cerámica
+2|Pinturas para el casco inferior
+2|Pinturas protectoras de la herrumbre
+2|Pinturas reflectantes en aerosol
+2|Pinturas repelentes al agua
+2|Pinturas retardantes de fuego
+2|Pinturas y lacas
+2|Pinturas, lacas y barnices
+2|Polvo de cobre para pintar (pinturas)
+2|Polvo de magnesio para pintar (pinturas)
+2|Polvo de niobio para pintar (pinturas)
+2|Polvo de tantalio para pintar (pinturas)
+2|Polvo de zinc para pintar (pinturas)
+2|Polvos de imprimación (jinoko)
+2|Polvos de imprimación (kiriko)
+2|Polvos de metales preciosos para su uso por pintores, decoradores, impresores y artistas
+2|Preparaciones para revestimiento con propiedades repelentes al agua (pintura)
+2|Preparaciones para tratar y conservar la madera
+2|Preparados antioxidantes en forma de recubrimiento para su uso en vehículos
+2|Productos para conservar la madera
+2|Recubrimientos endurecibles por radiación para hormigón
+2|Resinas naturales en bruto
+2|Resinas naturales para su uso en la fabricación de adhesivos
+2|Revestimiento de superficie coloreado no metálico para fabricación de piscinas y spas de fibra de vidrio
+2|Revestimiento decorativo de pulverización
+2|Revestimientos de pintura anticorrosiva para uso comercial marino
+2|Revestimientos de protección para chasis de vehículos
+2|Revestimientos de resina epoxi para su uso sobre pavimentos industriales de hormigón
+2|Revestimientos en forma de pinturas
+2|Revestimientos impermeabilizantes (pinturas)
+2|Revestimientos protectores transparentes para vehículos
+2|Revestimientos utilizados para el acabado de muebles
+2|Rubia
+2|Sandáraca (resina)
+2|Secantes para colores
+2|Témperas
+2|Tinta de imprenta intaglio
+2|Tinta de impresión
+2|Tinta de mimeógrafos
+2|Tinta para tatuaje
+2|Tinta planográfica
+2|Tintas de copiado
+2|Tintas de fragancias microencapsuladas para impresión flexográfica
+2|Tintas de imprenta
+2|Tintas metálicas
+2|Tintas para grabado
+2|Tintas para impresoras de chorro de tinta
+2|Tintas para tatuar
+2|Tintas secas
+2|Tintas termocrómicas para impresión
+2|Tintes básicos (tintes catiónicos)
+2|Tintes de azufre
+2|Tintes de naftol
+2|Tintes disolubles en alcohol
+2|Tintes naturales
+2|Tintes para madera
+2|Tintes rápidos
+2|Tóner
+2|Tóner (tinta) para fotocopiadoras
+2|Tóner de impresión
+2|Tóner de tinta
+2|Tóner xerográfico
+2|Tóneres
+2|Trementina (diluyente para pinturas)
+2|Trementina de resina para su uso como diluyente de pintura
+2|Vidriados (barnices vítreos)

--- a/lib/seeds/class_30_terms.csv
+++ b/lib/seeds/class_30_terms.csv
@@ -1,338 +1,627 @@
-class,reference_id,name
-30,300002,algas [condimentos]
-30,300003,pastas alimenticias
-30,300004,pasta de almendras
-30,300006,anís [semillas]
-30,300007,anís estrellado
-30,300008,productos de confitería para decorar árboles de Navidad
-30,300009,infusiones que no sean para uso médico
-30,300010,aromatizantes de café
-30,300010,saborizantes de café
-30,300011,preparaciones aromáticas para uso alimenticio
-30,300012,productos para sazonar
-30,300013,pan ácimo
-30,300013,pan ázimo
-30,300014,sal para conservar alimentos
-30,300015,biscotes
-30,300016,galletas*
-30,300017,galletas de malta
-30,300019,caramelos de menta
-30,300019,dulces de menta
-30,300020,caramelos
-30,300020,golosinas
-30,300022,gofres
-30,300022,barquillos
-30,300022,conos [barquillos]
-30,300023,brioches
-30,300023,bollos
-30,300024,cacao
-30,300026,café
-30,300027,café sin tostar
-30,300028,preparaciones vegetales utilizadas como sucedáneos del café
-30,300029,pasteles*
-30,300029,tortas [pasteles]
-30,300030,canela [especia]
-30,300031,alcaparras
-30,300032,caramelos blandos
-30,300033,curry [condimento]
-30,300034,preparaciones a base de cereales
-30,300035,gomas de mascar*
-30,300035,chicles*
-30,300036,achicoria [sucedáneo del café]
-30,300037,té*
-30,300038,chocolate
-30,300039,mazapán
-30,300040,clavo [especia]
-30,300041,condimentos
-30,300042,productos de confitería
-30,300042,dulces
-30,300043,copos de maíz
-30,300043,hojuelas de maíz
-30,300044,palomitas de maíz
-30,300044,rosetas de maíz
-30,300045,estabilizantes para nata montada
-30,300045,estabilizantes para crema batida
-30,300046,helados cremosos
-30,300047,creps [filloas]
-30,300047,panqueques
-30,300047,tortitas
-30,300048,esencias para alimentos, excepto esencias etéricas y aceites esenciales
-30,300049,sal de cocina
-30,300050,espesantes para uso culinario
-30,300051,cúrcuma*
-30,300053,edulcorantes naturales
-30,300054,especias
-30,300055,pan de especias
-30,300055,pan de jengibre
-30,300056,pimienta de Jamaica
-30,300057,harinas*
-30,300058,harina de habas
-30,300058,harina de alubias
-30,300058,harina de frijoles
-30,300058,harina de judías
-30,300058,harina de porotos
-30,300059,harina de maíz
-30,300060,harina de mostaza
-30,300061,harina de cebada
-30,300062,harina de soja
-30,300062,harina de soya
-30,300063,harina de flor
-30,300063,harina de trigo
-30,300065,almidón para uso alimenticio
-30,300065,fécula para uso alimenticio
-30,300066,fermentos para masas
-30,300067,pasta de azúcar [producto de confitería]
-30,300068,petits fours
-30,300069,azúcar*
-30,300070,aromatizantes, que no sean aceites esenciales, para productos de pastelería y repostería
-30,300070,saborizantes, que no sean aceites esenciales, para productos de pastelería y repostería
-30,300071,polvos para productos de pastelería y repostería
-30,300072,mezclas pasteleras
-30,300073,jengibre molido
-30,300074,espesantes para helados cremosos
-30,300075,hielo natural o artificial
-30,300076,hielo
-30,300077,glucosa para uso culinario
-30,300078,gluten preparado en forma de producto alimenticio
-30,300080,grañones para la alimentación humana
-30,300081,vinagres
-30,300082,ketchup [salsa]
-30,300083,cacao con leche
-30,300084,café con leche
-30,300085,chocolate con leche [bebida]
-30,300086,fermento [levadura]
-30,300087,levadura*
-30,300088,espesantes para salchichas
-30,300089,macarons [pastelería]
-30,300090,macarrones [pastas alimenticias]
-30,300091,maíz molido
-30,300092,maíz tostado
-30,300093,pan*
-30,300094,maltosa
-30,300095,melaza
-30,300096,jarabe de melaza
-30,300096,sirope de melaza
-30,300097,menta para productos de confitería
-30,300098,miel
-30,300100,cebada mondada
-30,300101,mostaza
-30,300102,nuez moscada
-30,300103,fideos
-30,300104,tartas saladas
-30,300104,empanadas
-30,300105,cebada molida
-30,300106,sándwiches
-30,300106,bocadillos y emparedados
-30,300107,pastillas [productos de confitería]
-30,300108,productos de pastelería
-30,300109,galletas de mantequilla
-30,300109,galletas [petits-beurre]
-30,300110,panecillos
-30,300111,pimentón [producto para sazonar]
-30,300111,ajíes [productos para sazonar]
-30,300111,chiles [productos para sazonar]
-30,300111,páprika [producto para sazonar]
-30,300112,pizzas
-30,300113,pimienta
-30,300114,harina de patata*
-30,300114,harina de papa*
-30,300115,pudines
-30,300115,budines
-30,300116,pralinés
-30,300116,bombones de chocolate
-30,300116,garrapiñadas
-30,300117,raviolis
-30,300117,ravioles
-30,300118,regaliz [productos de confitería]
-30,300119,arroz*
-30,300120,azafrán [productos para sazonar]
-30,300121,sagú
-30,300122,salsas [condimentos]
-30,300123,sal de apio
-30,300124,sémola
-30,300125,sorbetes [helados]
-30,300126,espaguetis
-30,300127,tapioca
-30,300128,harina de tapioca*
-30,300129,tartas
-30,300130,aromatizantes de vainilla para uso culinario
-30,300130,saborizantes de vainilla para uso culinario
-30,300131,vainillina [sucedáneo de la vainilla]
-30,300132,fideos vermicelli
-30,300133,pasteles de carne [empanadas de carne]
-30,300133,empanadas de carne [pasteles de carne]
-30,300134,patés en costra
-30,300135,ablandadores de carne para uso doméstico
-30,300136,helados
-30,300136,nieves [helados]
-30,300137,polvos para preparar helados cremosos
-30,300138,productos de confitería a base de almendras
-30,300139,productos de confitería a base de cacahuetes
-30,300139,productos de confitería a base de cacahuate
-30,300139,productos de confitería a base de maní
-30,300140,aromatizantes alimentarios que no sean aceites esenciales
-30,300140,saborizantes alimentarios que no sean aceites esenciales
-30,300141,aromatizantes, que no sean aceites esenciales, para bebidas
-30,300141,saborizantes, que no sean aceites esenciales, para bebidas
-30,300142,avena molida
-30,300143,avena mondada
-30,300144,alimentos a base de avena
-30,300145,copos de avena
-30,300145,hojuelas de avena
-30,300146,sémola de avena
-30,300147,barritas de regaliz [productos de confitería]
-30,300148,vinagre de cerveza
-30,300149,bebidas a base de café
-30,300150,bebidas a base de cacao
-30,300151,bebidas a base de chocolate
-30,300152,sucedáneos del café
-30,300153,azúcar candi*
-30,300153,azúcar piedra
-30,300161,copos de cereales secos
-30,300161,hojuelas de cereales secos
-30,300162,chow-chow [condimento]
-30,300163,cuscús
-30,300164,extractos de malta para uso alimenticio
-30,300165,malta para la alimentación humana
-30,300166,propóleos*
-30,300167,relish [condimento]
-30,300167,salsa de pepinillos dulces [relish]
-30,300168,jalea real*
-30,300169,agua de mar para uso culinario
-30,300170,sushi
-30,300171,salsa de tomate
-30,300172,mayonesa
-30,300174,galletas saladas [crackers]
-30,300175,crema inglesa
-30,300176,pasta de frutas [producto de confitería]
-30,300176,gomitas [productos de confitería]
-30,300177,muesli
-30,300178,pastelitos de arroz
-30,300179,salsa de soja
-30,300179,salsa de soya
-30,300181,yogur helado [helado cremoso]
-30,300182,chutney [condimento]
-30,300183,rollitos de primavera
-30,300183,rollitos primavera
-30,300184,tacos [alimentos]
-30,300185,tortillas de harina o maíz
-30,300186,té helado
-30,300187,bebidas a base de té
-30,300188,aliños para ensalada
-30,300188,aderezos para ensalada
-30,300189,pan rallado
-30,300189,pan molido
-30,300190,tabulé
-30,300191,halvas
-30,300192,quiches
-30,300193,jugos de carne
-30,300193,salsas de carne [gravies]
-30,300194,miso
-30,300195,refrigerios a base de cereales
-30,300196,refrigerios a base de arroz
-30,300197,papilla de harina de maíz con agua o leche [hominy]
-30,300197,hominy [maíz descascarillado]
-30,300197,maíz descascarillado [hominy]
-30,300198,sémola de maíz descascarillado
-30,300199,polvos de hornear
-30,300200,bicarbonato de soda para uso culinario
-30,300200,bicarbonato de sosa para uso culinario
-30,300201,hierbas aromáticas en conserva [productos para sazonar]
-30,300202,comidas preparadas a base de fideos
-30,300203,preparaciones para glasear pasteles
-30,300204,mousse de chocolate
-30,300205,mousses de postre [productos de confitería]
-30,300206,coulis de frutas [salsas]
-30,300207,adobos
-30,300208,hamburguesas con queso [sándwiches]
-30,300209,pesto
-30,300210,preparaciones para glasear jamón
-30,300212,semillas de lino para uso culinario [productos para sazonar]
-30,300212,linaza para la alimentación humana [productos para sazonar]
-30,300213,germen de trigo para la alimentación humana
-30,300214,barritas de cereales ricas en proteínas
-30,300215,crémor tártaro para uso culinario
-30,300216,aditivos de gluten para uso culinario
-30,300217,salsas para pastas alimenticias
-30,300218,barras de cereales
-30,300219,azúcar de palma
-30,300220,masa para hornear
-30,300221,sucedáneos del té a base de flores u hojas
-30,300222,masa de pastelería
-30,300224,pelmeni
-30,300225,decoraciones de chocolate para pasteles
-30,300226,decoraciones de azúcar para pasteles
-30,300227,frutos secos recubiertos de chocolate
-30,300228,arroz con leche
-30,300229,harina de frutos secos
-30,300230,ajo molido [condimento]
-30,300231,baozi
-30,300232,pasta de arroz para uso culinario
-30,300233,jiaozi
-30,300234,ramen
-30,300235,tortitas saladas
-30,300236,mezclas para tortitas saladas
-30,300237,burritos mexicanos
-30,300238,arroz preparado enrrollado en hojas de algas
-30,300239,papel comestible
-30,300240,papel de arroz comestible
-30,300241,pastas para untar a base de chocolate
-30,300242,pastas para untar a base de chocolate con frutos secos
-30,300243,bolas de masa guisada a base de harina
-30,300244,sirope de agave [edulcorante natural]
-30,300245,glaseados brillantes
-30,300246,platos liofilizados cuyo ingrediente principal es el arroz
-30,300247,platos liofilizados cuyo ingrediente principal son las pastas alimenticias
-30,300248,bebidas a base de manzanilla
-30,300249,dulce de leche
-30,300250,bibimbap [arroz mezclado con ternera y verduras]
-30,300251,onigiri
-30,300252,arroz instantáneo
-30,300253,perritos calientes
-30,300253,perros calientes
-30,300254,cubitos de hielo
-30,300255,semillas procesadas en cuanto productos para sazonar
-30,300256,semillas de sésamo [productos para sazonar]
-30,300257,picalilli [encurtido]
-30,300258,quinoa procesada
-30,300259,bulgur
-30,300260,trigo sarraceno procesado
-30,300261,harina de trigo sarraceno
-30,300262,salsa de arándanos rojos [condimento]
-30,300263,salsa de manzana
-30,300264,tostones [pan frito]
-30,300264,picatostes
-30,300264,crutones
-30,300265,panes planos a base de patata
-30,300267,productos de confitería a base de frutas
-30,300268,galletas saladas de arroz
-30,300269,tortitas de kimchi
-30,300270,hielo picado con alubias rojas dulces
-30,300270,hielo picado con frijoles rojos dulces
-30,300271,pastillas de menta para refrescar el aliento
-30,300272,gomas de mascar para refrescar el aliento
-30,300273,fideos udon
-30,300274,fideos soba
-30,300275,pan sin gluten
-30,300276,tamarindo [condimento]
-30,300277,laksa
-30,300278,profiteroles
-30,300279,cruasanes
-30,300280,napolitanas de chocolate
-30,300280,chocolatines de hojaldre
-30,300281,té de algas kombu
-30,300282,crème brûlée
-30,300282,crema quemada
-30,300283,masa para rebozar
-30,300283,masa para freír
-30,300284,obleas de papel comestible
-30,300285,cocadas
-30,300285,rocas de coco
-30,300286,cápsulas de café, llenas
-30,300287,agua de azahar para uso alimenticio
-30,300288,polos y polos flash
-30,300288,bolis y paletas de hielo
-30,300289,turrón
-30,300290,harissa [condimento]
-30,300291,pasta de jengibre [producto para sazonar]
-30,300292,bebidas de té con leche
+class|name
+30|Aceite de chiles como condimento o aderezo
+30|Achicoria y mezclas de achicoria, todas para su uso como sucedáneos del café
+30|Aderezo para ensalada
+30|Aderezos para ensalada
+30|Aderezos para ensalada que contienen crema
+30|Agentes espesantes para uso culinario
+30|Agua de mar para uso culinario
+30|Aioli
+30|Ajo en polvo
+30|Alfajores (pastelillos rellenos de dulce de leche)
+30|Algodón de azúcar
+30|Almíbar para cubrir
+30|Almidón de maíz para uso alimenticio
+30|Almidón de palma de sagú para alimentación
+30|Almidón de patata dulce para alimentación
+30|Aromatizantes de hierbas para elaborar bebidas
+30|Aromatizantes para mantequilla que no sean aceites esenciales
+30|Aromatizantes para queso que no sean aceites esenciales
+30|Aromatizantes para sopas (que no sean aceites esenciales)
+30|Aromatizantes que no sean aceites esenciales para productos de pastelería y repostería
+30|Arroz al vapor
+30|Arroz artificial sin cocer
+30|Arroz cocinado
+30|Arroz descascarillado
+30|Arroz enriquecido sin cocinar
+30|Arroz glutinoso
+30|Arroz glutinoso envuelto en hojas de bambú (Zongzi)
+30|Arroz inflado
+30|Arroz integral
+30|Arroz malteado fermentado (koji)
+30|Arroz seco cocinado
+30|Avena instantánea
+30|Avena mondada
+30|Azúcar
+30|Azúcar blanca
+30|Azúcar candi para uso alimenticio
+30|Azúcar cristalizada para decorar alimentos
+30|Azúcar cristalizada para decorar pasteles
+30|Azúcar de cristal que no sea de confitería
+30|Azúcar de palma
+30|Azúcar en cubos
+30|Azúcar en polvo
+30|Azúcar granulada
+30|Azúcar mascabado
+30|Bagels (rosca de pan)
+30|Baguettes
+30|Baklava (pastelillo a base de pistachos o nueces, masa filo y almíbar)
+30|Barquillos para helados cremosos
+30|Barquillos rellenos de mermelada de judías (monaka)
+30|Barras de cereales
+30|Barras de chocolate
+30|Barras de helados comestibles
+30|Barras de hielo
+30|Barras de pasta de porotos dulces en gelatina (yohkan)
+30|Barras heladas de fruta
+30|Barritas de caramelo
+30|Barritas de cereales ricas en proteínas
+30|Barritas de torrija congeladas
+30|Bases de pizza
+30|Bases de pizza congeladas
+30|Bases de tacos
+30|Bases para tartas
+30|Bebidas a base de cacao
+30|Bebidas a base de café
+30|Bebidas a base de chocolate
+30|Bebidas a base de té
+30|Bebidas basadas en el té con sabor a frutas
+30|Bebidas de cacao con leche
+30|Bebidas de café
+30|Bebidas de café con leche
+30|Bebidas lácteas a base de chocolate
+30|Biscotes
+30|Bizcochería
+30|Bizcocho de chocolate y nueces
+30|Bizcochos
+30|Bizcochuelos en forma de paleta (cake pops)
+30|Bocadillos a base de maíz
+30|Bocadillos a base de trigo
+30|Bolas de arroz glutinoso
+30|Bolas de masa al vapor chinas (shumai, cocidas)
+30|Bolas de masa dulce (dango)
+30|Bolitas de arroz (dumplings)
+30|Bolitas de azúcar para confitería
+30|Bollería (productos a base de harina)
+30|Bollitos (dumplings) a base de harina
+30|Bollos (pan)
+30|Bollos al vapor rellenos de carne picada (niku-manjuh)
+30|Bollos de crema
+30|Bollos de mermelada
+30|Bollos de mermelada de judías
+30|Bombones de azúcar
+30|Brioches
+30|Budín de arroz
+30|Buñuelos de arroz recubiertos con mermelada de alubias dulces (ankoro)
+30|Cacao
+30|Cacao en polvo
+30|Cacao tostado, en polvo, en grano o en bebida
+30|Cacao y bebidas a base de cacao preparados
+30|Café
+30|Café descafeinado
+30|Café en polvo en formato de bolsas de goteo
+30|Café exprés
+30|Café helado
+30|Café instantáneo
+30|Café molido
+30|Café sin cafeína
+30|Café sin tostar
+30|Café tostado, en polvo, granulado o en bebidas
+30|Café y bebidas a base de café preparados
+30|Café y sucedáneos del café
+30|Café y té
+30|Calugas (caramelos blandos)
+30|Calzones rotos (masas fritas)
+30|Canela en polvo (especia)
+30|Canelones
+30|Capuchino
+30|Caracolas de pasta
+30|Caramelo
+30|Caramelos
+30|Caramelos (dulces)
+30|Caramelos de azúcar cocido
+30|Caramelos de ginseng
+30|Caramelos de ginseng rojo
+30|Caramelos de goma
+30|Caramelos de menta
+30|Caramelos macizos cubiertos de azúcar
+30|Caramelos masticables a base de gelatina
+30|Caramelos sin azúcar
+30|Cebada mondada
+30|Cebada triturada
+30|Cereales listos para comer
+30|Cereales para el desayuno
+30|Chacarero (sándwich a base de carne, porotos verdes, tomate y ají verde)
+30|Chalotas procesadas para su uso como condimento
+30|Chaparritas (masas horneadas rellenas con salchicha y queso)
+30|Chicles de bomba
+30|Chile en polvo (especia)
+30|Chimney cakes (cucuruchos de masa dulce rellenos)
+30|Chips de arroz
+30|Chips de wan tan
+30|Chocolate
+30|Chocolate caliente
+30|Chocolate caliente vegano
+30|Chocolate con leche
+30|Chocolate para coberturas
+30|Chocolate para confitería y pan
+30|Chocolate relleno
+30|Chocolate sin leche
+30|Chocolates (confitería)
+30|Chocolates en polvo
+30|Churros (masas fritas)
+30|Churros fritos (Youtiao)
+30|Chutney
+30|Chutneys (condimento)
+30|Clavo en polvo (especia)
+30|Comidas preparadas a base de fideos
+30|Condimento de chile
+30|Condimento para tacos
+30|Condimentos a base de mezclas de curry
+30|Condimentos alimentarios que consisten principalmente en kétchup y salsa
+30|Condimentos en polvo
+30|Condimentos para carne de cordero hervida al instante
+30|Confitería helada
+30|Confituras de chocolate
+30|Copos de avena
+30|Copos de maíz
+30|Corteza de chocolate con granos de café molidos
+30|Crema inglesa
+30|Cremas bávaras
+30|Crème brûlées (crema quemada)
+30|Crepes
+30|Creps (filloas)
+30|Croissants
+30|Cubitos de hielo
+30|Cuchuflís (dulces de masa esponjosa o crocante rellenos con dulce de leche en forma tubular)
+30|Cúrcuma comestible
+30|Curry en polvo (condimento)
+30|Cuscús (sémola)
+30|Delicia turca
+30|Dobladitas (panes)
+30|Donas
+30|Dulce con cacao
+30|Dulce con caramelo
+30|Dulce de menta
+30|Dulces
+30|Dulces (caramelos)
+30|Dulces a base de almidón
+30|Dulces con una base de almidón (ame)
+30|Dulces de chocolate
+30|Dulces de helado
+30|Dulces de yogur helado
+30|Dulces hechos de aceite de sésamo
+30|Dulces prensados tradicionales coreanos (dasik)
+30|Empanadas
+30|Empanadillas de masa rellenas chinas (gyoza, cocinadas)
+30|Empolvados (pastelillos cubiertos de azúcar en polvo)
+30|Envolturas de pasta para gyoza (empanadilla japonesa)
+30|Envolturas de pastelería para monaka (dulce japonés)
+30|Envolturas de won ton
+30|Esencias de café
+30|Esencias de café para uso como sucedáneos del café
+30|Espagueti sin cocinar
+30|Espaguetis y albóndigas
+30|Especia en polvo de pimiento japonés (sansho en polvo)
+30|Especia en polvo de rábano picante japonés (wasabi en polvo)
+30|Especias comestibles
+30|Especias para hornear
+30|Extractos de cacao para consumo humano
+30|Extractos de café
+30|Extractos de café para uso como sucedáneos de café
+30|Extractos de levadura
+30|Extractos de levadura para consumo humano
+30|Extractos de levadura para uso alimenticio
+30|Extractos de té
+30|Fideos
+30|Fideos asiáticos
+30|Fideos chinos instantáneos
+30|Fideos chinos sin cocinar
+30|Fideos de almidón de frijol verde sin cocinar (harusame)
+30|Fideos de arroz
+30|Fideos de arroz chinos sin cocinar (fideos bifun)
+30|Fideos de fécula
+30|Fideos de ramen
+30|Fideos fritos
+30|Fideos fritos con vegetales (japchae)
+30|Fideos instantáneos
+30|Fideos secos
+30|Fideos soba instantáneos
+30|Fideos soba sin cocinar (fideos de alforfón japoneses)
+30|Fideos somen sin cocinar (fideo muy delgado de trigo)
+30|Fideos udon instantáneos
+30|Fideos udon sin cocinar
+30|Frappes (café con hielo cubierto de espuma)
+30|Fructosa para alimentación
+30|Frutos secos recubiertos de chocolate
+30|Gachas (plato elaborado en base a avena cocida)
+30|Gachas a base de judías mungo
+30|Gachas de arroz
+30|Gachas de harina de arroz
+30|Galletas
+30|Galletas con sabor a queso
+30|Galletas de almendras
+30|Galletas de arroz con forma de gránulos (arare)
+30|Galletas de cebolla o queso
+30|Galletas de malta
+30|Galletas de mantequilla
+30|Galletas de masa frita (karintoh)
+30|Galletas Graham
+30|Galletas saladas
+30|Galletas saladas (crackers)
+30|Galletas saladas condimentadas
+30|Galletas saladas de arroz (senbei)
+30|Galletas y galletas saladas
+30|Galletas y pan
+30|Glaseado para pasteles
+30|Glaseado para tartas
+30|Glucosa para uso alimenticio
+30|Gofres
+30|Gofres (waffles)
+30|Gofres comestibles
+30|Gofres congelados
+30|Golosinas
+30|Golosinas en goma de frutas
+30|Goma de mascar sin azúcar
+30|Goma guar para uso culinario
+30|Gomas de mascar
+30|Gomas de mascar que no sean para uso médico
+30|Granos de café cubiertos de azúcar
+30|Granos de café molidos
+30|Granos de cereales procesados
+30|Granos de maíz tostados
+30|Granos procesados
+30|Hamburguesas en panecillos
+30|Harina alimenticia
+30|Harina de almidón de arroz
+30|Harina de almidón de maíz
+30|Harina de almidón de trigo
+30|Harina de arroz
+30|Harina de arroz glutinoso
+30|Harina de cebada para uso alimenticio
+30|Harina de grano para alimentación
+30|Harina de maíz
+30|Harina de maíz para uso alimenticio
+30|Harina de papa para uso alimenticio
+30|Harina de semillas de lágrimas de Job
+30|Harina de tapioca para uso alimenticio
+30|Harina de trigo para uso alimenticio
+30|Harina de trigo sarraceno para uso alimenticio
+30|Harina para hacer bolas de masa cocida rellenas de arroz glutinoso
+30|Helados
+30|Helados con fruta
+30|Helados cremosos
+30|Helados cremosos en polvo
+30|Helados cremosos mezclados
+30|Helados de fruta
+30|Helados de frutas
+30|Hielo
+30|Hierbas de jardín preservadas como aliños
+30|Infusión de tila
+30|Jarabe de fécula para uso alimenticio
+30|Jarabe de maíz para uso culinario
+30|Judías dulces (ama-natto)
+30|Jugos de carne (salsas)
+30|Lasaña
+30|Laurel (condimento)
+30|Leche asada (postre de budín a base de leche, huevos y azúcar)
+30|Leche nevada (postre a base de merengue)
+30|Levadura
+30|Levadura en comprimidos que no sea para uso médico
+30|Levadura en polvo
+30|Levadura para uso como ingrediente alimentario
+30|Levadura, polvos de hornear y saborizantes
+30|Linaza para la alimentación humana
+30|Lo mein (fideos)
+30|Macarons (productos de pastelería)
+30|Macarrones (galletas) a base de coco
+30|Macarrones (sin cocinar)
+30|Macarrones con queso
+30|Magdalenas (quequitos)
+30|Maíz procesado
+30|Maíz tostado
+30|Maltosa para alimentación
+30|Malvavisco
+30|Manjar (dulce de leche)
+30|Manzanas caramelizadas
+30|Masa de obleas
+30|Masa filo
+30|Masa para bizcochos de chocolate con nueces (brownies)
+30|Masa para empanada
+30|Masa para galletas congelada
+30|Masa para gofres
+30|Masa para hornear
+30|Masa para pastelería
+30|Masa para pizzas
+30|Masas al vapor rellenas con pasta de porotos rojos
+30|Masas al vapor rellenas de porotos rojos
+30|Masas de pastel de pan crujiente tipo Graham
+30|Masas para bollos
+30|Masas para pan
+30|Masas para pastel
+30|Masticables (golosinas blandas)
+30|Mayonesa
+30|Melazas
+30|Menta para confitería
+30|Merengues
+30|Merkén (condimento)
+30|Mermelada de alubia dulce con recubrimiento blando con una base de alubia azucarada (nerikiri)
+30|Mezcla de pan a base de maíz
+30|Mezclas condimentadas para guisos
+30|Mezclas de cacao
+30|Mezclas de café y achicoria
+30|Mezclas de galletas
+30|Mezclas de gelatina de alubia de adzuki dulce (mizu-yokan-no-moto)
+30|Mezclas de pastelería
+30|Mezclas de sorbetes
+30|Mezclas de tortas
+30|Mezclas instantáneas para budín
+30|Mezclas instantáneas para donas
+30|Mezclas instantáneas para panqueques
+30|Mezclas para condimentar
+30|Mezclas para masa de pizza
+30|Mezclas para preparar chocolate caliente
+30|Miel para uso alimenticio
+30|Miel y jarabe de melaza
+30|Milhojas
+30|Molletes
+30|Molletes ingleses
+30|Mostaza
+30|Mostaza en polvo (especias)
+30|Nieves y helados cremosos
+30|Obleas para base de tartas
+30|Orégano (condimento)
+30|Pad thai (tallarines salteados tailandeses)
+30|Paella (plato preparado a base de arroz)
+30|Palitos de arroz
+30|Palitos de pan
+30|Palomitas de maíz
+30|Palomitas de maíz agridulces
+30|Palomitas de maíz aromatizadas
+30|Palomitas de maíz azucaradas
+30|Palomitas de maíz cubiertas de caramelo
+30|Palomitas de maíz glaseadas
+30|Pan
+30|Pan ácimo en láminas
+30|Pan con azukis (legumbres de color rojizo y dulces típicas de Japón)
+30|Pan con bajo contenido de sal
+30|Pan con sabor a especias
+30|Pan con soja
+30|Pan crujiente al estilo indio (poppadums)
+30|Pan de ajo
+30|Pan integral
+30|Pan molido
+30|Pan pita
+30|Pan plano
+30|Pan tostado
+30|Panecillos de canela
+30|Panes de frutas
+30|Panes de molde
+30|Panes de pascua
+30|Panes y bollos
+30|Panetón
+30|Panqueques congelados
+30|Panqueques de cebolla verde (pajeon)
+30|Panqueques de kimchi (kimchijeon)
+30|Pantrucas (plato a base de masas, verduras y carne)
+30|Papilla de harina de maíz con agua o leche (hominy)
+30|Pasta alimenticia
+30|Pasta alimenticia fresca
+30|Pasta de almendras
+30|Pasta de azúcar (producto de confitería)
+30|Pasta de frutas como saborizante de alimentos
+30|Pasta de guindilla fermentada (gochujang)
+30|Pasta de miso
+30|Pasta de soja (condimento)
+30|Pasta para biscotes
+30|Pasta seca
+30|Pasta y fideos
+30|Pastas alimenticias
+30|Pastas alimenticias farináceas para consumo humano
+30|Pastas alimenticias rellenas
+30|Pastas danesas
+30|Pastas de chocolate
+30|Pastas de curry
+30|Pastas para sopas
+30|Pastel de almendras
+30|Pastel de chocolate
+30|Pastel de helado
+30|Pasteles (torta)
+30|Pasteles al vapor de tipo japonés (mushi-gashi)
+30|Pasteles con azúcar desecados de harina de arroz (rakugan)
+30|Pasteles de arroz machacado dulce (mochi-gashi)
+30|Pasteles de arroz triturado (mochi)
+30|Pasteles de frutas
+30|Pasteles de frutas (plum cakes)
+30|Pasteles de luna
+30|Pasteles de mijo
+30|Pasteles de mijo envueltos en azúcar o arroz inflado (okoshi)
+30|Pasteles dulces de frutas, pasas y especias
+30|Pasteles enrollados en forma de broche blandos de arroz machacado (gyuhi)
+30|Pasteles esponjosos al vapor (Fa Gao)
+30|Pasteles veganos
+30|Pastelillos de fruta
+30|Pastelitos de arroz
+30|Pastelitos de avena
+30|Pastelitos de crema
+30|Pastelitos dulces y salados (productos de pastelería)
+30|Pebre (salsa)
+30|Pepitas de chocolate
+30|Pepitas de manteca y azúcar
+30|Pepitos rellenos de crema
+30|Petit-beurre (galletas)
+30|Piezas de azúcar de cristal (confitería)
+30|Piezas secas de gluten de trigo (fu, no cocinadas)
+30|Pimienta (especia)
+30|Pimienta en polvo (especias)
+30|Pizza congelada
+30|Pizza fresca
+30|Pizzas preparadas
+30|Polvo de arruruz japonés (kudzu-ko para uso alimenticio)
+30|Polvo de pimienta roja (gochutgaru)
+30|Polvos de hornear
+30|Postres
+30|Postres de budín
+30|Postres de budín a base de arroz
+30|Pralinés
+30|Pretzels (galletas saladas)
+30|Pretzels blandos
+30|Pretzels con cobertura de chocolate
+30|Pretzels recubiertos de chocolate
+30|Productos de confitería elaborada con azúcar
+30|Productos de confitería para decorar árboles de Navidad
+30|Productos de pastelería
+30|Productos de pastelería y repostería
+30|Productos para sazonar alimentos
+30|Propóleos (resina de abeja) para la alimentación humana
+30|Pudin de arroz ocho tesoros
+30|Pudines para postes instantáneos
+30|Pudines para su uso como postre
+30|Quinoa procesada
+30|Rábano picante preparado (condimento)
+30|Ravioli preparados
+30|Regaliz
+30|Relleno de malvavisco
+30|Revestimientos de chocolate
+30|Rollitos de avena y de trigo
+30|Rollos de alga seca que contienen arroz cocido estilo koreano (gimbap)
+30|Rollos de salchichas
+30|Saborizantes de almendra
+30|Saborizantes de fruta excepto esenciales
+30|Saborizantes de limón
+30|Saborizantes de té
+30|Saborizantes de vainilla
+30|Saborizantes para alimentos
+30|Saborizantes para bebidas que no sean aceites esenciales
+30|Saborizantes para mantequilla
+30|Saborizantes para pasteles que no sean aceites esenciales
+30|Saborizantes para quesos
+30|Saborizantes para sopas
+30|Saborizantes que no sean aceites esenciales
+30|Saborizantes que no sean aceites esenciales para productos de pastelería y repostería
+30|Saborizantes y productos para sazonar
+30|Sachima (pastel chino)
+30|Sal
+30|Sal comestible
+30|Sal con azafrán para condimentar alimentos
+30|Sal de apio
+30|Sal de cocina
+30|Sal de mesa
+30|Sal de mesa mezclada con semillas de sésamo
+30|Salmuera para cocinar
+30|Salmuera para cócteles
+30|Salsa Alfredo
+30|Salsa condimentada de soja (Chiyou)
+30|Salsa de barbacoa
+30|Salsa de chile
+30|Salsa de chocolate
+30|Salsa de langostino
+30|Salsa de ostra
+30|Salsa de soja (salsa de soya)
+30|Salsa de soya con kombu (alga asiática)
+30|Salsa kétchup
+30|Salsa marrón
+30|Salsa para tacos
+30|Salsa tártara
+30|Salsa teriyaki
+30|Salsas
+30|Salsas listas para comer
+30|Salsas para carne a la barbacoa
+30|Salsas para ensalada
+30|Salsas para pastas alimenticias
+30|Salsas para pescado
+30|Sambal oelek (salsa de pimiento rojo molido)
+30|Samosas
+30|Sándwiches de hamburguesa
+30|Sándwiches de perritos calientes
+30|Sándwiches de pescado
+30|Savarines
+30|Sémola con leche (postre de budín a base de sémola, azúcar y leche)
+30|Sémola de maíz descascarillado
+30|Sirope de almidón en polvo para uso alimenticio
+30|Sirope de almidón glutinoso (mizu-ame)
+30|Sirope de arce
+30|Sirope de chocolate
+30|Sirope de melaza
+30|Sirope para panqueque
+30|Sorbete
+30|Sorbetes
+30|Soufflés de postre
+30|Sucedáneo de mayonesa
+30|Sucedáneos de café (café artificial o preparaciones vegetales utilizadas como café)
+30|Sucedáneos de helado a base de soja
+30|Sucedáneos de mazapán
+30|Sucedáneos de miel
+30|Sucedáneos del azúcar
+30|Sucedáneos del café
+30|Sucedáneos del café y té
+30|Sucedáneos del té
+30|Sushi
+30|Tabulé
+30|Taiyaki (pasteles japoneses con forma de pez con varios rellenos)
+30|Tallarines de fécula
+30|Tarta de queso
+30|Tartaletas de crema inglesa
+30|Tartas de arándanos
+30|Tartas de calabaza
+30|Tartas de helado
+30|Tartas de huevos
+30|Tartas de nata
+30|Tartas heladas
+30|Tartas saladas
+30|Té
+30|Té amarillo
+30|Té blanco
+30|Té blanco instantáneo
+30|Té chai
+30|Té de arroz integral tostado
+30|Te de cebada
+30|Te de damasco asiático (maesilcha)
+30|Té de ginseng
+30|Té de jengibre
+30|Té de lima
+30|Te de loto blanco (Baengnyeoncha)
+30|Té de manzanilla
+30|Té de menta
+30|Té de oolong (té chino)
+30|Té de polvo de alga marina salada (kombu-cha)
+30|Té de polvo tostado de cebada con cáscara (mugi-cha)
+30|Té de pomelo
+30|Té de rosa mosqueta
+30|Té de salvia
+30|Té fermentado
+30|Té instantáneo
+30|Té negro (té inglés)
+30|Té negro instantáneo
+30|Té oolong instantáneo
+30|Té sin teína
+30|Té sin teína endulzado con edulcorantes
+30|Té tie guan yin
+30|Té verde
+30|Té verde instantáneo
+30|Té verde japonés
+30|Tequeños (masas fritas)
+30|Tés de fruta
+30|Toffee
+30|Toffees
+30|Torrijas congeladas
+30|Torta de milhojas (productos de pastelería)
+30|Tortas y pasteles de yogurt congelado
+30|Tortitas (crumpets)
+30|Tostadas francesas congeladas
+30|Tostones
+30|Trigo molido
+30|Trigo preparado para la alimentación humana
+30|Turrón
+30|Turrón de vino (postre a base de merengue de vino)
+30|Vinagre de frutas
+30|Vinagre de vino
+30|Vinagre saborizado
+30|Vinagres
+30|Vinagres aromatizados
+30|Wontons
+30|Wrap (rollos de sándwich)
+30|Yerba mate (infusión)
+30|Yogur helado (helado cremoso)
+30|Yuja-cha (té coreano de yuja con miel)
+30|Zumaque para usar como condimento

--- a/lib/seeds/class_31_terms.csv
+++ b/lib/seeds/class_31_terms.csv
@@ -1,205 +1,294 @@
-class,reference_id,name
-31,310002,cítricos frescos
-31,310003,algas sin procesar para la alimentación humana o animal
-31,310004,frutos secos sin procesar
-31,310005,animales de zoológico
-31,310006,animales vivos
-31,310007,alimentos para animales
-31,310007,productos alimenticios para animales
-31,310008,árboles [plantas]
-31,310009,árboles de Navidad*
-31,310010,troncos de árbol
-31,310011,arbustos
-31,310012,avena*
-31,310013,bayas frescas
-31,310014,sal para el ganado
-31,310015,remolachas frescas
-31,310015,betabeles frescos
-31,310016,salvado de cereales
-31,310017,madera en bruto
-31,310018,virutas de madera para fabricar pasta de madera
-31,310018,virutas para fabricar pasta de madera
-31,310019,madera sin desbastar
-31,310020,granos de cacao sin procesar
-31,310020,habas de cacao sin procesar
-31,310021,caña de azúcar
-31,310022,algarrobas en bruto
-31,310023,cereales en grano sin procesar
-31,310024,champiñones frescos
-31,310024,hongos frescos
-31,310024,setas frescas
-31,310025,micelio de hongos para la reproducción
-31,310026,tortas oleaginosas para el ganado
-31,310027,castañas frescas
-31,310028,cal de forraje
-31,310029,raíces de achicoria
-31,310030,escarola fresca
-31,310031,galletas para perros
-31,310032,limones frescos
-31,310033,cáscara de coco
-31,310034,cocos
-31,310035,alimentos para pájaros
-31,310036,tortas de colza para el ganado
-31,310037,pepinos frescos
-31,310038,conos de lúpulo
-31,310039,afrecho para la alimentación animal
-31,310039,salvado para la alimentación animal
-31,310040,copra
-31,310041,mariscos vivos
-31,310042,verduras, hortalizas y legumbres frescas
-31,310043,calabazas frescas
-31,310044,coronas de flores naturales
-31,310045,huevos fertilizados para incubar
-31,310046,pajote [cobertura de humus]
-31,310048,residuos de destilería para la alimentación animal
-31,310049,residuos de cebada para fabricar cervezas
-31,310050,productos para la cría de animales
-31,310052,productos para el engorde de animales
-31,310052,productos para cebar animales
-31,310053,harina de arroz [pienso]
-31,310054,habas frescas
-31,310054,alubias frescas
-31,310054,frijoles frescos
-31,310054,judías frescas
-31,310054,porotos frescos
-31,310055,flores naturales
-31,310056,flores secas para decorar
-31,310057,polen [materia prima]
-31,310058,heno
-31,310059,fortificantes para la alimentación animal
-31,310059,piensos fortificantes
-31,310060,piensos
-31,310060,forraje
-31,310060,pastos [alimentos para el ganado]
-31,310060,alimentos para el ganado
-31,310061,trigo
-31,310061,trigo candeal
-31,310062,frutas frescas
-31,310063,césped natural
-31,310063,pasto natural
-31,310064,bayas de enebro
-31,310065,semillas [botánica]
-31,310066,granos [cereales]
-31,310067,granos para la alimentación animal
-31,310068,granos de siembra
-31,310068,semillas de siembra
-31,310069,granos de cereales para aves de corral
-31,310070,hierbas aromáticas frescas
-31,310071,plantas
-31,310072,plantones
-31,310073,lúpulo
-31,310074,nueces de cola
-31,310075,lechugas frescas
-31,310076,lentejas frescas
-31,310077,levadura para la alimentación animal
-31,310078,corcho en bruto
-31,310079,harina de lino [pienso]
-31,310080,arena higiénica para animales
-31,310081,turba para lechos de animales
-31,310082,maíz*
-31,310083,tortas de maíz para el ganado
-31,310084,malta para elaborar cervezas y licores
-31,310086,orujo [residuo de frutos]
-31,310087,avellanas frescas
-31,310088,harinas para animales
-31,310089,huevas
-31,310090,huevos de gusano de seda
-31,310091,bulbos de flores
-31,310092,cebollas frescas
-31,310093,aceitunas frescas
-31,310094,naranjas frescas
-31,310095,cebada*
-31,310096,ortigas
-31,310097,huesos de sepia para pájaros
-31,310098,paja [tallos de cereales]
-31,310098,paja [tallos de cereales] para camas de animales
-31,310099,paja [forraje]
-31,310100,palmas [hojas de palmera]
-31,310101,palmeras
-31,310102,cebos [comida para el ganado]
-31,310103,peces
-31,310104,vides
-31,310105,piñas de pino
-31,310106,pimientos [plantas]
-31,310107,plantas secas para decorar
-31,310108,puerros frescos
-31,310108,ajoporros frescos
-31,310109,guisantes frescos
-31,310109,arvejas frescas
-31,310109,chícharos frescos
-31,310110,patatas frescas
-31,310110,papas frescas
-31,310111,productos de puesta para la avicultura
-31,310112,cebo con sustancias harinosas para el ganado
-31,310114,raíces comestibles para la alimentación animal
-31,310115,uvas frescas
-31,310116,ruibarbo fresco
-31,310117,rosales
-31,310118,centeno
-31,310119,gusanos de seda
-31,310120,sésamo comestible sin procesar
-31,310121,trufas frescas
-31,310122,vinaza [residuos de la vinificación]
-31,310123,aves de corral vivas
-31,310124,algarrobilla [alimentos para animales]
-31,310125,almendras [frutos]
-31,310126,cacahuetes frescos
-31,310126,cacahuates frescos
-31,310126,maníes frescos
-31,310127,harina de cacahuete para animales
-31,310127,harina de cacahuate para animales
-31,310127,harina de maní para animales
-31,310128,tortas de cacahuete para animales
-31,310128,tortas de cacahuate para animales
-31,310128,tortas de maní para animales
-31,310129,subproductos del procesamiento de cereales para la alimentación animal
-31,310131,bagazo de caña de azúcar en bruto
-31,310132,carnadas vivas para la pesca
-31,310133,cangrejos de río vivos
-31,310133,acamayas vivas
-31,310134,crustáceos vivos
-31,310135,bogavantes vivos
-31,310136,mejillones vivos
-31,310137,ostras vivas
-31,310137,ostrones vivos
-31,310138,alimentos para animales de compañía
-31,310139,cortezas en bruto [árboles]
-31,310140,langostas vivas
-31,310141,objetos comestibles y masticables para animales
-31,310142,bebidas para animales de compañía
-31,310143,harina de pescado para la alimentación animal
-31,310144,arroz sin procesar
-31,310145,pepinos de mar [cohombros de mar] vivos
-31,310146,papel granulado para lechos de animales de compañía
-31,310147,arena aromática para lechos de animales de compañía
-31,310148,plantas de aloe vera
-31,310149,espinacas frescas
-31,310150,semillas de lino para la alimentación animal
-31,310150,linaza para la alimentación animal
-31,310151,harina de linaza para la alimentación animal
-31,310152,germen de trigo para la alimentación animal
-31,310153,alcachofas frescas
-31,310154,arenques vivos
-31,310155,salmones vivos
-31,310156,sardinas vivas
-31,310157,atunes vivos
-31,310158,ajos frescos
-31,310159,calabacines frescos
-31,310159,zapallos frescos
-31,310160,semillas de lino comestibles sin procesar
-31,310160,linaza comestible sin procesar
-31,310161,arreglos de fruta fresca
-31,310162,anchoas vivas
-31,310163,insectos comestibles vivos
-31,310164,mazorcas de maíz dulce sin procesar [desgranadas o no]
-31,310165,quinoa sin procesar
-31,310166,trigo sarraceno sin procesar
-31,310167,carpas koi vivas
-31,310168,moluscos vivos
-31,310169,cebos liofilizados para la pesca
-31,310170,flores comestibles, frescas
-31,310171,jengibre fresco
-31,310172,granos de soja frescos
-31,310172,granos de soya frescos
-31,310173,plantas de cánnabis
-31,310174,cánnabis sin procesar
+class|name
+31|Abulones vivos
+31|Aceitunas frescas
+31|Aceitunas sin elaborar
+31|Achicoria roja fresca
+31|Agar no procesado (alga de tengusa)
+31|Aguacates frescos
+31|Ajo fresco
+31|Ajos verdes frescos
+31|Alfalfa (alimento para animales)
+31|Alforfón no procesado
+31|Alga café no procesada (alga de hijiki)
+31|Alga marina no procesada (alga kombu)
+31|Alga marina no procesada (wakame)
+31|Alga nori comestible sin procesar
+31|Algas en polvo para consumo animal
+31|Algas para la alimentación animal
+31|Algas sin preparar para consumo humano
+31|Alimento para el ganado
+31|Alimento para peces de acuario
+31|Alimento para roedores
+31|Alimentos de base láctea para animales
+31|Alimentos para animales
+31|Alimentos para animales con extractos botánicos
+31|Alimentos para carpas doradas
+31|Alimentos para hámsteres
+31|Alimentos para peces
+31|Almendras frescas
+31|Anguilas vivas
+31|Animales de caza vivos
+31|Animales de laboratorio vivos
+31|Arándanos frescos
+31|Árboles de Navidad cortados
+31|Árboles de Navidad cortados y vivos
+31|Árboles enanos en maceta (bonsái)
+31|Arbustos
+31|Arbustos vivos
+31|Arena aromática para animales
+31|Arena higiénica para gatos y animales pequeños
+31|Arena para gatos
+31|Arreglos de flores vivas
+31|Arroz natural destinado a pienso para animales
+31|Arroz sin procesar
+31|Aves de corral vivas
+31|Bacalao (vivos)
+31|Bagazo de caña de azúcar crudo
+31|Batatas frescas (camote)
+31|Bebidas para animales
+31|Bebidas para canes
+31|Berenjenas frescas
+31|Bloques de lamer sal para ganado
+31|Bogavantes vivos
+31|Bonsáis naturales
+31|Brotes de frijol frescos
+31|Bulbos de flores y bulbos
+31|Bulbos de lirios comestibles, frescos
+31|Bulbos para uso agrícola
+31|Bulbos para uso hortícola
+31|Caballa española viva
+31|Cabras vivas
+31|Cactus comestibles frescos
+31|Calabacín fresco
+31|Caña de azúcar
+31|Cangrejos de nieve vivos
+31|Capelán vivo
+31|Capullos para la producción de huevos
+31|Caquis frescos japoneses
+31|Caracoles (vivos)
+31|Caracoles de mar no vivos
+31|Carnada viva
+31|Carnadas vivas para la pesca
+31|Carpas plateadas vivas
+31|Carpines vivos
+31|Castañas de agua frescas
+31|Castañas frescas
+31|Cebada sin procesar
+31|Cebo vivo
+31|Cebollas frescas
+31|Cebollino fresco
+31|Cebos (comida para el ganado)
+31|Cerdos vivos
+31|Cereales sin procesar
+31|Chalotes no procesados
+31|Champiñones frescos
+31|Champiñones sin elaborar
+31|Chícharos frescos
+31|Chiles frescos
+31|Chirivías frescas
+31|Chucherías para perros (comestibles)
+31|Ciruelas frescas
+31|Cocos frescos
+31|Col fresca
+31|Coles de Bruselas frescas
+31|Coles de brusselas frescos
+31|Comida para animales
+31|Comida para gatos
+31|Copra
+31|Corales vivos
+31|Corales vivos de acuario
+31|Corcho en bruto
+31|Coronas de flores naturales
+31|Corvinas amarillas vivas
+31|Crisantemos coronados comestibles frescos
+31|Espárragos frescos
+31|Espinacas frescas
+31|Esporas y huevas para uso agrícola
+31|Flores cortadas
+31|Flores frescas comestibles
+31|Flores naturales
+31|Flores secas
+31|Flores vivas
+31|Forraje para caballos
+31|Frijoles frescos
+31|Fruta fresca
+31|Frutas orgánicas frescas
+31|Frutas sin elaborar
+31|Frutas, legumbres, verduras y hortalizas frescas
+31|Frutillas frescas
+31|Frutos frescos de espino
+31|Galletas para perros
+31|Gallinas vivas
+31|Gambas vivas
+31|Ganado
+31|Ganado vivo
+31|Gírgolas, frescas
+31|Goji sin procesar
+31|Golosinas comestibles para mascotas
+31|Granos de cacao sin procesar
+31|Granos sin procesar
+31|Guirnaldas de flores naturales
+31|Hámsteres
+31|Harina de grano de soja (alimentación animal)
+31|Harina de pescado para la alimentación animal
+31|Helechos frescos (gosari)
+31|Heno
+31|Hierbas aromáticas orgánicas frescas
+31|Hierbas de jardín frescas
+31|Hierbas para uso culinario frescas
+31|Hierbas secas para la decoración
+31|Higos frescos
+31|Hojas frescas de batata
+31|Hongo velo de novia alargado fresco
+31|Hongos gelatinosos blancos comestibles
+31|Hongos negros comestibles frescos
+31|Huesos de jibia para pájaros
+31|Huesos masticables digestivos para perros
+31|Huesos masticables para perros
+31|Huevos de gusano de seda
+31|Huevos fertilizados para incubar
+31|Huevos para incubar
+31|Jengibre crudo
+31|Jengibre fresco
+31|Kiwis frescos
+31|Langostas vivas
+31|Langostinos vivos
+31|Leche en polvo para animales
+31|Leche en polvo para mascotas
+31|Lechuga de mar no procesada (alga de aosa)
+31|Legumbres frescas
+31|Lenguados vivos
+31|Lentejas frescas
+31|Levadura para pienso de animales
+31|Lichis frescos
+31|Liebres de mar, vivas
+31|Limas frescas
+31|Limones frescos
+31|Linaza para la alimentación animal
+31|Lirios de día comestibles, frescos
+31|Longkong (fruta asiática) fresco
+31|Madera en bruto
+31|Madera no descortezada
+31|Maíz sin elaborar
+31|Mamíferos vivos, peces (no para alimentación), pájaros e insectos
+31|Mandarinas frescas
+31|Maní fresco
+31|Manzanas frescas
+31|Mariscos árticos, vivos
+31|Mariscos vivos
+31|Mejillones azules vivos
+31|Melocotones frescos
+31|Melón fresco oriental (cham-oe)
+31|Melones espinudos frescos (fruto del paraíso)
+31|Melones frescos
+31|Membrillo fresco
+31|Menta fresca
+31|Mijo de cola de zorro no procesado
+31|Mijo de corral japonés no procesado
+31|Mijo de prosa no procesado
+31|Moras frescas (bokbunja)
+31|Murtilla fresca
+31|Naranjas mandarinas frescas
+31|Nísperos frescos
+31|Nueces frescas
+31|Nueves frescas
+31|Objetos comestibles y masticables para animales
+31|Ojo de dragón fresco (longan)
+31|Ovejas vivas
+31|Papas dulces frescas (camote)
+31|Papel granulado para animales domésticos (lechos higiénicos)
+31|Papel granulado para la higiene de animales domésticos
+31|Pasto natural
+31|Patatas sin elaborar
+31|Patos vivos
+31|Peces de colores
+31|Peces para acuario
+31|Pelo de conejo
+31|Pepinos de mar (cohombros de mar) vivos
+31|Pepinos frescos
+31|Peras frescas
+31|Percas vivas
+31|Perifollo fresco
+31|Perros
+31|Pescado para comida animal
+31|Pieles en bruto
+31|Piensos mezclados para animales
+31|Piensos para perros
+31|Piensos sintéticos para animales
+31|Pimientos frescos
+31|Piñones frescos
+31|Pistachos frescos
+31|Plantas de floración
+31|Plantas de fruta viva
+31|Plantas secas para decoración
+31|Plantas vivas
+31|Plantas y flores naturales
+31|Plantones
+31|Plátanos frescos
+31|Platijas (peces) vivas
+31|Pollos de hueso negro vivos
+31|Pomarrosas frescas
+31|Pomelos frescos
+31|Porotos rojos crudos
+31|Productos masticables comestibles para perros
+31|Puerros frescos
+31|Pulpa de almidón (alimentos para animales)
+31|Pupas vivas de abejas
+31|Quingombós frescos
+31|Quinoa no procesada
+31|Rabanitos picantes, frescos
+31|Radicchio fresco
+31|Raíces de alcachofa china fresca, para su uso como vegetales
+31|Raíces de yacón frescas
+31|Raíz de bardana fresca
+31|Raíz de rábano cruda
+31|Ramilletes de flores naturales
+31|Remolachas frescas
+31|Repollos de napa frescos (baechu)
+31|Rizomas frescos comestibles
+31|Rosas
+31|Rúcula fresca
+31|Salacas (frutas) frescas
+31|Salvado de arroz (alimentos para animales)
+31|Sandías frescas
+31|Semillas de árbol de manzana
+31|Semillas de árbol urushi
+31|Semillas de cereal sin procesar
+31|Semillas de césped
+31|Semillas de chía no procesadas
+31|Semillas de cultivos
+31|Semillas de flores
+31|Semillas de fruta
+31|Semillas de lino no procesadas
+31|Semillas de urushi
+31|Semillas para frutas, verduras, hortalizas y legumbres
+31|Semillas para pájaros
+31|Semillas para plantas
+31|Semillas para uso agrícola
+31|Semillas para uso hortícola
+31|Semillas sin procesar para uso agrícola
+31|Semillas y bulbos
+31|Señuelos vivos para pesca
+31|Setos y arbustos vivos, podados en formas decorativas
+31|Soja fresca y tierna en vaina (edamame)
+31|Sollas vivas
+31|Sorgo no procesado
+31|Spirulina no procesada
+31|Spirulina procesada
+31|Subproductos del procesamiento de cereales para la alimentación animal
+31|Sucedáneos de leche para animales
+31|Tallos de ajo frescos
+31|Tomates cereza (cherry) frescos
+31|Tomates frescos
+31|Tomates no procesados
+31|Tortas de salsa de soja (alimentación animal)
+31|Trigo sin elaborar
+31|Truchas vivas
+31|Trufas frescas
+31|Uvas frescas
+31|Verdolaga, planta fresca
+31|Verduras no procesadas
+31|Verduras, hortalizas y legumbres frescas
+31|Verduras, hortalizas y legumbres orgánicas frescas
+31|Virutas de madera para fabricar pasta de madera
+31|Zanahorias frescas

--- a/lib/seeds/class_32_terms.csv
+++ b/lib/seeds/class_32_terms.csv
@@ -1,66 +1,127 @@
-class,reference_id,name
-32,320001,extractos de frutas sin alcohol
-32,320002,cervezas
-32,320003,cerveza de jengibre
-32,320003,bebida de jengibre
-32,320004,cerveza de malta
-32,320005,mosto de cerveza
-32,320006,bebidas de frutas sin alcohol
-32,320006,bebidas de jugos de frutas sin alcohol
-32,320006,bebidas de zumos de frutas sin alcohol
-32,320007,bebidas a base de suero de leche
-32,320008,preparaciones sin alcohol para elaborar bebidas
-32,320009,esencias sin alcohol para elaborar bebidas
-32,320010,zumos de frutas
-32,320010,jugos de frutas
-32,320011,siropes para bebidas
-32,320012,aguas [bebidas]
-32,320013,preparaciones para elaborar aguas gaseosas
-32,320013,preparaciones para elaborar aguas carbonatadas
-32,320014,agua de litines
-32,320015,aguas minerales [bebidas]
-32,320017,agua de Seltz
-32,320018,aguas de mesa
-32,320019,mostos
-32,320020,limonadas
-32,320021,extractos de lúpulo para elaborar cervezas
-32,320022,zumos vegetales [bebidas]
-32,320022,jugos vegetales [bebidas]
-32,320023,siropes para limonadas
-32,320025,mosto de malta
-32,320026,mosto de uva
-32,320027,horchata
-32,320028,sodas [aguas]
-32,320029,sorbetes [bebidas]
-32,320030,zumo de tomate [bebida]
-32,320030,jugo de tomate [bebida]
-32,320031,bebidas sin alcohol
-32,320033,pastillas para bebidas gaseosas
-32,320034,polvos para elaborar bebidas gaseosas
-32,320035,aguas gaseosas
-32,320035,aguas carbonatadas
-32,320041,zarzaparrilla [bebida sin alcohol]
-32,320042,aperitivos sin alcohol
-32,320043,cócteles sin alcohol
-32,320043,cocteles sin alcohol
-32,320044,néctares de frutas sin alcohol
-32,320045,bebidas isotónicas
-32,320047,sidra sin alcohol
-32,320048,kvas
-32,320049,bebidas sin alcohol a base de miel
-32,320050,batidos de frutas u hortalizas
-32,320050,licuados de frutas u hortalizas
-32,320051,bebidas de aloe vera sin alcohol
-32,320052,mezclas [bebidas] a base de cerveza
-32,320053,bebidas a base de soja que no sean sucedáneos de la leche
-32,320054,bebidas enriquecidas con proteínas para deportistas
-32,320055,bebidas a base de arroz, que no sean sucedáneos de la leche
-32,320056,bebidas sin alcohol con sabor a café
-32,320057,bebidas sin alcohol con sabor a té
-32,320058,bebidas refrescantes sin alcohol
-32,320058,refrescos
-32,320059,cerveza de cebada
-32,320060,bebidas energéticas
-32,320061,bebidas de frutas secas sin alcohol
-32,320062,cerveza con limonada
-32,320062,clara
+class|name
+32|Agua de abedul
+32|Agua de arce
+32|Agua de glaciar
+32|Agua de manantial
+32|Agua de mesa
+32|Agua destilada para beber
+32|Agua embotellada
+32|Agua gaseosa
+32|Agua mineral
+32|Agua mineral aromatizada
+32|Agua mineral saborizada
+32|Agua mineral y gaseosa
+32|Agua potable depurada
+32|Agua que no sea carbonatada
+32|Agua sin gas
+32|Agua tónica (bebidas no medicinales)
+32|Aguas de mesa
+32|Aguas gaseosas
+32|Aguas gaseosas (sodas)
+32|Aguas minerales
+32|Aguas minerales gaseosas
+32|Aguas minerales y gaseosas
+32|Aguas para beber
+32|Aguas saborizadas
+32|Aperitivos sin alcohol
+32|Batidos de frutas u hortalizas (smoothies)
+32|Batidos de hortalizas
+32|Bebida de jengibre
+32|Bebidas a base de frutas
+32|Bebidas a base de frutas congeladas
+32|Bebidas carbonatadas con sabor a fruta
+32|Bebidas carbónicas sin alcohol
+32|Bebidas cola
+32|Bebidas con sabor a frutas
+32|Bebidas con sabor a té no alcohólicas
+32|Bebidas de agua de coco
+32|Bebidas de deporte que contienen electrolitos
+32|Bebidas de fruta congelada
+32|Bebidas de fruta congeladas
+32|Bebidas de fruta y jugos de fruta
+32|Bebidas de frutas sin alcohol
+32|Bebidas de guaraná
+32|Bebidas de jugo de aloe vera
+32|Bebidas de jugo de manzana
+32|Bebidas de jugo de naranja
+32|Bebidas de jugo de piña
+32|Bebidas de jugo de tomate
+32|Bebidas de jugo de uva
+32|Bebidas de malta sin alcohol
+32|Bebidas gaseosas sin alcohol aromatizas con té
+32|Bebidas isotónicas no alcohólicas
+32|Bebidas no alcohólicas que contienen jugo de frutas
+32|Bebidas sin alcohol a base de miel
+32|Bebidas y jugos de fruta
+32|Cerveza ale y lager
+32|Cerveza ale y porter
+32|Cerveza ale, lager, stout y porter
+32|Cerveza bock
+32|Cerveza con sabor a café
+32|Cerveza de raíz (refresco hecho con distintas raíces)
+32|Cerveza negra (cerveza de malta tostada)
+32|Cerveza no alcohólica saborizada
+32|Cerveza saborizadas
+32|Cervezas aromatizadas
+32|Cervezas con bajo contenido en alcohol
+32|Cervezas sin alcohol
+32|Clara de cerveza
+32|Cocktails no-alcohólicos
+32|Concentrados de jugo de frutas
+32|Concentrados para hacer bebidas de frutas
+32|Concentrados para hacer jugo de frutas
+32|Concentrados para su uso en la preparación de refrescos
+32|Esencias para elaborar agua mineral saborizada (no en la naturaleza de aceites esenciales)
+32|Esencias para elaborar bebidas no alcohólicas (no en la naturaleza de aceites esenciales)
+32|Esencias para elaborar bebidas sin alcohol que no sean aceites esenciales
+32|Extracto de lúpulo para la fabricación de cerveza
+32|Extractos de frutas sin alcohol para preparar bebidas
+32|Gaseosas
+32|Granizados de frutas
+32|Jarabe de malta para hacer bebidas
+32|Jugo de arándanos
+32|Jugo de frutas
+32|Jugos de fruta y bebidas de fruta
+32|Jugos de frutas gaseosos
+32|Kvas (bebidas sin alcohol)
+32|Lagers
+32|Limonada
+32|Limonadas
+32|Mezclado de jugo de frutas
+32|Néctares de frutas
+32|Polvos utilizados en la preparación de bebidas a base de frutas
+32|Ponche de arroz seco no alcohólico (sikhye)
+32|Ponche de caqui seco con canela no alcohólico (sujeonggwa)
+32|Ponches de frutas sin alcohol
+32|Ponches sin alcohol
+32|Refrescos a base de frutas aromatizados con té
+32|Refrescos bajos en calorías
+32|Refrescos con sabor a café
+32|Refrescos de extractos de limón
+32|Refrescos no alcohólicos
+32|Refrescos sin gas
+32|Siropes para bebidas
+32|Siropes para elaborar aguas minerales saborizadas
+32|Siropes para elaborar bebidas
+32|Siropes para elaborar bebidas con sabores de frutas
+32|Siropes para elaborar bebidas no alcohólicas
+32|Siropes para hacer refrescos
+32|Smoothies (bebidas en las que predomine la fruta)
+32|Sorbetes (bebidas)
+32|Sorbetes (sorbetes)
+32|Sorbetes en forma de bebidas
+32|Sucedáneo de la cerveza
+32|Vino sin alcohol
+32|Vinos desalcoholizados
+32|Zumo condensado de ciruelas ahumadas
+32|Zumo de frutas mezclado
+32|Zumo de granada
+32|Zumo de grosella negra
+32|Zumo de guayaba
+32|Zumo de melón
+32|Zumo de naranja
+32|Zumo de sandía
+32|Zumo de uva
+32|Zumos a base de fruta congelados
+32|Zumos de frutas
+32|Zumos vegetales (bebidas)

--- a/lib/seeds/class_33_terms.csv
+++ b/lib/seeds/class_33_terms.csv
@@ -1,40 +1,83 @@
-class,reference_id,name
-33,330001,licor de menta
-33,330001,alcohol de menta
-33,330002,extractos de frutas con alcohol
-33,330003,amargos [licores]
-33,330004,anís [licor]
-33,330005,anisete
-33,330006,aperitivos*
-33,330007,arac
-33,330008,bebidas destiladas
-33,330009,sidras
-33,330010,cócteles*
-33,330010,cocteles*
-33,330011,curaçao
-33,330011,curasao
-33,330011,curazao
-33,330012,digestivos [licores y bebidas espirituosas]
-33,330013,vinos
-33,330014,ginebra
-33,330015,licores
-33,330016,aguamiel [hidromiel]
-33,330016,hidromiel [aguamiel]
-33,330017,kirsch
-33,330018,bebidas espirituosas
-33,330019,aguardientes
-33,330019,brandy
-33,330020,aguapié
-33,330021,perada
-33,330022,sake
-33,330023,whisky
-33,330024,esencias alcohólicas
-33,330025,extractos alcohólicos
-33,330026,bebidas alcohólicas, excepto cervezas
-33,330031,bebidas alcohólicas que contienen frutas
-33,330032,alcohol de arroz
-33,330033,ron
-33,330034,vodka
-33,330035,bebidas alcohólicas premezcladas que no sean a base de cerveza
-33,330036,bebidas alcohólicas a base de caña de azúcar
-33,330037,bebidas de alcohol destilado a base de cereales
+class|name
+33|Aguamiel (hidromiel)
+33|Anís (licor)
+33|Anisete
+33|Aperitivos a base de alcohol destilado
+33|Aperitivos a base de vino (bebidas)
+33|Arac
+33|Arak
+33|Bebidas a base de ron
+33|Bebidas a base de vino
+33|Bebidas alcohólicas (sangría)
+33|Bebidas alcohólicas a base de azúcar de caña
+33|Bebidas alcohólicas carbonatadas, excepto cervezas
+33|Bebidas alcohólicas de fruta
+33|Bebidas alcohólicas destiladas a base de grano
+33|Bebidas alcohólicas excepto cerveza
+33|Bebidas alcohólicas premezcladas
+33|Bebidas alcohólicas que contienen frutas
+33|Bebidas espirituosas
+33|Bebidas espirituosas y licores
+33|Bebidas japonesas de alta graduación alcohólica aromatizadas con extracto de agujas de pino
+33|Bebidas japonesas de alta graduación alcohólica aromatizadas con extracto de ciruela asiática
+33|Cachaza
+33|Cocktails alcohólicos en la forma de jaleas enfriadas
+33|Cócteles alcohólicos que contienen leche
+33|Cócteles de frutas con alcohol
+33|Cremas de licor
+33|Destilados de cereza
+33|Espirituoso chino de sorgo (gaolian-jiou)
+33|Espirituosos destilados coreanos (soju)
+33|Espirituosos destilados de arroz (awamori)
+33|Extractos alcohólicos
+33|Extractos de bebidas espirituosas
+33|Ginebra
+33|Grapa
+33|Jerez
+33|Kirsch
+33|Licor blanco japonés (shochu)
+33|Licor chino (baiganr)
+33|Licor de grosella
+33|Licor de jengibre
+33|Licor mezclado a base de arroz dulce estilo japonés (shiro-zake)
+33|Licor mezclado chino (wujiapie-jiou)
+33|Licor preparado chino (laojiou)
+33|Licor tonificante a base de extractos de serpiente mamushi (mamushi-zake)
+33|Licores
+33|Licores a base de café
+33|Licores amargos alcohólicos
+33|Licores regenerados japoneses (naoshi)
+33|Mezclas con alcohol para cócteles
+33|Ponche de huevo con alcohol
+33|Ponche de ron
+33|Ponche de vino
+33|Ponches alcohólicos
+33|Refrescos alcohólicos
+33|Ron (bebida alcohólica)
+33|Ron de jugo de caña de azúcar
+33|Sake
+33|Sidra seca
+33|Sochu (espirituosos)
+33|Vino caliente
+33|Vino de arroz coreano tradicional (makgeoli)
+33|Vino de fresa
+33|Vino de frutas
+33|Vino de mesa
+33|Vino de mora (bokbunjaju)
+33|Vino de uva
+33|Vinos blancos espumosos
+33|Vinos dulces
+33|Vinos espirituosos
+33|Vinos espumosos
+33|Vinos espumosos de frutas
+33|Vinos espumosos de uva
+33|Vinos espumosos naturales
+33|Vinos tintos
+33|Vinos tintos espumosos
+33|Vinos tranquilos
+33|Vinos y licores
+33|Vinos y vinos espirituosos
+33|Vinos y vinos espumosos
+33|Vodka
+33|Whisky
+33|Whisky de malta

--- a/lib/seeds/class_34_terms.csv
+++ b/lib/seeds/class_34_terms.csv
@@ -1,69 +1,93 @@
-class,reference_id,name
-34,340001,fósforos
-34,340001,cerillas
-34,340001,cerillos
-34,340002,embocaduras de boquillas de ámbar amarillo para puros y cigarrillos
-34,340002,embocaduras de boquillas de ámbar amarillo para cigarros y cigarrillos
-34,340003,tabaco
-34,340004,petacas para tabaco
-34,340005,boquillas de cigarrillo
-34,340005,boquillas de cigarro [cigarrillo]
-34,340006,filtros para cigarrillos
-34,340006,filtros para cigarros [cigarrillos]
-34,340007,encendedores para fumadores
-34,340007,mecheros [encendedores de bolsillo]
-34,340008,depósitos de gas para encendedores
-34,340008,depósitos de gas para mecheros [encendedores de bolsillo]
-34,340009,pipas
-34,340010,librillos de papel de fumar
-34,340011,papel absorbente para pipas
-34,340012,tabaco de mascar
-34,340013,puros
-34,340014,cortapuros
-34,340015,pureras
-34,340015,cajas para puros
-34,340015,cigarreras para puros
-34,340015,petacas para puros
-34,340016,pitilleras
-34,340016,estuches para cigarrillos
-34,340016,petacas para cigarrillos
-34,340017,boquillas para puros
-34,340019,cigarrillos que contengan sucedáneos del tabaco que no sean para uso médico
-34,340019,cigarros [cigarrillos] que contengan sucedáneos del tabaco que no sean para uso médico
-34,340020,cigarrillos*
-34,340020,cigarros [cigarrillos]
-34,340021,aparatos de bolsillo para liar cigarrillos
-34,340021,aparatos de bolsillo para liar cigarros [cigarrillos]
-34,340022,boquillas para cigarrillos
-34,340022,boquillas para cigarros [cigarrillos]
-34,340023,embocaduras de boquillas para cigarrillos
-34,340024,papel de fumar
-34,340025,puritos
-34,340026,limpiapipas
-34,340027,piedras de encendedor de bolsillo
-34,340027,piedras de mechero [encendedor de bolsillo]
-34,340028,hierbas para fumar*
-34,340030,portapipas
-34,340030,soportes para pipas
-34,340031,fosforeras
-34,340031,cerilleros
-34,340032,botes para tabaco
-34,340033,rapé [tabaco en polvo]
-34,340034,tabaqueras [cajas para rapé]
-34,340035,cajas para fósforos
-34,340035,cajas para cerillas
-34,340035,cajas para cerillos
-34,340036,ceniceros para fumadores
-34,340037,escupideras para consumidores de tabaco
-34,340038,cajas con humidificador para puros
-34,340039,cigarrillos electrónicos
-34,340040,soluciones líquidas para cigarrillos electrónicos
-34,340041,vaporizadores bucales para fumadores
-34,340042,aromatizantes, que no sean aceites esenciales, para tabaco
-34,340042,saborizantes, que no sean aceites esenciales, para tabaco
-34,340043,aromatizantes, que no sean aceites esenciales, para cigarrillos electrónicos
-34,340043,saborizantes, que no sean aceites esenciales, para cigarrillos electrónicos
-34,340044,mechas especiales para encendedores de cigarrillos
-34,340045,shishas
-34,340045,narguiles
-34,340045,hookahs
+class|name
+34|Aparatos de bolsillo para liar cigarrillos
+34|Aparatos de bolsillo para liar sus propios cigarrillos
+34|Aromatizantes para cigarrillos electrónicos, que no sean aceites esenciales
+34|Boquillas de metales preciosos para cigarrillos
+34|Boquillas para cigarrillos
+34|Boquillas para cigarrillos que no sean de metales preciosos
+34|Boquillas para puros
+34|Botes para tabaco
+34|Cajas de metales preciosos para puros y cigarrillos
+34|Cajas humidificadas para puros
+34|Cajas para cerillos que no sean de metales preciosos
+34|Cajas para fósforos
+34|Cajas para fósforos de metales preciosos
+34|Cajas para fósforos que no sean de metales preciosos
+34|Ceniceros
+34|Ceniceros de metales preciosos
+34|Ceniceros para fumadores de metales preciosos
+34|Ceniceros para fumadores que no sean de metales preciosos
+34|Ceniceros que no sean de metales preciosos
+34|Cerillos de azufre
+34|Cerillos de fósforo amarillo
+34|Cerillos de parafina
+34|Cigarreras que no sean de metales preciosos
+34|Cigarrillos
+34|Cigarrillos electrónicos
+34|Cigarrillos electrónicos para su uso como una alternativa a los cigarrillos tradicionales
+34|Cigarrillos mentolados
+34|Cortapuros
+34|Dispositivos de bolsillo para liar sus propios cigarrillos
+34|Dispositivos electrónicos y sus partes (comprendidos en esta clase) para calentar cigarrillos o tabaco para liberar aerosol que contiene nicotina para inhalar
+34|Dispositivos para calentar tabaco para su inhalación
+34|Encendedores de cigarrillos que no sean de metales preciosos ni para automóviles
+34|Encendedores de cigarros
+34|Encendedores para fumadores (encendedores de cigarrillos) que no sean para automóviles
+34|Encendedores que no sean de metales preciosos ni para automóviles
+34|Estuches de puros que no sean de metales preciosos
+34|Filtros para cigarrillos
+34|Filtros para tabaco
+34|Fosforeras
+34|Fósforos
+34|Fósforos de seguridad
+34|Fundas para pipas largas de tabaco asiáticas
+34|Hojas de tabaco
+34|Humidificadores para puros
+34|Latas de tabaco
+34|Limpiapipas
+34|Máquinas de bolsillo para liar cigarrillos
+34|Máquinas para liar cigarrillos
+34|Molinillos de tabaco
+34|Narguiles (pipa oriental)
+34|Narguilés electrónicos
+34|Papel absorbente para pipas
+34|Papel de fumar
+34|Papel para enrollar cigarrillos
+34|Petacas para tabaco
+34|Piedras de encendedor de bolsillo
+34|Piedras de encendedor y pedernales
+34|Pipas de fumar electrónicas
+34|Pipas de madera
+34|Pipas largas para tabaco asiáticas (kiseru)
+34|Pipas mentoladas
+34|Pipas para fumar
+34|Pipas para tabaco que no sean de metales preciosos
+34|Pitilleras
+34|Pitilleras automáticas
+34|Pitilleras hechas de metales preciosos
+34|Prensadores para pipas
+34|Puntas de filtros de cigarrillos
+34|Pureras
+34|Puros
+34|Puros electrónicos
+34|Rapé (tabaco en polvo)
+34|Soluciones de nicotina líquida para su uso en cigarrillos electrónicos
+34|Sucedáneos del tabaco
+34|Sucedáneos del tabaco que no sean para uso médico
+34|Tabaco
+34|Tabaco aromatizado
+34|Tabaco de hookah
+34|Tabaco de mascar
+34|Tabaco de pipa mentolado
+34|Tabaco desmenuzado japonés (kizami tobacco)
+34|Tabaco mentolado
+34|Tabaco para cigarrillos
+34|Tabaco para fumar
+34|Tabaco para liar
+34|Tabaco para pipas
+34|Tabaco sin humo
+34|Tabaco, puros y cigarrillos
+34|Tabaqueras (cajas para rapé)
+34|Tabaqueras (cajas para rapé) de metales preciosos
+34|Tabaqueras (cajas para rapé) que no sean de metales preciosos
+34|Tubos para cigarrillos

--- a/lib/seeds/class_35_terms.csv
+++ b/lib/seeds/class_35_terms.csv
@@ -1,164 +1,486 @@
-class,reference_id,name
-35,350001,asistencia en la dirección de negocios
-35,350002,indagaciones sobre negocios
-35,350003,fijación de carteles publicitarios
-35,350005,servicios de agencias de importación-exportación
-35,350006,servicios de agencias de información comercial
-35,350007,análisis del precio de costo
-35,350008,difusión de anuncios publicitarios
-35,350009,servicios de fotocopia
-35,350012,servicios de oficinas de empleo
-35,350012,servicios de agencias de colocación
-35,350013,alquiler de máquinas y aparatos de oficina*
-35,350015,contabilidad
-35,350015,teneduría de libros
-35,350016,elaboración de estados de cuenta
-35,350017,auditorías empresariales
-35,350018,consultoría sobre organización y dirección de negocios
-35,350019,consultoría sobre gestión de personal
-35,350020,consultoría sobre dirección de negocios
-35,350022,servicios de mecanografía
-35,350022,servicios de dactilografía
-35,350023,demostración de productos
-35,350024,distribución de material publicitario [folletos, prospectos, impresos, muestras]
-35,350024,publicidad por correo directo
-35,350024,difusión de material publicitario [folletos, prospectos, impresos, muestras]
-35,350025,asistencia en la dirección de empresas comerciales o industriales
-35,350027,actualización de documentación publicitaria
-35,350028,distribución de muestras
-35,350029,servicios de expertos en eficiencia empresarial
-35,350030,ventas en pública subasta
-35,350031,estudios de mercado
-35,350032,valoración de negocios comerciales
-35,350033,investigación comercial
-35,350035,alquiler de material publicitario
-35,350036,consultoría sobre organización de negocios
-35,350038,publicación de textos publicitarios
-35,350039,publicidad
-35,350040,publicidad radiofónica
-35,350041,búsqueda de negocios
-35,350042,relaciones públicas
-35,350043,servicios de taquigrafía
-35,350043,servicios de estenografía
-35,350044,publicidad televisada
-35,350045,transcripción de comunicaciones
-35,350046,decoración de escaparates
-35,350046,decoración de vidrieras [escaparates]
-35,350047,servicios de agencias de publicidad
-35,350048,asesoramiento sobre dirección de empresas
-35,350049,servicios de modelos para publicidad o promoción de ventas
-35,350051,investigación de marketing
-35,350061,servicios de gestión informática de archivos
-35,350062,consultoría profesional sobre negocios comerciales
-35,350063,previsiones económicas
-35,350064,organización de exposiciones con fines comerciales o publicitarios
-35,350065,suministro de información sobre negocios
-35,350066,sondeos de opinión
-35,350067,preparación de nóminas
-35,350068,selección de personal
-35,350069,servicios administrativos para la reubicación de empresas
-35,350070,alquiler de espacios publicitarios
-35,350071,promoción de ventas para terceros
-35,350072,servicios de secretariado
-35,350073,preparación de declaraciones tributarias
-35,350074,servicios de contestador automático para abonados ausentes
-35,350075,tratamiento de textos
-35,350076,servicios de suscripción a periódicos para terceros
-35,350076,servicios de abono a periódicos para terceros
-35,350077,publicidad por correspondencia
-35,350078,gerencia administrativa de hoteles
-35,350079,gestión empresarial de artistas intérpretes o ejecutantes
-35,350080,compilación de información en bases de datos informáticas
-35,350081,sistematización de información en bases de datos informáticas
-35,350082,organización de ferias comerciales
-35,350083,alquiler de fotocopiadoras
-35,350084,publicidad en línea por una red informática
-35,350085,servicios de abastecimiento para terceros [compra de productos y servicios para otras empresas]
-35,350086,búsqueda de datos en archivos informáticos para terceros
-35,350087,alquiler de tiempo publicitario en medios de comunicación
-35,350088,servicios de comunicados de prensa
-35,350089,alquiler de distribuidores automáticos
-35,350089,alquiler de máquinas expendedoras
-35,350090,servicios de tests psicotécnicos para la selección de personal
-35,350090,tests psicotécnicos para la selección de personal
-35,350091,servicios de comparación de precios
-35,350092,presentación de productos en cualquier medio de comunicación para su venta minorista
-35,350093,suministro de información y asesoramiento comerciales al consumidor en la selección de productos y servicios
-35,350094,suscripción a servicios de telecomunicaciones para terceros
-35,350095,tramitación administrativa de pedidos de compra
-35,350096,gestión comercial de licencias de productos y servicios de terceros
-35,350097,servicios de externalización [asistencia comercial]
-35,350097,servicios de subcontratación [asistencia comercial]
-35,350098,facturación
-35,350099,redacción de textos publicitarios
-35,350100,recopilación de estadísticas
-35,350101,servicios de composición de página con fines publicitarios
-35,350102,búsqueda de patrocinadores
-35,350103,organización de desfiles de moda con fines promocionales
-35,350104,producción de películas publicitarias
-35,350105,servicios de representación de deportistas
-35,350106,marketing
-35,350106,mercadotecnia
-35,350107,servicios de telemarketing
-35,350108,servicios de venta minorista de preparaciones farmacéuticas, veterinarias y sanitarias, así como de suministros médicos
-35,350109,alquiler de puestos de venta
-35,350110,suministro de información de contacto de comercios y empresas
-35,350111,optimización de motores de búsqueda con fines de promoción de ventas
-35,350112,optimización del tráfico en sitios web
-35,350113,servicios publicitarios de pago por clic
-35,350114,servicios de intermediación comercial
-35,350115,gestión de trabajadores autónomos [porte salarial]
-35,350116,negociación y conclusión de transacciones comerciales para terceros
-35,350117,actualización y mantenimiento de datos en bases de datos informáticas
-35,350118,servicios de gestión de proyectos comerciales en el marco de proyectos de construcción
-35,350119,suministro de información comercial por sitios web
-35,350120,suministro de espacios de venta en línea para vendedores y compradores de productos y servicios
-35,350121,desarrollo de conceptos publicitarios
-35,350122,gestión administrativa externalizada para empresas
-35,350123,servicios de presentación de declaraciones tributarias
-35,350124,gestión comercial de planes de reembolso para terceros
-35,350125,alquiler de vallas publicitarias
-35,350126,redacción de currículos para terceros
-35,350127,indexación de páginas web con fines comerciales o publicitarios
-35,350128,administración de programas de viajero frecuente 
-35,350129,servicios de programación de citas [trabajos de oficina]
-35,350130,servicios de recordatorio de citas [trabajos de oficina]
-35,350131,administración de programas de fidelización de consumidores
-35,350132,redacción de guiones publicitarios 
-35,350133,registro de datos y de comunicaciones escritas
-35,350134,actualización y mantenimiento de información en los registros
-35,350135,compilación de índices de información con fines comerciales o publicitarios
-35,350136,servicios de intermediarios comerciales en el marco de la puesta en relación de potenciales inversores privados con empresarios que necesitan financiación
-35,350137,producción de programas de televenta
-35,350138,consultoría sobre estrategias de comunicación [relaciones públicas]
-35,350139,consultoría sobre estrategias de comunicación [publicidad]
-35,350140,negociación de contratos de negocios para terceros
-35,350141,promoción de productos y servicios mediante el patrocinio de eventos deportivos
-35,350142,servicios de inteligencia competitiva
-35,350143,servicios de inteligencia de mercado
-35,350144,auditorías contables y financieras
-35,350145,servicios de venta minorista en línea de música digital descargable
-35,350146,servicios de venta minorista en línea de tonos de llamada descargables
-35,350147,servicios de venta minorista en línea de música y películas pregrabados y descargables
-35,350148,servicios de venta mayorista de preparaciones farmacéuticas, veterinarias y sanitarias, así como suministros médicos
-35,350149,servicios de registro de listas de regalos
-35,350150,marketing selectivo
-35,350151,gestión interina de negocios comerciales
-35,350152,publicidad exterior
-35,350153,servicios de venta minorista de obras de arte suministradas por galerías de arte
-35,350154,asistencia administrativa para responder a convocatorias de licitación
-35,350154,asistencia administrativa para responder a solicitudes de propuestas [RFPs]
-35,350155,marketing en el marco de la edición de software
-35,350156,servicios de relaciones de prensa
-35,350157,servicios de comunicaciones corporativas
-35,350158,alquiler de equipos de oficina en instalaciones de cotrabajo
-35,350159,servicios de grupos de presión comercial
-35,350159,servicios de cabildeo comercial
-35,350160,suministro de comentarios de usuarios con fines comerciales o publicitarios
-35,350161,suministro de clasificaciones de usuarios con fines comerciales o publicitarios
-35,350161,suministro de evaluaciones de usuarios con fines comerciales o publicitarios
-35,350162,servicios de centrales telefónicas
-35,350162,servicios de atención telefónica
-35,350163,servicios de venta minorista en relación con productos de panadería
-35,350164,creación de perfiles de consumidores con fines comerciales o de marketing
-35,350165,servicios administrativos de derivación médica
+class|name
+35|Administración de archivos computarizado central
+35|Administración de negocios
+35|Administración de negocios de deportistas
+35|Administración de negocios en el campo del transporte y reparto
+35|Administración de programas de descuento que permiten a los participantes obtener descuentos en productos y servicios a través del uso de una tarjeta de membresía de descuento
+35|Administración y gestión de negocios
+35|Agencias de colocación
+35|Agencias de empleo temporal
+35|Agencias de exportación e importación
+35|Agencias de importación y exportación
+35|Agencias de importación y exportación en el campo de la energía
+35|Agencias de importación-exportación de productos
+35|Agencias de información comercial para la facilitación de información de negocios, incluyendo datos demográficos o mercadotécnicos
+35|Agencias de talento (gestión o empleo)
+35|Agentes de publicidad
+35|Alquiler de distribuidores automáticos
+35|Alquiler de espacios publicitarios
+35|Alquiler de espacios publicitarios en sitios web
+35|Alquiler de espacios publicitarios y material publicitario
+35|Alquiler de maquinaria y equipo de oficina
+35|Alquiler de máquinas de escribir y máquinas copiadoras
+35|Alquiler de máquinas o aparatos para oficinas
+35|Alquiler de material publicitario
+35|Alquiler de stands para ventas
+35|Alquiler de todo tipo de material de publicidad y materiales de presentación de marketing
+35|Alquiler de vallas publicitarias
+35|Análisis de costos
+35|Análisis de datos de negocios
+35|Análisis de datos y estadísticas de investigación de mercado
+35|Análisis de dirección de negocios
+35|Análisis de mercado
+35|Análisis de respuesta a la publicidad
+35|Análisis de trabajo para determinar aptitudes y otros requisitos de trabajadores
+35|Análisis publicitarios
+35|Análisis y tasación de empresas
+35|Archivo de documentos o cintas magnéticas (trabajos de oficina)
+35|Arrendamiento de vallas publicitarias
+35|Asesoramiento de eficiencia empresarial
+35|Asesoramiento de negocios e información comercial
+35|Asesoramiento de negocios e información de negocios para empresas
+35|Asesoramiento de negocios y análisis de mercados
+35|Asesoramiento e información relativa a la gestión de negocios comerciales
+35|Asesoramiento e información sobre servicios de clientes y gestión de productos y precios en sitios de Internet en relación con compras realizadas a través de Internet
+35|Asesoramiento en el campo de la gestión de negocios y marketing
+35|Asesoramiento en fusiones y adquisiciones
+35|Asesoramiento en gestión de negocios comerciales franquiciados
+35|Asesoramiento en gestión de negocios y comercialización de productos en el marco de un contrato de franquicia
+35|Asesoramiento en gestión de personal
+35|Asesoramiento en materia de organización y gestión de los negocios comerciales
+35|Asesoramiento en organización de negocios
+35|Asesoramiento relativo al marketing de productos químicos
+35|Asesoramiento, indagación o información de negocios
+35|Asesoría en el análisis de los hábitos y necesidades de compra de consumidores con la ayuda de datos sensoriales, cuantitativos y cualitativos
+35|Asesoría en la administración de establecimientos de franquicias
+35|Asistencia a empresas industriales o comerciales en la gestión de su negocio
+35|Asistencia comercial en gestión de negocios
+35|Asistencia comercial en relación a implementación e integración de sistemas
+35|Asistencia en administración comercial
+35|Asistencia en gestión comercial e industrial
+35|Asistencia en gestión corporativa
+35|Asistencia en gestión de actividades de negocios
+35|Asistencia en gestión de negocios para empresas industriales y comerciales
+35|Asistencia en gestión de negocios y en particular la realización de las tareas necesarias para el buen desarrollo de ventas por subasta
+35|Asistencia en gestión y planificación de negocios
+35|Asistencia en la gestión y operación de negocios comerciales
+35|Asistencia en operación de negocios para empresas
+35|Asistencia y asesoramiento en relación a organización y gestión de negocios
+35|Auditoría de tasas de servicios para terceros
+35|Auditorías empresariales (análisis de negocios)
+35|Ayuda en la gestión de asuntos de negocios o funciones comerciales de una empresa industrial o comercial
+35|Búsqueda de mercados
+35|Búsqueda de patrocinadores
+35|Búsquedas de negocios
+35|Celebración de sondeos de opinión pública
+35|Clasificación, manipulación y recepción de correo
+35|Colocación de personal
+35|Colocación laboral y de personal
+35|Colocación profesional
+35|Colocación y selección de personal
+35|Compilación de directorios de empresas
+35|Compilación de estadísticas con fines de negocios o comerciales
+35|Compilación de información en bases de datos informáticas
+35|Compilación y análisis de estadísticas para determinar los índices de audiencia de programas de radio y televisión
+35|Compilación y sistematización de información en bancos de datos
+35|Compilación y sistematización de información en bases de datos
+35|Compilación, producción y diseminación de anuncios publicitarios
+35|Consultoría comercial
+35|Consultoría contable
+35|Consultoría de gestión de negocios en relación con la estrategia, la mercadotecnia, la producción, el personal y cuestiones de ventas al por menor
+35|Consultoría de gestión industrial incluyendo análisis de costes/rendimiento
+35|Consultoría de personal
+35|Consultoría e información económica para el sector industrial y comercial (también proveida en línea) para planificar, organizar y monitorear proyectos únicos y complejos en diferentes sectores de una o varias empresas
+35|Consultoría e información relativa a la contabilidad
+35|Consultoría en adquisición de negocios
+35|Consultoría en adquisición y fusión de negocios
+35|Consultoría en el campo de adquisiciones de negocios
+35|Consultoría en fusión de negocios
+35|Consultoría en gestión de negocios
+35|Consultoría en gestión de negocios en el campo del transporte y reparto
+35|Consultoría en gestión de negocios incluido vía la Internet
+35|Consultoría en marketing
+35|Consultoría en organización de negocios
+35|Consultoría en organización y gestión de negocios
+35|Consultoría en organización y gestión de negocios incluida la gestión de personal
+35|Consultoría en organización y operación de negocios
+35|Consultoría en publicidad
+35|Consultoría en recursos humanos
+35|Consultoría en relación a la organización o la gestión de una empresa comercial
+35|Consultoría en segmentación de mercado
+35|Consultoría en selección de personal
+35|Consultoría en técnicas de ventas y programas de ventas
+35|Consultoría organizacional de negocios
+35|Consultoría profesional de negocios
+35|Consultoría sobre contratación de personal
+35|Consultoría sobre dirección de negocios en el campo de viajes corporativos
+35|Consultoría, gestión, planificación y supervisión de negocios
+35|Consultoría, indagación o información de negocios
+35|Contabilidad administrativa
+35|Contabilidad de costes
+35|Contabilidad para terceros
+35|Control de inventario
+35|Copiado de documentos para terceros
+35|Creación y mantenimiento de material publicitario
+35|Decoración de vidrieras (escaparates)
+35|Demostración de productos
+35|Demostración de productos y servicios por medios electrónicos, también aplicable a los servicios de venta telemática
+35|Desarrollo de campañas publicitarias para negocios
+35|Desarrollo de conceptos de marketing
+35|Desarrollo de conceptos para economía y negocios
+35|Desarrollo de estrategias y conceptos de marketing
+35|Desarrollo de planes de mercadotecnia
+35|Determinación de índices de audiencia para emisiones de radio y televisión
+35|Difusión de anuncios publicitarios
+35|Difusión de material publicitario (folletos e impresos)
+35|Difusión de material publicitario en la calle
+35|Diseminación de anuncios publicitarios
+35|Diseminación de anuncios publicitarios y material publicitario (volantes, folletos, catálogos y muestras)
+35|Diseminación de publicidad para terceros vía la Internet
+35|Distribución de anuncios publicitarios y comerciales
+35|Distribución de correo publicitario y complementos publicitarios adjuntos a ediciones regulares
+35|Distribución de material publicitario (folletos, prospectos, muestras, en particular para ventas por catálogo) transfronteriza o no
+35|Distribución de materiales publicitarios
+35|Distribución de materiales publicitarios (volantes, prospectos, folletos, muestras), en particular para ventas a larga distancia por catálogo, transfronteriza o no
+35|Distribución de muestras
+35|Distribución de muestras con fines publicitarios
+35|Distribución de productos con fines publicitarios
+35|Distribución de prospectos y muestras
+35|Distribución de volantes (folletos) publicitarios para terceros
+35|Distribución y difusión de materiales publicitarios (folletos, prospectos, impresos y muestras)
+35|Duplicación de documentos
+35|Edición y posproducción de anuncios y publicidad
+35|Elaboración de declaraciones tributarias
+35|Encuestas de opinión pública
+35|Escritura de direcciones en sobres
+35|Estudios de investigación de mercado
+35|Estudios de marketing
+35|Estudios de marketing de cosméticos, perfumería y productos de belleza
+35|Estudios de mercado y análisis de estudios de mercado
+35|Estudios de sondeos de opinión de los mercados
+35|Estudios de viabilidad de negocios
+35|Evaluación de personalidad con fines comerciales
+35|Evaluación en relación a asuntos comerciales
+35|Evaluación estadística de datos de marketing
+35|Evaluaciones e informes expertos relacionados con asuntos de negocios
+35|Exposiciones de desfiles de modas con fines comerciales
+35|Facilitación de espacios de publicidad por medios electrónicos y red informática mundial
+35|Facilitación de espacios publicitarios en publicaciones periódicas, periódicos y revistas
+35|Facilitación de información de estudios de mercado
+35|Facilitación de información relativa a las ventas comerciales
+35|Facilitación de información sobre comercio
+35|Facilitación de información sobre empleo
+35|Facilitación de información sobre negocios comerciales e información comercial vía una red informática mundial
+35|Facilitación de informes de marketing
+35|Facilitación de subastas en línea
+35|Facilitación de un directorio comercial en línea en la Internet
+35|Facilitación y alquiler de espacio publicitario en la Internet
+35|Facturación
+35|Facturación médica
+35|Gestión administrativa de hospitales
+35|Gestión administrativa de hotel
+35|Gestión administrativa y comercial de museos
+35|Gestión comercial
+35|Gestión de archivos informáticos
+35|Gestión de bases de datos
+35|Gestión de empresas incluida la consultoría en materia demográfica
+35|Gestión de hotel para terceros
+35|Gestión de negocios comerciales
+35|Gestión de negocios de hoteles para terceros
+35|Gestión de negocios de logística para terceros
+35|Gestión de negocios en el campo del transporte y reparto
+35|Gestión de negocios para una empresa comercial y para una empresa de servicios
+35|Gestión de negocios y consultoría en organización de empresas
+35|Gestión de personal
+35|Gestión de recursos humanos
+35|Gestión de relaciones con los clientes
+35|Gestión de una empresa aérea
+35|Gestión empresarial de tiendas
+35|Gestión y asesoramiento de negocios comerciales
+35|Gestión y compilación de bases de datos informáticas
+35|Indagaciones e investigaciones de negocios
+35|Información comercial
+35|Información de clasificación de ventas de productos
+35|Información e indagación de negocios
+35|Información e investigación, evaluación y peritajes de negocios
+35|Información empresarial a través de redes informáticas mundiales
+35|Información en materia de negocios
+35|Información sobre métodos de ventas
+35|Información sobre ventas de productos
+35|Información y asesoramiento a los consumidores sobre la selección de productos y artículos a la venta
+35|Información y asesoramiento comerciales al consumidor
+35|Información, compilación de datos y análisis en relación a gestión de negocios
+35|Inventario de mercancías
+35|Investigación comercial
+35|Investigación de consumo
+35|Investigación de mercado
+35|Investigación de mercado por medio de una computadora
+35|Investigación de mercado y análisis de negocios
+35|Investigación de mercados y negocios
+35|Investigación publicitaria
+35|Marketing de afiliación
+35|Marketing directo
+35|Mediación de acuerdos en relación con la venta y compra de productos
+35|Mediación de negocios comerciales para terceros
+35|Mediación de publicidad
+35|Mediación y cierre de negocios comerciales para terceros
+35|Modelaje para publicidad o promoción de ventas
+35|Negociación y cierre de transacciones comerciales para terceros a través de sistemas de telecomunicación
+35|Negociación y resolución de transacciones comerciales para terceros
+35|Operación de negocios, administración de negocios y funciones de oficina
+35|Organización de competiciones de negocios
+35|Organización de desfiles de moda para promoción de ventas
+35|Organización de desfiles de modas con fines comerciales
+35|Organización de exposiciones con fines comerciales o publicitarios
+35|Organización de exposiciones y eventos con fines comerciales o publicitarios
+35|Organización de exposiciones y ferias con fines comerciales o publicitarios
+35|Organización de ferias con fines comerciales y publicitarios
+35|Organización de ferias y exposiciones con fines comerciales y publicitarios
+35|Organización de promociones utilizando medios audiovisuales
+35|Organización de servicios comerciales contractuales con terceros
+35|Organización de servicios de bienvenida telefónica de terceros y de servicios de recepcionista telefónica para terceros
+35|Organización de subastas
+35|Organización de subastas por internet
+35|Organización de ventas en subasta
+35|Organización de ventas en subastas
+35|Organización y dirección de exposiciones de arte con fines comerciales o publicitarios
+35|Organización y dirección de presentaciones de producto
+35|Organización y realización de eventos de marketing promocional para terceros
+35|Organización y realización de ferias y exposiciones con fines de negocios y publicitarios
+35|Organización y realización de subastas
+35|Organización y realización de ventas en subasta pública
+35|Planificación de la sucesión de negocios
+35|Planificación de negocios
+35|Planificación de negocios en materia de gestión, en concreto, búsqueda de socios para fusiones y absorciones de negocios
+35|Planificación en gestión de negocios
+35|Planificación y realización de ferias comerciales, exposiciones y presentaciones con fines económicos o publicitarios
+35|Preparación de anuncios publicitarios para terceros
+35|Preparación de estados de cuentas y análisis para negocios comerciales
+35|Preparación de estudios de mercado
+35|Preparación de informes comerciales
+35|Preparación de nóminas
+35|Preparación de nóminas salariales
+35|Preparación de reportes de negocios
+35|Preparación de sondeos de opinión pública
+35|Preparación y colocación de anuncios publicitarios para terceros
+35|Preparación y realización de planes y conceptos de medios de comunicación y publicitarios
+35|Previsiones sobre asuntos económicos
+35|Previsiones y análisis económicos
+35|Procesamiento administrativo de pedidos de compra en el marco de los servicios prestados por empresas de pedidos por correo
+35|Producción de cintas de vídeo, discos de vídeo y grabaciones audiovisuales con fines promocionales
+35|Producción de material publicitario
+35|Producción de material publicitario y comerciales
+35|Producción de películas publicitarias
+35|Producción de publicidad televisada
+35|Promoción (publicidad) de los beneficios de tecnologías de iluminación eficientes a profesionales de la iluminación
+35|Promoción de productos y servicios para terceros a través de la distribución de tarjetas de descuento
+35|Promoción de una serie de películas para terceros
+35|Promoción de ventas de productos y servicios de terceros mediante la distribución de material impreso y concursos de promoción
+35|Promoción de ventas para terceros a través de la distribución y la administración de tarjetas de usuarios privilegiados
+35|Promoción en línea de redes informáticas y sitios web
+35|Provisión de consultoría de marketing en el campo de los medios sociales
+35|Provisión de información de negocios en el campo de los medios sociales
+35|Provisión de información de negocios via sitios web
+35|Provisión de información en el campo del marketing
+35|Pruebas para determinar la capacitación profesional
+35|Publicación de material publicitario
+35|Publicación de textos publicitarios
+35|Publicidad a través de anuncios en techos de taxis
+35|Publicidad a través de banderines
+35|Publicidad callejera
+35|Publicidad de bienes inmuebles comerciales o residenciales
+35|Publicidad en cine
+35|Publicidad en la Internet para terceros
+35|Publicidad en línea en redes informáticas
+35|Publicidad en línea vía redes informáticas de comunicación
+35|Publicidad en periódicos
+35|Publicidad en prensa popular y profesional
+35|Publicidad en publicaciones periódicas, folletos y periódicos
+35|Publicidad en revistas
+35|Publicidad incluida la promoción de productos y servicios de terceros a través de acuerdos de patrocinio y acuerdos de licencia en relación eventos deportivos internacionales
+35|Publicidad por transmisión de publicidad en línea para terceros a través de redes electrónicas de comunicación
+35|Publicidad radiofónica
+35|Publicidad relativa a productos farmacéuticos y productos de imagen in vivo
+35|Publicidad televisada
+35|Publicidad y consultoría en gestión de negocios
+35|Publicidad y consultoría en mercadotecnia
+35|Publicidad y mercadotecnia
+35|Publicidad y promoción de ventas en relación con productos y servicios, ofrecidos y pedidos a través de telecomunicaciones o medios electrónicos
+35|Publicidad y servicios de publicidad por televisión, radio y correo
+35|Publicidada través de todos los medios de comunicación
+35|Pujas en subastas online en nombre de terceros
+35|Recolección de información de investigación de mercado
+35|Recolección y sistematización de información en bases de datos informáticas
+35|Recopilación de anuncios para su uso como páginas web en Internet
+35|Recopilación y facilitación de información de precios y estadísticas sobre comercio y negocios
+35|Redacción de textos publicitarios
+35|Relaciones públicas
+35|Reportes y estudios de mercado
+35|Representación de artistas del espectáculo
+35|Representación de deportistas profesionales
+35|Reproducción de documentos
+35|Reproducción de documentos (servicios de fotocopiado)
+35|Reubicación de personal
+35|Seguimiento del volumen de ventas para terceros
+35|Selección de personal utilizando pruebas psicológicas
+35|Servicio como departamento de recursos humanos para terceros
+35|Servicio de decoración de escaparates
+35|Servicio de investigación de mercado
+35|Servicios asistencia y consultoría en el campo de la gestión negocios de empresas del sector energético
+35|Servicios de administración de negocios para el procesamiento de ventas en la Internet
+35|Servicios de adquisición de bebidas alcohólicas para terceros (compra de productos para otras empresas)
+35|Servicios de agencias de publicidad
+35|Servicios de agencias de talento (representación comercial de artistas del espectáculo)
+35|Servicios de análisis de marketing
+35|Servicios de análisis e investigación de mercado
+35|Servicios de anuncios publicitarios clasificados
+35|Servicios de asesoramiento de negocios en el campo de la agricultura
+35|Servicios de asesoramiento de preparación y realización de transacciones comerciales
+35|Servicios de asesoramiento en materia de gestión de negocios y operaciones de negocios
+35|Servicios de asesoramiento, consultoría e información de negocios
+35|Servicios de asesoría para asuntos organizacionales y administración de negocios, con y sin la ayuda de bases de datos electrónicos
+35|Servicios de asistencia, asesoramiento y consultoría en relación a planificación de negocios, análisis de negocios, gestión de negocios y organización de negocios
+35|Servicios de asistencia, gestión e información de negocios
+35|Servicios de club de clientes y fidelidad de clientes para propósitos comerciales, promocionales o de publicidad
+35|Servicios de comercio electrónico, en concreto, suministro de información sobre productos a través de redes de telecomunicaciones con una finalidad publicitaria y de ventas
+35|Servicios de comercio en línea en los cuales el vendedor publica productos para su subasta y donde las pujas se realizan de manera electrónica a través de Internet
+35|Servicios de comparación de precios
+35|Servicios de composición de página con fines publicitarios
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 1
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 10
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 11
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 12
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 13
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 14
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 15
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 16
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 17
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 18
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 19
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 2
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 20
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 21
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 22
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 23
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 24
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 25
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 26
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 27
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 28
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 29
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 3
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 30
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 31
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 32
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 33
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 34
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 4
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 5
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 6
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 7
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 8
+35|Servicios de compra y venta al por mayor y al detalle de productos de la clase 9
+35|Servicios de compra y venta al por mayor y al detalle de productos de las clases 1 a la 34
+35|Servicios de consultoría de negocios
+35|Servicios de consultoría e información sobre negocios
+35|Servicios de consultoría en el ámbito del desarrollo de conceptos publicitarios
+35|Servicios de consultoría en gestión de negocios
+35|Servicios de consultoría en organización y gestión de negocios
+35|Servicios de consultoría en relación con estrategias de negocio
+35|Servicios de consultoría para la búsqueda de patrocinadores
+35|Servicios de consultoría relativa a la publicidad
+35|Servicios de consultoría y asesoramiento en estrategia empresarial
+35|Servicios de consultoría y asesoramiento en gestión de negocios
+35|Servicios de contabilidad
+35|Servicios de contabilidad forense
+35|Servicios de contabilidad para fondos de pensiones
+35|Servicios de contabilidad para fusiones y adquisiciones
+35|Servicios de contabilidad relativos a costes para explotaciones agrícolas
+35|Servicios de contestador automático para abonados ausentes
+35|Servicios de contratación de ejecutivos y colocación
+35|Servicios de demostración de productos en escaparates por modelos en vivo
+35|Servicios de desarrollo de estrategias para negocios
+35|Servicios de desarrollo de negocios
+35|Servicios de edición de textos publicitarios
+35|Servicios de estenografía
+35|Servicios de estudios de mercado informatizados
+35|Servicios de evaluación de costes
+35|Servicios de evaluación de marca
+35|Servicios de evaluación de mercados
+35|Servicios de expertos en la eficiencia empresarial
+35|Servicios de exposición para la comercialización dirigidos a negocios
+35|Servicios de facilitación de información sobre comercio exterior
+35|Servicios de facturación
+35|Servicios de facturación para negocios
+35|Servicios de gestión de registro, a saber, indexación de documentos para terceros
+35|Servicios de gestión y asesoramiento de negocios
+35|Servicios de gestión y asesoramiento de negocios en relación a franquicias
+35|Servicios de imagen corporativa
+35|Servicios de información de negocios y asesoramiento contable
+35|Servicios de información en relación a asuntos de negocios
+35|Servicios de información y tasación de negocios
+35|Servicios de información, asesoramiento y consultoría en relación a negocios y gestión o administración de negocios incluidos los servicios prestados en línea o vía la Internet
+35|Servicios de ingreso de datos computacionales(a bases de datos)
+35|Servicios de investigación de marketing
+35|Servicios de marketing comercial
+35|Servicios de marketing en el ámbito de la optimización del tráfico en sitios web
+35|Servicios de mecanografía
+35|Servicios de modelos para publicidad o promoción de ventas
+35|Servicios de oficina de empleo
+35|Servicios de planificación estratégica de negocios
+35|Servicios de posicionamiento de marcas
+35|Servicios de procesamiento de textos y dactilografía
+35|Servicios de promoción comercial (merchandising)
+35|Servicios de promoción de productos y servicios de terceros
+35|Servicios de promoción de ventas
+35|Servicios de publicidad
+35|Servicios de publicidad de una agencia de publicidad de radio y televisión
+35|Servicios de publicidad e información comercial vía la Internet
+35|Servicios de publicidad para la promoción de la correduría de acciones y otros valores
+35|Servicios de publicidad por correo directo
+35|Servicios de publicidad y de promoción
+35|Servicios de publicidad y promoción de ventas
+35|Servicios de publicidad y promoción y consultoría relacionada
+35|Servicios de recepción de pedidos telefónicos para terceros
+35|Servicios de reclutamiento de ejecutivos
+35|Servicios de recolocación laboral
+35|Servicios de reubicación para empresas
+35|Servicios de secretariado taquigráfico
+35|Servicios de selección de personal y agencias de empleo
+35|Servicios de subastas
+35|Servicios de subastas online a través de Internet
+35|Servicios de subastas prestados en Internet
+35|Servicios de suscripción a periódicos para terceros
+35|Servicios de taquigrafía
+35|Servicios de trámite de declaraciones fiscales
+35|Servicios de traslado de negocios
+35|Servicios de valoración de riesgos para negocios
+35|Servicios prestados por un franquiciador, a saber, asistencia en el funcionamiento o gestión de empresas industriales o comerciales
+35|Servicios publicitarios y de propaganda
+35|Servicios que comprenden el registro, la transcripción, composición, recopilación y sistematización de comunicaciones y grabaciones escritas, así como la recopilación de datos matemáticos o estadísticos
+35|Servicios que consisten en el registro, recopilación, transcripción y sistematización de comunicaciones escritas y datos
+35|Servicios relacionados con la presentación de productos al público
+35|Servicios secretariales y de oficina
+35|Sistematización de datos en bases de datos informáticas
+35|Sondeo de opinión pública
+35|Subasta a través de redes de telecomunicaciones
+35|Subasta de propiedades
+35|Subastas en línea
+35|Subastas por teléfono y televisión
+35|Suministro de consejos y recomendaciones a consumidores sobre productos con fines comerciales
+35|Suministro de información comercial, a través de Internet, redes por cable u otras formas de transferencia de datos
+35|Suministro de recomendaciones de productos a consumidores
+35|Supervisión de negocios
+35|Supervisión en gestión de negocios
+35|Suscripción a periódicos electrónicos
+35|Suscripción a un canal de televisión
+35|Suscripción a un paquete de medios informativos
+35|Suscripción a un servicio telemático, telefónico o informático (internet)
+35|Suscripciones a libros, revistas, diarios y libros de historietas
+35|Suscripciones a periódicos
+35|Tests psicotécnicos para la selección de personal
+35|Tramitación administrativa de pedidos de compra
+35|Transcripción de mensajes
+35|Transcripción taquigráfica
+35|Valoración de negocios comerciales
+35|Valoraciones en negocios comerciales y evaluaciones en asuntos de negocios

--- a/lib/seeds/class_36_terms.csv
+++ b/lib/seeds/class_36_terms.csv
@@ -1,108 +1,258 @@
-class,reference_id,name
-36,360001,suscripción de seguros contra accidentes
-36,360002,préstamos a plazos
-36,360002,pagos en cuotas
-36,360003,servicios actuariales
-36,360004,alquiler de bienes inmuebles
-36,360005,corretaje*
-36,360006,servicios de agencias de crédito
-36,360007,servicios de agencias inmobiliarias
-36,360008,corretaje de bienes inmuebles
-36,360009,servicios de agencias de cobro de deudas
-36,360010,corretaje de seguros
-36,360011,servicios financieros de correduría aduanera
-36,360011,servicios financieros de agencias de aduana
-36,360012,suscripción de seguros
-36,360013,servicios bancarios
-36,360014,tasación de bienes inmuebles
-36,360014,tasaciones inmobiliarias
-36,360015,recaudación de fondos de beneficencia
-36,360016,fondos mutuos de inversión
-36,360016,constitución de capital
-36,360017,inversión de capital
-36,360018,servicios de caución
-36,360019,operaciones de cambio
-36,360020,emisión de cheques de viaje
-36,360021,operaciones de cámara de compensación [clearing]
-36,360022,servicios de depósito en cajas de seguridad
-36,360023,organización de colectas financieras
-36,360024,préstamos [financiación]
-36,360025,servicios de estimaciones fiscales
-36,360026,evaluación financiera [seguros, bancos, bienes inmuebles]
-36,360027,descuento de facturas [factoraje]
-36,360028,servicios fiduciarios
-36,360029,servicios de financiación
-36,360030,gestión financiera
-36,360031,préstamos prendarios
-36,360031,préstamos pignoraticios
-36,360032,administración de bienes inmuebles
-36,360033,administración de edificios de viviendas
-36,360034,suscripción de seguros contra incendios
-36,360035,alquiler de apartamentos
-36,360035,alquiler de departamentos
-36,360036,alquiler de explotaciones agrícolas
-36,360038,suscripción de seguros médicos
-36,360039,suscripción de seguros marítimos
-36,360040,servicios de banco hipotecario
-36,360041,servicios de caja de ahorros
-36,360042,arrendamiento con opción de compra [leasing]
-36,360042,arrendamiento financiero
-36,360043,corretaje de valores
-36,360044,suscripción de seguros de vida
-36,360045,servicios de agencias de alojamiento [apartamentos]
-36,360045,servicios de agencias de alquiler [departamentos]
-36,360046,análisis financiero
-36,360051,tasación de antigüedades
-36,360052,tasación de obras de arte
-36,360053,verificación de cheques
-36,360054,consultoría financiera
-36,360055,consultoría sobre seguros
-36,360056,procesamiento de pagos por tarjeta de crédito
-36,360057,procesamiento de pagos por tarjeta de débito
-36,360058,transferencia electrónica de fondos
-36,360059,suministro de información financiera
-36,360060,suministro de información sobre seguros
-36,360061,tasación de joyas
-36,360062,tasación numismática
-36,360063,cobro de alquileres
-36,360064,tasación filatélica
-36,360065,emisión de bonos de valor
-36,360066,depósito de valores
-36,360067,cotizaciones en bolsa
-36,360068,emisión de tarjetas de crédito
-36,360069,alquiler de oficinas [bienes inmuebles]
-36,360070,servicios de pago de jubilaciones
-36,360071,patrocinio financiero
-36,360072,servicios bancarios en línea
-36,360073,servicios de liquidación de empresas [finanzas]
-36,360103,estimación financiera de costos de reparación
-36,360103,estimación financiera de costes de reparación
-36,360104,corretaje [correduría] de créditos de carbono
-36,360104,correduría de créditos de carbono
-36,360105,valoración de la madera en pie
-36,360107,valoración de lanas
-36,360108,préstamos con garantía
-36,360109,servicios de fondos de previsión
-36,360110,corretaje de valores bursátiles
-36,360111,asesoramiento sobre deudas
-36,360112,organización de la financiación de proyectos de construcción
-36,360113,suministro de información financiera por sitios web
-36,360114,gestión financiera de pagos de reembolso para terceros
-36,360115,inversión de fondos
-36,360116,corretaje de acciones, bonos y obligaciones
-36,360117,concesión de descuentos en establecimientos asociados de terceros mediante una tarjeta de miembro
-36,360118,servicios de depósito de fianzas por libertad provisional
-36,360119,alquiler de oficinas para el cotrabajo
-36,360120,estimaciones financieras para responder a convocatorias de licitación
-36,360120,estimaciones financieras para responder a solicitudes de propuestas [RFPs]
-36,360121,evaluación financiera de los costes de desarrollo en relación con las industrias del petróleo, el gas y la minería
-36,360122,investigación financiera
-36,360123,negocios inmobiliarios
-36,360124,transferencia electrónica de monedas virtuales
-36,360125,evaluación financiera de activos de propiedad intelectual
-36,360126,servicios de elaboración de presupuestos para la estimación de costes
-36,360126,servicios de elaboración de presupuestos para la estimación de costos
-36,360127,financiación participativa
-36,360128,servicios de pago por billetera electrónica
-36,360128,servicios de pago por monedero electrónico
-36,360129,operaciones de cambio de monedas virtuales
+class|name
+36|Administración de activos financieros
+36|Administración de ahorros previsionales
+36|Administración de carteras de valores
+36|Administración de cuentas de ahorro
+36|Administración de fondos de capital de riesgo
+36|Administración de fondos de pensiones
+36|Administración financiera de ahorros previsionales
+36|Administración financiera de fondos de pensiones
+36|Administración financiera de planes de pensión de empleados
+36|Adquisición de bienes inmuebles para terceros
+36|Agencias de cobro de deudas
+36|Agencias de crédito
+36|Agencias de seguros
+36|Agencias o correduría para operaciones de valores, futuros indexados, opciones sobre títulos y futuros sobre mercados de valores extranjeros
+36|Agencias o corretaje para el alquiler de edificios
+36|Agencias o corretaje para el alquiler de tierras
+36|Agencias o corretaje para el alquiler o arrendamiento de tierras
+36|Agencias para la correduría en operaciones con títulos en mercados de valores extranjeros y en operaciones a comisión de futuros sobre mercados de valores extranjeros
+36|Agencias para la negociación de futuros de productos básicos
+36|Ajustes de reclamaciones de seguros que no sean de vida
+36|Alquiler de apartamentos
+36|Alquiler de apartamentos y oficinas
+36|Alquiler de cajeros automáticos
+36|Alquiler de departamentos
+36|Alquiler de máquinas contadoras o clasificadoras de billetes y monedas
+36|Análisis de inversiones financieras y estudios bursátiles
+36|Análisis financieros
+36|Análisis por computadora de información sobre bolsas de valores
+36|Arrendamiento con opción de compra (leasing)
+36|Arrendamiento de bienes inmuebles
+36|Arrendamiento de edificios
+36|Arrendamiento de espacio para oficinas
+36|Arrendamiento de espacios en centros comerciales
+36|Arrendamiento de explotaciones agrícolas
+36|Arrendamiento de terrenos
+36|Arrendamiento de tierras
+36|Arrendamiento o alquiler de edificios
+36|Arriendo con opción de compra (leasing) de equipos de telecomunicaciones
+36|Asesoramiento en materia de deudas
+36|Asesoramiento en materia de inversiones
+36|Asesoramiento financiero
+36|Asesoramiento financiero sobre pensiones
+36|Asesoramiento financiero y asesoramiento en materia de seguros
+36|Banca a distancia (home banking)
+36|Banca electrónica a través de una red informática mundial (banca por Internet)
+36|Bienes inmuebles (evaluación (tasación) de -)
+36|Cambio de divisas en tiempo real online
+36|Casas prendarias
+36|Cobro de alquileres
+36|Cobro de deudas
+36|Comercio de opciones de valores
+36|Comercio de valores futuros
+36|Comercio de valores futuros extranjeros
+36|Comprobación de tarjetas de crédito
+36|Cómputo del índice de primas de seguros
+36|Consultoría de inversión de capitales
+36|Consultoría e información relativa a los seguros
+36|Consultoría en inversiones de capital
+36|Consultoría en materia de seguros
+36|Consultoría en seguros
+36|Consultoría financiera
+36|Consultoría financiera relacionada con inversiones inmobiliarias
+36|Consultoría inmobiliaria
+36|Consultoría relativa a la financiación de proyectos energéticos
+36|Corretaje de acciones y obligaciones
+36|Corretaje de acciones y otros valores
+36|Corretaje de acciones, participaciones y otros valores
+36|Corretaje de bienes inmuebles
+36|Corretaje de bonos
+36|Corretaje de compras a plazos
+36|Corretaje de créditos hipotecarios
+36|Corretaje de fondos mutuos
+36|Corretaje de futuros
+36|Corretaje de inversión financiera
+36|Corretaje de seguros de vida
+36|Corretaje de valores bursátiles
+36|Corretaje en bolsa
+36|Cotización de precios del mercado de valores
+36|Dirección de estudios de viabilidad financiera
+36|Emisión de bonos de valor
+36|Emisión de cartas de crédito
+36|Emisión de cheques
+36|Emisión de cheques bancarios
+36|Emisión de cheques de viajero
+36|Emisión de cheques y cartas de crédito
+36|Emisión de tarjetas de crédito
+36|Estimaciones financieras en materia de seguros
+36|Evaluación de bienes inmuebles
+36|Evaluación de la solvencia crediticia de empresas y particulares
+36|Evaluación de propiedades personales para otros
+36|Evaluaciones de reclamaciones de seguros (valoración)
+36|Facilitación de becas educacionales
+36|Facilitación de información del mercado de valores
+36|Facilitación de información en materia de seguros
+36|Facilitación de información financiera
+36|Facilitación de información financiera a inversionistas
+36|Facilitación de información sobre cuentas bancarias por teléfono
+36|Facilitación de información y datos en materia del mercado de valores
+36|Facilitación de noticias en el campo de las finanzas
+36|Financiación de actividades industriales
+36|Financiación de arrendamiento a crédito
+36|Financiación de capital de riesgo
+36|Financiación de compras
+36|Financiación de cuentas por cobrar
+36|Financiación de préstamos
+36|Financiación de proyectos
+36|Financiación en relación a automóviles
+36|Financiación garantizada financieramente
+36|Financiamiento de leasing automotriz
+36|Garantías financieras (servicios de fianzas)
+36|Gestión de carteras de valores mobiliarios
+36|Gestión de carteras de valores transferibles
+36|Gestión de inversiones
+36|Gestión de un fondo de inversión de capitales
+36|Gestión financiera vía la Internet
+36|Información en materia de seguros
+36|Información y consultoría en materia de seguros
+36|Información y evaluación financiera
+36|Intercambio financiero
+36|Inversión de capital privado
+36|Inversión de fondos
+36|Inversión por medios electrónicos
+36|Mantenimiento de cuentas de custodia para inversiones
+36|Negociación de valores
+36|Operaciones de cambio
+36|Operaciones de fondos de inversión
+36|Operaciones monetarias de cambio
+36|Organización de una bolsa de valores para el comercio de acciones y otros valores financieros
+36|Planificación de fideicomisos financieros
+36|Planificación de fideicomisos patrimoniales
+36|Planificación financiera de jubilación
+36|Preparación de informes financieras
+36|Préstamos (financiación) y descuento de facturas
+36|Préstamos con amortización a plazos
+36|Préstamos prendarios
+36|Previsiones financieras
+36|Procesamiento de pagos electrónicos hechos con tarjetas prepagadas
+36|Procesamiento de reclamaciones de seguros
+36|Recaudación de fondos con fines benéficos
+36|Recaudación de fondos de beneficencia
+36|Recaudación de fondos para obras de caridad en previsión y prevención de desastres
+36|Refinanciación de créditos hipotecarios
+36|Representaciones fiduciarias
+36|Servicio de cambio de divisas
+36|Servicio de corretaje de inversiones de capital
+36|Servicio de transacciones financieras de compraventa con opción de arriendo (leaseback),
+36|Servicios actuariales de seguros
+36|Servicios bancarios
+36|Servicios bancarios de cuentas corrientes
+36|Servicios bancarios de cuentas corrientes electrónicas sin papel
+36|Servicios bancarios de cuentas de ahorro
+36|Servicios bancarios electrónicos sin papel
+36|Servicios bancarios en cajeros automáticos
+36|Servicios bancarios mercantiles y de inversión bancaria
+36|Servicios bancarios y financieros
+36|Servicios de aceptación electrónica de cheques
+36|Servicios de administración de planes de acciones para empleados
+36|Servicios de agencia de bienes inmuebles residenciales
+36|Servicios de agencia de factoring
+36|Servicios de análisis e investigación financiera
+36|Servicios de asesoramiento en planificación financiera e inversión
+36|Servicios de asesoramiento relacionados con fondos mutuos
+36|Servicios de asesoramiento y consultoría financiera
+36|Servicios de asesores relacionados con el control de créditos y débitos, inversiones, subvenciones y financiación de préstamos
+36|Servicios de banca comercial
+36|Servicios de banca por Internet
+36|Servicios de banca por teléfono
+36|Servicios de cajeros automáticos
+36|Servicios de calificación crediticia
+36|Servicios de calificación de crédito financiero
+36|Servicios de casas de empeño
+36|Servicios de cobro de cheques
+36|Servicios de colectas de beneficencia
+36|Servicios de consultas sobre inversiones de materias primas
+36|Servicios de cooperativas de crédito
+36|Servicios de corredor de bolsa
+36|Servicios de correduría bursátil
+36|Servicios de corredurías de seguros
+36|Servicios de cotización y listado de información bursátil
+36|Servicios de crédito y préstamo
+36|Servicios de créditos hipotecarios
+36|Servicios de depósito de valores
+36|Servicios de deposito en cajas de seguridad
+36|Servicios de evaluación de créditos
+36|Servicios de fideicomiso
+36|Servicios de financiación y préstamo
+36|Servicios de financiamiento provistos a través de la recolección de dinero proveniente de diversas personas (crowdfunding)
+36|Servicios de gestión de deudas
+36|Servicios de giros de dinero a través de correo
+36|Servicios de información de cambio de divisas
+36|Servicios de información e investigación financiera
+36|Servicios de información financiera y asesoramiento
+36|Servicios de información relacionados con la banca
+36|Servicios de información sobre bolsa
+36|Servicios de información sobre precios de acciones
+36|Servicios de información y consultoría en materia seguros y finanzas
+36|Servicios de intermediación de préstamos para automóvil
+36|Servicios de inversión de capital
+36|Servicios de inversión en bienes inmobiliarios
+36|Servicios de inversiones de fondos de capitales privados
+36|Servicios de liquidación de facturas
+36|Servicios de mercado de futuros
+36|Servicios de negociación de deudas
+36|Servicios de pago de alquileres
+36|Servicios de pago de facturas prestados a través de un sitio web
+36|Servicios de planificación financiera para la jubilación
+36|Servicios de préstamos inmobiliarios
+36|Servicios de procesamiento de transacciones de tarjetas de crédito
+36|Servicios de recuperación de deudas
+36|Servicios de reembolso de aranceles
+36|Servicios de tarjetas de cargo
+36|Servicios de tarjetas de crédito y de cobro
+36|Servicios de tarjetas de crédito y débito
+36|Servicios de tarjetas de crédito y tarjetas de débito
+36|Servicios de tarjetas de crédito y tarjetas de pago
+36|Servicios de tarjetas de garantía de cheques
+36|Servicios de transferencia de dinero
+36|Servicios de transferencia de divisas
+36|Servicios de valoración de bienes inmuebles
+36|Servicios de valoración de opciones sobre acciones
+36|Servicios de valoración de propiedad intelectual
+36|Servicios de verificación de cheques
+36|Servicios de verificación de solvencia empresarial
+36|Servicios electrónicos de cobro de peaje
+36|Servicios financieros, en concreto, liquidación de deudas
+36|Suministro de información de mercado de títulos/valores
+36|Suministro de información financiera relacionada con la industria financiera dedicada a inversiones con enfoque ambiental
+36|Suministro de préstamos a estudiantes
+36|Suscripción de anualidades
+36|Suscripción de seguros contra accidentes
+36|Suscripción de seguros de accidentes marítimos
+36|Suscripción de seguros de incendios marítimos
+36|Suscripción de seguros de transporte marítimo
+36|Suscripción de seguros de vida
+36|Suscripción de seguros médicos
+36|Suscripción de seguros que no sean de vida
+36|Suscripción de valores
+36|Tasación de antigüedades
+36|Tasación de automóviles de segunda mano
+36|Tasación de bienes inmuebles
+36|Tasación de obras de arte
+36|Tasación de piedras preciosas
+36|Tasación filatélica
+36|Tasación y evaluación de antigüedades
+36|Tasación y valoración de bienes inmuebles
+36|Tasaciones inmobiliarias
+36|Transacciones con valores y servicios de inversión para terceros a través de Internet
+36|Transacciones de cambio de divisas y de efectivo
+36|Transacciones electrónicas de tarjetas de crédito
+36|Transferencia electrónica de dinero
+36|Transferencia electrónica de fondos
+36|Transferencia electrónica de fondos por telecomunicaciones
+36|Valoración de bienes inmuebles
+36|Valoración de la madera en pie
+36|Valoración de reclamaciones de seguros de propiedades personales
+36|Valoración financiera de la lana
+36|Valoraciones financieras

--- a/lib/seeds/class_37_terms.csv
+++ b/lib/seeds/class_37_terms.csv
@@ -1,153 +1,388 @@
-class,reference_id,name
-37,370001,conservación de muebles
-37,370002,reparación de aparatos fotográficos
-37,370003,instalación y reparación de aparatos eléctricos
-37,370004,instalación y reparación de ascensores
-37,370005,asfaltado
-37,370006,mantenimiento y reparación de vehículos a motor
-37,370006,mantenimiento y reparación de vehículos de motor
-37,370008,mantenimiento y reparación de aviones
-37,370009,limpieza de edificios [interiores]
-37,370010,servicios de lavandería
-37,370011,limpieza y reparación de calderas
-37,370012,mantenimiento y reparación de quemadores
-37,370013,alquiler de buldóceres
-37,370014,instalación, mantenimiento y reparación de máquinas y equipos de oficina
-37,370015,instalación y reparación de alarmas contra incendios
-37,370016,instalación y reparación de alarmas antirrobo
-37,370017,reparación de tapicerías
-37,370018,mantenimiento y reparación de cámaras blindadas
-37,370020,alquiler de máquinas de construcción
-37,370021,construcción naval
-37,370022,renovación de prendas de vestir
-37,370024,instalación y reparación de sistemas de calefacción
-37,370025,servicios de zapatería
-37,370025,reparación de calzado
-37,370026,deshollinado de chimeneas
-37,370027,mantenimiento y reparación de cajas fuertes
-37,370028,instalación y reparación de aparatos de aire acondicionado
-37,370029,construcción*
-37,370030,construcción submarina
-37,370031,supervisión [dirección] de obras de construcción
-37,370032,compostura de prendas de vestir
-37,370034,mantenimiento, limpieza y reparación del cuero
-37,370035,instalación de equipos de cocinas
-37,370036,demolición de edificios
-37,370037,tratamiento contra la herrumbre
-37,370037,tratamiento contra la oxidación
-37,370038,desinfección
-37,370040,pintura o reparación de letreros [rótulos]
-37,370041,instalación y reparación de almacenes [depósitos]
-37,370042,impermeabilización de construcciones
-37,370044,alquiler de excavadoras
-37,370045,limpieza de ventanas
-37,370045,limpieza de cristales de ventana
-37,370046,reparación y mantenimiento de proyectores de cine
-37,370047,instalación y reparación de hornos
-37,370048,mantenimiento, limpieza y reparación de pieles
-37,370049,engrase de vehículos
-37,370049,lubricación de vehículos
-37,370050,limpieza de prendas de vestir
-37,370051,reparación de relojes
-37,370052,construcción de fábricas
-37,370053,instalación y reparación de dispositivos de riego
-37,370054,servicios de aislamiento [construcción]
-37,370054,aislamiento de construcciones
-37,370055,lavado de vehículos
-37,370056,lavado de ropa
-37,370057,lavado
-37,370058,instalación, mantenimiento y reparación de máquinas
-37,370059,albañilería
-37,370060,restauración de muebles
-37,370061,construcción de rompeolas
-37,370062,planchado de prendas de vestir
-37,370063,instalación y mantenimiento de oleoductos
-37,370064,colocación de papel pintado
-37,370064,trabajos de empapelado
-37,370064,colocación de papel tapiz
-37,370065,reparación de paraguas
-37,370066,reparación de sombrillas
-37,370067,acolchado de muebles
-37,370068,trabajos de pintura para interiores y exteriores
-37,370069,apomazado
-37,370070,trabajos de yesería
-37,370071,trabajos de fontanería
-37,370071,trabajos de plomería
-37,370072,pulido de vehículos
-37,370073,reparación de bombas
-37,370074,construcción de puertos
-37,370077,recauchutado de neumáticos
-37,370078,instalación y reparación de aparatos de refrigeración
-37,370079,planchado de ropa
-37,370080,restañado
-37,370081,remache
-37,370082,tratamiento antioxidante para vehículos
-37,370082,tratamiento preventivo contra la herrumbre para vehículos
-37,370082,tratamiento preventivo contra la oxidación para vehículos
-37,370083,estaciones de servicio [reabastecimiento de carburante y mantenimiento]
-37,370084,instalación y reparación de teléfonos
-37,370085,mantenimiento de vehículos
-37,370086,trabajos de barnizado
-37,370087,limpieza de vehículos
-37,370089,servicios de reparación en caso de avería de vehículos
-37,370090,alquiler de máquinas de limpieza
-37,370091,exterminación de animales dañinos que no sea para la agricultura, la acuicultura, la horticultura y la silvicultura
-37,370093,montaje de andamios
-37,370101,colocación de ladrillos [albañilería]
-37,370102,limpieza de pañales
-37,370103,limpieza en seco
-37,370104,suministro de información sobre construcción
-37,370105,suministro de información sobre reparaciones
-37,370106,afilado de cuchillos
-37,370107,extracción minera
-37,370108,explotación de canteras
-37,370109,pavimentación de carreteras
-37,370110,lijado
-37,370111,reparación submarina
-37,370112,limpieza de edificios [fachadas]
-37,370113,vulcanización de neumáticos [reparación]
-37,370114,perforación de pozos
-37,370115,construcción de puestos de feria y de tiendas
-37,370116,instalación, mantenimiento y reparación de hardware
-37,370117,supresión de interferencias de instalaciones eléctricas
-37,370118,reconstrucción de motores usados o parcialmente destruidos
-37,370119,reconstrucción de máquinas usadas o parcialmente destruidas
-37,370120,alquiler de grúas [máquinas de construcción]
-37,370121,alquiler de máquinas barredoras
-37,370122,servicios de techado
-37,370123,servicios de nevado artificial
-37,370124,limpieza vial
-37,370125,reparación de cerraduras
-37,370126,restauración de obras de arte
-37,370127,restauración de instrumentos musicales
-37,370128,instalación de puertas y ventanas
-37,370129,mantenimiento de piscinas
-37,370129,mantenimiento de albercas de natación
-37,370129,mantenimiento de piletas de natación
-37,370130,servicios de recarga de cartuchos de tóner
-37,370131,consultoría sobre construcción
-37,370132,servicios de carpintería estructural
-37,370133,perforación de pozos profundos de gas y petróleo
-37,370134,alquiler de bombas de drenaje
-37,370135,alquiler de lavarropas
-37,370135,alquiler de máquinas de lavandería
-37,370136,reparación de líneas eléctricas
-37,370137,servicios de recarga de baterías de vehículos
-37,370138,equilibrado de neumáticos
-37,370138,balanceo de neumáticos
-37,370139,afinación de instrumentos de música
-37,370140,colocación de cables
-37,370141,esterilización de instrumentos médicos
-37,370142,servicios de fracturación hidráulica
-37,370143,servicios de control de plagas, que no guarden relación con la agricultura, la acuicultura, la horticultura y la silvicultura
-37,370144,alquiler de lavavajillas
-37,370145,alquiler de máquinas para secar la vajilla
-37,370146,instalación de servicios públicos en obras de construcción
-37,370147,servicios de electricistas
-37,370148,instalación y reparación de equipos de protección contra inundaciones
-37,370149,retirada de nieve
-37,370150,servicios de recarga de cartuchos de tinta
-37,370151,recarga de vehículos eléctricos
-37,370152,servicios domésticos [servicios de limpieza]
-37,370153,servicios de recarga de baterías para teléfonos celulares
-37,370153,servicios de recarga de baterías para teléfonos móviles
+class|name
+37|Abrillantado de calzado
+37|Acolchado de muebles
+37|Acristalamientos (trabajos con cristal)
+37|Actualización de hardware informático
+37|Afilado de tijeras y cuchillos de cocina
+37|Albañilería
+37|Alquiler de andamios y plataformas para la construcción
+37|Alquiler de aparatos para lavado de automóviles
+37|Alquiler de bombas para drenar
+37|Alquiler de bulldozers
+37|Alquiler de compresores de gas y aire
+37|Alquiler de equipo de telecomunicaciones incluidos los teléfonos y máquinas de fax
+37|Alquiler de lavaplatos para uso doméstico
+37|Alquiler de lavavajillas para uso industrial
+37|Alquiler de máquinas de construcción
+37|Alquiler de máquinas lavadoras eléctricas
+37|Alquiler de máquinas para la limpieza de alfombras
+37|Alquiler de máquinas y aparatos para la construcción
+37|Alquiler de plataformas de perforación
+37|Alquiler de secadoras de lavandería
+37|Alquiler de secadoras de ropa
+37|Alquiler de trapeadores
+37|Alquiler máquinas limpiadoras de pisos
+37|Andamiaje, excavaciones o construcción en concreto
+37|Aplicación de revestimientos en edificios
+37|Arreglo de ropa
+37|Asesoramiento en construcción
+37|Asesoramiento en materia de edificación
+37|Asfaltado
+37|Balanceo de neumáticos
+37|Bombeo de petróleo
+37|Bombeo de petróleo crudo
+37|Bombeo y extracción de petróleo
+37|Cableado de telecomunicación
+37|Colocación de alfombras
+37|Colocación de baldosas, ladrillos o bloques
+37|Colocación de ladrillos
+37|Colocación de papel tapiz
+37|Construcción de aeropuertos
+37|Construcción de carreteras
+37|Construcción de centrales de energía undimotriz
+37|Construcción de centrales eólicas
+37|Construcción de centros comerciales, áreas habitacionales y plantas de fabricación
+37|Construcción de edificios
+37|Construcción de establecimientos médicos
+37|Construcción de estructuras para el almacenamiento de gas natural
+37|Construcción de estructuras para el almacenamiento de petróleo crudo
+37|Construcción de estructuras para la producción de gas natural
+37|Construcción de estructuras para la producción de petróleo crudo
+37|Construcción de fábricas hidroeléctricas
+37|Construcción de instalaciones de energía geotérmica
+37|Construcción de oleoductos
+37|Construcción de terrazas interiores acristaladas
+37|Construcción de viviendas
+37|Construcción naval
+37|Construcción submarina
+37|Construcción y reparación de edificios
+37|Consultoría en supervisión de obras de construcción
+37|Control de plagas para casa residenciales
+37|Control de plagas relativo a edificios
+37|Demolición de construcciones
+37|Demolición de edificios
+37|Deshollinado de chimeneas
+37|Desinfección
+37|Desinfección de auriculares telefónicos
+37|Desinfección de instrumentos quirúrgicos
+37|Desinfección de vajilla
+37|Desmantelamiento de buques
+37|Dragado submarino
+37|Edificación de tiendas comerciales
+37|Eliminación de amianto
+37|Explotación de canteras
+37|Exterminación de animales dañinos que no sea para la agricultura
+37|Exterminación de animales dañinos que no sea para la agricultura, horticultura o silvicultura
+37|Extracción de petróleo
+37|Facilitación de información sobre servicios de reparación en el sector de la aviación
+37|Facilitación de instalaciones de autoservicio para el lavado de coches
+37|Fontanería e instalación de gas y agua
+37|Impermeabilización de construcciones
+37|Impermeabilización de edificios
+37|Información con relación a la construcción, reparación y mantenimiento de aeronaves
+37|Información relativa al alquiler de equipo para construcciones y edificios
+37|Información sobre mantenimiento de equipo de medición y comprobación
+37|Inspección de vehículos y/o edificios previo a su reparación y/o mantención
+37|Instalación de aislamientos en obras de construcción
+37|Instalación de aparatos de iluminación
+37|Instalación de aparatos de producción de petróleo
+37|Instalación de canalones para la lluvia
+37|Instalación de conexiones electrónicas y digitales en un centro de llamadas o call center
+37|Instalación de elevadores
+37|Instalación de líneas de teléfonos
+37|Instalación de los productos de fundición
+37|Instalación de maquinaria eléctrica y de generadores
+37|Instalación de materiales aislantes
+37|Instalación de oleoductos
+37|Instalación de pararrayos
+37|Instalación de productos de impermeabilización de sótanos
+37|Instalación de puertas y ventanas
+37|Instalación de techos metálicos
+37|Instalación o reparación de cerraduras
+37|Instalación personalizada de interiores de automóvil
+37|Instalación y mantenimiento de instalaciones fotovoltaicas
+37|Instalación y mantenimiento de instalaciones termosolares
+37|Instalación y mantenimiento de oleoductos
+37|Instalación y reparación de aparatos de aire acondicionado
+37|Instalación y reparación de ascensores
+37|Instalación y reparación de hardware informático
+37|Instalación y reparación de sistemas de calefacción
+37|Instalación, mantenimiento y reparación de aparatos de oficina
+37|Instalación, mantenimiento y reparación de hardware informático
+37|Instalación, modificación, sustitución y reparación de cerraduras
+37|Instalación, reparación y mantenimiento de computadoras y periféricos informáticos
+37|Instalaciones de lavado y secado de ropa
+37|Lavado de ropa
+37|Lavado textil
+37|Limpieza de alfombras y tapetes
+37|Limpieza de calzado
+37|Limpieza de edificios
+37|Limpieza de fosas sépticas
+37|Limpieza de instalaciones industriales
+37|Limpieza de las superficies exteriores de los edificios
+37|Limpieza de superficies exteriores de edificios
+37|Limpieza de tanques de almacenamiento
+37|Limpieza de ventanas
+37|Limpieza en seco
+37|Limpieza exterior e interior de aviones
+37|Limpieza fachadas de edificios
+37|Limpieza vial
+37|Limpieza y lavado de vehículos
+37|Loteo y urbanización de terrenos para la construcción
+37|Lubricación de vehículos
+37|Mantenimiento de acuarios
+37|Mantenimiento de aparatos e instrumentos para uso médico
+37|Mantenimiento de aparatos electrónicos
+37|Mantenimiento de cocinas no eléctricas
+37|Mantenimiento de hardware informático
+37|Mantenimiento de piscinas
+37|Mantenimiento de tuberías
+37|Mantenimiento de vehículos
+37|Mantenimiento o reparación de cajas fuertes
+37|Mantenimiento y reparación de aeronaves
+37|Mantenimiento y reparación de centrales eólicas
+37|Mantenimiento y reparación de edificios
+37|Mantenimiento y reparación de instalaciones de calefacción
+37|Mantenimiento y reparación de quemadores
+37|Mantenimiento y reparación de vehículos
+37|Mantenimiento y reparación de vehículos a motor
+37|Mantenimiento y reparación de vehículos eléctricos
+37|Obras de dragado
+37|Pavimentación de carreteras
+37|Perforación de pozos
+37|Perforación de pozos de agua
+37|Perforación de pozos petroleros
+37|Perforación para gas y petróleo
+37|Perforación y bombeo de petróleo
+37|Pintado de aeronaves
+37|Pintado de señales
+37|Pintura y barnizado
+37|Pintura y reparación de señales
+37|Planchado a vapor de prendas de vestir
+37|Provisión de instalaciones de lavandería
+37|Provisión de lavanderías autoservicio
+37|Pulido de concreto
+37|Pulido de pisos
+37|Pulido de vehículos
+37|Pulverización de insecticidas para edificios comerciales
+37|Pulverización de insecticidas para hogares
+37|Recarga de cartuchos de tóner
+37|Recauchado de neumáticos
+37|Recuperación del terreno
+37|Refuerzo de edificios
+37|Reparación de aeronaves
+37|Reparación de aparatos de filtrado de aire
+37|Reparación de aparatos de iluminación
+37|Reparación de aparatos de suministro de agua
+37|Reparación de aparatos eléctricos de consumo
+37|Reparación de aparatos electrónicos
+37|Reparación de aparejos de pesca
+37|Reparación de ascensores
+37|Reparación de aspiradoras
+37|Reparación de automóviles
+37|Reparación de bañeras
+37|Reparación de bicicletas
+37|Reparación de binoculares
+37|Reparación de bolsas y bolsos
+37|Reparación de bombas
+37|Reparación de cámaras
+37|Reparación de cámaras fotográficas
+37|Reparación de camiones
+37|Reparación de cocinas no eléctricas
+37|Reparación de colchonetas de tatami
+37|Reparación de computadoras dañadas
+37|Reparación de edificios
+37|Reparación de equipo para billar
+37|Reparación de equipo para deportes
+37|Reparación de filtros de leche
+37|Reparación de gafas
+37|Reparación de grúas
+37|Reparación de joyas
+37|Reparación de juguetes o muñecas
+37|Reparación de maletas
+37|Reparación de máquinas de fax
+37|Reparación de máquinas electrónicas
+37|Reparación de máquinas y aparatos para trabajar el metal
+37|Reparación de marcos para puertas
+37|Reparación de paneles publicitarios
+37|Reparación de paraguas
+37|Reparación de persianas de ventanas
+37|Reparación de radios o televisores
+37|Reparación de remolques
+37|Reparación de ropa de vestir
+37|Reparación de señales
+37|Reparación de tapicerías
+37|Reparación de teléfonos
+37|Reparación o mantenimiento de alarmas de incendio
+37|Reparación o mantenimiento de aparatos de aire acondicionado para uso industrial
+37|Reparación o mantenimiento de aparatos de cocina para uso industrial
+37|Reparación o mantenimiento de aparatos de depuración del agua para uso industrial
+37|Reparación o mantenimiento de aparatos e instrumentos de laboratorio
+37|Reparación o mantenimiento de aparatos purificar para agua
+37|Reparación o mantenimiento de aparatos telefónicos
+37|Reparación o mantenimiento de automóviles
+37|Reparación o mantenimiento de bombas
+37|Reparación o mantenimiento de calderas
+37|Reparación o mantenimiento de calentadores de gas para agua
+37|Reparación o mantenimiento de computadoras
+37|Reparación o mantenimiento de cortadoras de forraje
+37|Reparación o mantenimiento de distribuidores automáticos
+37|Reparación o mantenimiento de distribuidores de energía o de máquinas y aparatos de control
+37|Reparación o mantenimiento de elevadores
+37|Reparación o mantenimiento de equipo de gasolineras
+37|Reparación o mantenimiento de equipos de control de contaminación de aguas
+37|Reparación o mantenimiento de generadores de fuerza
+37|Reparación o mantenimiento de hogares (chimeneas) para uso industrial
+37|Reparación o mantenimiento de iluminación eléctrica
+37|Reparación o mantenimiento de incubadoras de huevos
+37|Reparación o mantenimiento de incubadoras de pollos
+37|Reparación o mantenimiento de instalaciones de lavado de vehículos
+37|Reparación o mantenimiento de instrumentos musicales
+37|Reparación o mantenimiento de máquinas de costura
+37|Reparación o mantenimiento de máquinas e implementos agrícolas
+37|Reparación o mantenimiento de máquinas e implementos para cosechar
+37|Reparación o mantenimiento de máquinas e instrumentos de medición y comprobación
+37|Reparación o mantenimiento de máquinas e instrumentos de sericultura
+37|Reparación o mantenimiento de máquinas e instrumentos para cultivar
+37|Reparación o mantenimiento de máquinas e instrumentos para la fabricación de zapatos
+37|Reparación o mantenimiento de máquinas e instrumentos para procesar fibras de plantas
+37|Reparación o mantenimiento de máquinas eléctricas de limpieza de suelos
+37|Reparación o mantenimiento de máquinas lavadoras para uso industrial
+37|Reparación o mantenimiento de máquinas lavavajillas para uso industrial
+37|Reparación o mantenimiento de máquinas médicas
+37|Reparación o mantenimiento de máquinas ordeñadoras
+37|Reparación o mantenimiento de máquinas para uso en salones de belleza y barberías
+37|Reparación o mantenimiento de máquinas y aparatos cinematográficos
+37|Reparación o mantenimiento de máquinas y aparatos de buceo
+37|Reparación o mantenimiento de máquinas y aparatos de carga y descarga
+37|Reparación o mantenimiento de máquinas y aparatos de congelación
+37|Reparación o mantenimiento de máquinas y aparatos de embalaje y envoltura
+37|Reparación o mantenimiento de máquinas y aparatos de fotográficos
+37|Reparación o mantenimiento de máquinas y aparatos de imprimir y encuadernar
+37|Reparación o mantenimiento de máquinas y aparatos de minería
+37|Reparación o mantenimiento de máquinas y aparatos de oficina
+37|Reparación o mantenimiento de máquinas y aparatos de plantas de energía nuclear
+37|Reparación o mantenimiento de máquinas y aparatos de prensado de basura
+37|Reparación o mantenimiento de máquinas y aparatos de telecomunicación
+37|Reparación o mantenimiento de máquinas y aparatos de videofrecuencia
+37|Reparación o mantenimiento de máquinas y aparatos fabricación de pulpa y papel
+37|Reparación o mantenimiento de máquinas y aparatos ópticos
+37|Reparación o mantenimiento de máquinas y aparatos para aplastar y triturar basura
+37|Reparación o mantenimiento de máquinas y aparatos para la construcción
+37|Reparación o mantenimiento de máquinas y aparatos para la fabricación de artículos de cristalería
+37|Reparación o mantenimiento de máquinas y aparatos para la fabricación de productos de caucho
+37|Reparación o mantenimiento de máquinas y aparatos para la industria maderera
+37|Reparación o mantenimiento de máquinas y aparatos para la preparación de alimentos y bebidas
+37|Reparación o mantenimiento de máquinas y aparatos para pintar
+37|Reparación o mantenimiento de máquinas y aparatos recreativos
+37|Reparación o mantenimiento de máquinas y aparatos textiles
+37|Reparación o mantenimiento de máquinas y herramientas para trabajar los metales
+37|Reparación o mantenimiento de máquinas y sistemas de fabricación de circuitos integrados
+37|Reparación o mantenimiento de máquinas y sistemas para la fabricación de semiconductores
+37|Reparación o mantenimiento de material rodante ferroviario
+37|Reparación o mantenimiento de mezcladoras de forraje
+37|Reparación o mantenimiento de molinos de forraje
+37|Reparación o mantenimiento de motores eléctricos
+37|Reparación o mantenimiento de navíos
+37|Reparación o mantenimiento de ollas y sartenes de cocina
+37|Reparación o mantenimiento de plantas químicas
+37|Reparación o mantenimiento de prensas de forraje
+37|Reparación o mantenimiento de relojes
+37|Reparación o mantenimiento de retroproyectores
+37|Reparación o mantenimiento de sistemas mecánicos para aparcamientos
+37|Reparación o mantenimiento de transportadoras
+37|Reparación o mantenimiento de vehículos automóviles de dos ruedas o bicicletas
+37|Reparación y acabado de carrocerías de automóviles para terceros
+37|Reparación y conservación de edificios en caso del demolición
+37|Reparación y mantenimiento de alimentadores o bombas para aumentar la presión
+37|Reparación y mantenimiento de andamios y plataformas para la construcción
+37|Reparación y mantenimiento de audífonos para sordos
+37|Reparación y mantenimiento de bombas
+37|Reparación y mantenimiento de impresoras 3D
+37|Reparación y mantenimiento de máquinas y aparatos de juego
+37|Reparación y mantenimiento de máquinas y aparatos de oficina
+37|Reparación y mantenimiento de máquinas y aparatos de procesamiento químico
+37|Reparación y mantenimiento de máquinas y aparatos de telecomunicación
+37|Reparación y mantenimiento de máquinas y aparatos para el procesar materias plásticas
+37|Reparación y mantenimiento de máquinas y aparatos para procesar tabaco
+37|Reparación y mantenimiento de máquinas y aparatos para uso médico
+37|Reparación y mantenimiento de proyectores de cine
+37|Reparación y mantenimiento de tanques de almacenamiento
+37|Reparación y mantenimiento de teléfonos inteligentes
+37|Reparación y mantenimiento de vehículos
+37|Reparación y restauración de libros
+37|Reparación, servicio y mantenimiento de vehículos y aparatos de locomoción aérea
+37|Repostaje con hidrógeno para vehículos
+37|Restauración de edificios
+37|Restauración de instrumentos musicales
+37|Restauración de mobiliario
+37|Restauración de muros y estructuras de mampostería
+37|Restauración de obras de arte
+37|Restauración de sombreros
+37|Restauración de tejados
+37|Restauración, reparación y mantenimiento de muebles
+37|Servicios de afinado de instrumentos musicales
+37|Servicios de ajuste de esquís
+37|Servicios de aseo
+37|Servicios de asesoramiento en materia de demolición de edificios
+37|Servicios de asesoramiento en materia de instalación de aparatos de iluminación
+37|Servicios de asesoramiento en materia de instalación de ascensores
+37|Servicios de asesoramiento en materia de instalación de equipos audiovisuales
+37|Servicios de asesoramiento en materia de instalación de equipos de telefonía
+37|Servicios de asesoramiento relacionados con el mantenimiento de edificios
+37|Servicios de asesoramiento relacionados con la colocación de tubos
+37|Servicios de asesoramiento relacionados con la excavación
+37|Servicios de asesoramiento relacionados con la reparación de vehículos
+37|Servicios de cantería
+37|Servicios de construcción de edificios
+37|Servicios de deshielo para aviones
+37|Servicios de fumigación de edificios.
+37|Servicios de impermeabilización contra humedades
+37|Servicios de instalación de andamios para edificios y plataformas de trabajo
+37|Servicios de instalación de elevadores y montacargas
+37|Servicios de lavandería
+37|Servicios de levantamiento de hormigón
+37|Servicios de limpieza
+37|Servicios de limpieza de aparatos de aire acondicionado
+37|Servicios de limpieza de baños
+37|Servicios de limpieza de campanas extractoras
+37|Servicios de limpieza de desagües
+37|Servicios de limpieza de escaleras mecánicas
+37|Servicios de limpieza de escenarios de crímenes
+37|Servicios de limpieza de piscinas de natación
+37|Servicios de limpieza de tapicerías
+37|Servicios de mantenimiento y reparación de aeronaves
+37|Servicios de marcado de pavimentos
+37|Servicios de nevado artificial
+37|Servicios de nivelación de hormigón
+37|Servicios de pintura decorativa
+37|Servicios de pintura decorativa de interiores
+37|Servicios de reacondicionamiento de apartamentos
+37|Servicios de reacondicionamiento de automóviles
+37|Servicios de reacondicionamiento de edificios
+37|Servicios de remover nieve
+37|Servicios de reparación de aparatos médicos
+37|Servicios de reparación de carretillas elevadoras
+37|Servicios de reparación de cerraduras
+37|Servicios de reparación de ordenadores
+37|Servicios de reparación de relojes
+37|Servicios de reparación de vehículos
+37|Servicios de reparación para generadores eléctricos y turbinas de viento
+37|Servicios de repostaje de aeronaves
+37|Servicios de repostaje de vehículos
+37|Servicios de restauración de libros antiguos
+37|Servicios de restauración de trabajos de caligrafía
+37|Servicios de supresión de interferencias para aparatos eléctricos
+37|Servicios de techado
+37|Servicios de zapatería
+37|Servicios domésticos relacionados con la limpieza de casas u oficinas
+37|Siderurgias
+37|Supervisión (dirección) de obras de construcción
+37|Tendido de cables
+37|Trabajo de reparación en edificios
+37|Trabajos de fontanería
+37|Trabajos de pintura para interiores y exteriores
+37|Trabajos de yesería
+37|Tratamiento antioxidante para vehículos
+37|Tratamiento contra la herrumbre
+37|Vulcanización (reparación) de neumáticos

--- a/lib/seeds/class_38_terms.csv
+++ b/lib/seeds/class_38_terms.csv
@@ -1,51 +1,198 @@
-class,reference_id,name
-38,380003,radiodifusión
-38,380004,envío de mensajes
-38,380005,teledifusión
-38,380006,transmisión de telegramas
-38,380007,servicios telegráficos
-38,380008,comunicaciones telegráficas
-38,380009,servicios de telefonía
-38,380010,comunicaciones telefónicas
-38,380011,servicios de télex
-38,380012,servicios de agencias de noticias
-38,380021,teledifusión por cable
-38,380022,servicios de comunicación por telefonía móvil
-38,380023,comunicaciones por terminales de ordenador
-38,380023,comunicaciones por terminales de computadora
-38,380024,transmisión de mensajes e imágenes asistida por ordenador
-38,380024,transmisión de mensajes e imágenes asistida por computadora
-38,380025,transmisión de mensajes de correo electrónico
-38,380026,transmisión de faxes
-38,380027,suministro de información sobre telecomunicaciones
-38,380028,servicios de radiomensajería [radio, teléfono u otros medios de comunicación electrónica]
-38,380028,servicios de radiobúsqueda [radio, teléfono u otros medios de comunicación electrónica]
-38,380029,alquiler de aparatos para el envío de mensajes
-38,380030,comunicaciones por redes de fibra óptica
-38,380031,alquiler de aparatos de fax
-38,380032,alquiler de módems
-38,380033,alquiler de aparatos de telecomunicación
-38,380034,alquiler de teléfonos
-38,380035,transmisión por satélite
-38,380036,servicios de tablones de anuncios electrónicos [telecomunicaciones]
-38,380037,servicios de conexión telemática a una red informática mundial
-38,380038,servicios de encaminamiento y enlace para telecomunicaciones
-38,380039,servicios de teleconferencia
-38,380040,suministro de acceso de usuario a redes informáticas mundiales
-38,380041,alquiler de tiempo de acceso a redes informáticas mundiales
-38,380042,provisión de canales de telecomunicación para servicios de televenta
-38,380043,suministro de foros de discusión [chats] en Internet
-38,380044,suministro de acceso a bases de datos
-38,380045,servicios de buzón de voz
-38,380046,transmisión de tarjetas de felicitación en línea
-38,380047,transmisión de archivos digitales
-38,380047,transmisión de archivos informáticos
-38,380048,servicios de difusión inalámbrica
-38,380049,servicios de videoconferencia
-38,380050,suministro de foros en línea
-38,380051,transmisión de flujo continuo de datos [streaming]
-38,380052,radiocomunicación
-38,380052,comunicaciones radiofónicas
-38,380053,transmisión de vídeo a la carta
-38,380054,transmisión de pódcast
-38,380055,alquiler de teléfonos inteligentes
+class|name
+38|Acceso de usuarios a programas informáticos en redes de datos
+38|Acceso multiusuario a redes informáticas globales de información para la transferencia y divulgación de una amplia gama de información
+38|Alquiler de aparatos de fax
+38|Alquiler de aparatos de telecomunicación
+38|Alquiler de aparatos de telecomunicación e instalaciones
+38|Alquiler de aparatos e instrumentos de comunicación
+38|Alquiler de aparatos para la transmisión de imágenes
+38|Alquiler de capacidad de transmisión vía satélite
+38|Alquiler de dispositivos de telecomunicaciones
+38|Alquiler de enrutadores de telecomunicaciones
+38|Alquiler de equipo para difusión
+38|Alquiler de equipo para telecomunicaciones
+38|Alquiler de líneas de telecomunicación e instalaciones
+38|Alquiler de módems
+38|Alquiler de teléfonos
+38|Alquiler de teléfonos celulares
+38|Alquiler de teléfonos inteligentes
+38|Alquiler de tiempo de acceso a redes informáticas mundiales
+38|Arrendamiento de aparatos de radio
+38|Arrendamiento de aparatos e instrumentos teleprocesadores y de comunicaciones computarizadas
+38|Arrendamiento de radios
+38|Comunicación de datos por correo electrónico
+38|Comunicación por fax
+38|Comunicación por ondas hertzianas
+38|Comunicación por red de fibra óptica
+38|Comunicación por telefonía móvil
+38|Comunicación por teléfono móvil
+38|Comunicación por terminales informáticas electrónicas
+38|Comunicación vía redes de fibra óptica
+38|Comunicación vía terminales informáticas análogas y digitales
+38|Comunicaciones por fax
+38|Comunicaciones por medio de teléfonos móviles
+38|Comunicaciones por teléfonos móviles
+38|Comunicaciones por televisión para reuniones
+38|Comunicaciones por terminales de computadora
+38|Comunicaciones telefónicas
+38|Comunicaciones telegráficas
+38|Comunicaciones vía redes de fibra óptica
+38|Comunicaciones vía redes de telecomunicación multinacional
+38|Comunicaciones vía terminales informáticas análogas y digitales
+38|Comunicaciones vía terminales informáticas por transmisión digital o satelital
+38|Comunicaciones vía transmisiones de radio, telégrafo, teléfono y televisión
+38|Correo electrónico
+38|Difusión de audio
+38|Difusión de programación de audio y video a través de la Internet
+38|Difusión de programas de radio
+38|Difusión de programas de radio y televisión
+38|Difusión de programas de televisión
+38|Difusión de programas de televisión contratados por suscripción
+38|Difusión de programas de televisión por cable
+38|Difusión digital de audio
+38|Emisión continua de datos (streaming)
+38|Emisión de programa de televisión vía cable
+38|Emisión de programas a través de Internet
+38|Emisión de programas de telecompra
+38|Emisión en continuo de contenidos de audio, visuales y audiovisuales a través de redes informáticas mundiales
+38|Emisión satelital de televisión
+38|Envío de mensajes a través de un sitio web
+38|Envío de mensajes electrónicos
+38|Envío de telegramas
+38|Envío, recepción y retransmisión de mensajes
+38|Facilitación de acceso a bases de datos
+38|Facilitación de acceso a infraestructura de telecomunicaciones para terceros
+38|Facilitación de acceso a la Internet
+38|Facilitación de acceso a redes de telecomunicación
+38|Facilitación de acceso a sitios electrónicos
+38|Facilitación de acceso a un sitio web de música en la Internet
+38|Facilitación de acceso a una red informática mundial
+38|Facilitación de acceso a una red informática mundial para usuarios
+38|Facilitación de acceso de usuario a Internet (proveedores de servicios)
+38|Facilitación de acceso multiusuario a redes informáticas para la transferencia de información de todas indoles
+38|Facilitación de conexiones de telecomunicación electrónica
+38|Facilitación de líneas de charla utilizando Internet
+38|Facilitación de servicios de correo electrónico
+38|Facilitación de servicios de videoconferencia
+38|Facilitación del acceso a datos o documentos almacenados electrónicamente archivos centrales para consultas remotas
+38|Foros en línea para transmitir mensajes entre usuarios de ordenador
+38|Información sobre telecomunicaciones
+38|Intercambio electrónico de datos
+38|Intercambio electrónico de datos almacenados en bases de datos accesibles vía redes de telecomunicación
+38|Prestación de servicios de fax por correo electrónico
+38|Provisión de foros de discusión (salas de chats) en Internet
+38|Provisión de salas de chat en línea para redes sociales
+38|Provisión de servicios de chat por voz
+38|Radiodifusión
+38|Radiotelefonía móvil
+38|Salas virtuales de charla establecidas vía mensajes de texto
+38|Servicio de emisión continua de contenido multimedia (streaming)
+38|Servicios de acceso a telecomunicación
+38|Servicios de agencia de noticias para transmisión electrónica
+38|Servicios de audioteleconferencias
+38|Servicios de buzón de voz
+38|Servicios de comunicación de banda ancha por radio
+38|Servicios de comunicación de radio, teléfono y telégrafo
+38|Servicios de comunicación, en concreto, transmisión electrónica de datos y documentos entre usuarios de ordenadores
+38|Servicios de conexión telemática a una red informática mundial
+38|Servicios de consultoría en telecomunicaciones
+38|Servicios de correo de voz
+38|Servicios de correo electrónico de datos
+38|Servicios de correo electrónico para datos y voz
+38|Servicios de correo electrónico seguros
+38|Servicios de correo y mensajería electrónica
+38|Servicios de difusión de contenidos web
+38|Servicios de difusión de radio por internet
+38|Servicios de difusión de televisión y radio
+38|Servicios de difusión de vídeo
+38|Servicios de emisión de televisión por cable
+38|Servicios de envío y recepción de mensajes
+38|Servicios de exclusión de llamadas
+38|Servicios de filtrado de llamadas
+38|Servicios de mensajería digital inalámbrica
+38|Servicios de mensajería electrónica instantánea
+38|Servicios de mensajería web
+38|Servicios de pasarela de telecomunicaciones
+38|Servicios de radiodifusión por internet
+38|Servicios de radioemisión (transmisión de información a través de radio)
+38|Servicios de radiotelefonía móvil
+38|Servicios de redes digitales de telecomunicación
+38|Servicios de reenvío de correo electrónico
+38|Servicios de reenvío de llamadas
+38|Servicios de tablones de anuncios electrónicos
+38|Servicios de telecomunicaciones aeronáuticas
+38|Servicios de telecomunicaciones vía satélite
+38|Servicios de teleconferencia
+38|Servicios de teleconferencia y videoconferencia
+38|Servicios de telefonía computacional
+38|Servicios de telefonía fija y móvil
+38|Servicios de telefonía móvil
+38|Servicios de telefonía por Internet
+38|Servicios de telefonía y teletexto
+38|Servicios de teletexto
+38|Servicios de transmisión de datos con alta tasa de transferencia para operarios de redes de telecomunicaciones
+38|Servicios de transmisión de información vía redes digitales
+38|Servicios de transmisión de ordenes electrónicas
+38|Servicios de transmisión de televisión de pago por evento
+38|Servicios de transmisión por satélite
+38|Servicios de transmisión y recepción de datos vía medios de telecomunicación
+38|Servicios de videoconferencia
+38|Servicios de videoteléfono
+38|Servicios en línea, a saber, envío de mensajes
+38|Servicios telefónicos de mensajería de voz
+38|Telecomunicaciones por correo electrónico
+38|Teledifusión por cable
+38|Telefonía móvil
+38|Transferencia de datos por telecomunicación
+38|Transmisión de artículos de noticias a agencias de noticias
+38|Transmisión de datos por teletipo
+38|Transmisión de datos, sonido e imágenes por satélite
+38|Transmisión de faxes
+38|Transmisión de imágenes asistida por ordenador
+38|Transmisión de imágenes y sonido vía satélite
+38|Transmisión de información a través de sistemas de comunicación por video
+38|Transmisión de información de bases de datos vía redes de telecomunicación
+38|Transmisión de información de mercados bursátiles con la ayuda de medios de telecomunicaciones
+38|Transmisión de información e imágenes asistida por computadora
+38|Transmisión de información e imágenes en relación a productos farmacéuticos, medicina e higiene
+38|Transmisión de información en el campo audiovisual
+38|Transmisión de información mediante comunicaciones de datos para facilitar la toma de decisiones
+38|Transmisión de información por códigos telemáticos
+38|Transmisión de información por redes de comunicación electrónica
+38|Transmisión de información por redes ópticas de telecomunicación
+38|Transmisión de información por teletipo
+38|Transmisión de información por teletipo o vía satélite
+38|Transmisión de información vía computadoras conectadas a la misma red telemática
+38|Transmisión de información vía redes de comunicación electrónica
+38|Transmisión de información vía redes nacionales e internacionales
+38|Transmisión de información vía teletipo
+38|Transmisión de mensajes
+38|Transmisión de mensajes asistida por computadora
+38|Transmisión de mensajes cortos
+38|Transmisión de mensajes electrónicos
+38|Transmisión de mensajes por ordenador
+38|Transmisión de mensajes sobre medios electrónicos
+38|Transmisión de noticias
+38|Transmisión de programas de radio y televisión por satélite
+38|Transmisión de radio por cable
+38|Transmisión de señal para comercio electrónico vía sistemas de telecomunicación y sistemas de comunicación de datos
+38|Transmisión de sonido e imagen vía satélite o redes de multimedia interactiva
+38|Transmisión de sonido, imágenes y datos
+38|Transmisión de sonidos, imágenes, señales y datos por satélite, cable o redes
+38|Transmisión de sonidos, video e información
+38|Transmisión de tarjetas de felicitación en línea
+38|Transmisión de telegramas
+38|Transmisión electrónica de correo y mensajes
+38|Transmisión electrónica de datos
+38|Transmisión electrónica de datos y documentos vía terminales informáticas y dispositivos electrónicos
+38|Transmisión electrónica de mensajes
+38|Transmisión electrónica de mensajes y datos
+38|Transmisión electrónica de noticias
+38|Transmisión electrónica de voz, datos e imágenes por difusión de televisión y vídeo
+38|Transmisión informática de información a la que se accede a través de un código o de un terminal
+38|Transmisión por cable
+38|Transmisión por satélite
+38|Transmisión y distribución de datos o imágenes audiovisuales vía una red informática mundial o la Internet
+38|Transmisión y recepción (transmisión) de información de bases de datos vía la red de telecomunicación
+38|Transmisión y recepción por radio
+38|Transmisión, recepción y procesamiento de señales codificadas y señales de emergencia

--- a/lib/seeds/class_39_terms.csv
+++ b/lib/seeds/class_39_terms.csv
@@ -1,131 +1,219 @@
-class,reference_id,name
-39,390002,acompañamiento de viajeros
-39,390003,suministro de agua
-39,390004,transporte aéreo
-39,390004,transportes aeronáuticos
-39,390006,transporte en ambulancia
-39,390007,servicios de remolque de vehículos averiados
-39,390008,alquiler de coches
-39,390008,alquiler de automóviles
-39,390009,transporte en automóvil
-39,390010,servicios de autobuses
-39,390011,servicios de barcos de recreo
-39,390012,alquiler de barcos
-39,390013,servicios de rompehielos
-39,390014,camionaje
-39,390015,salvamento de barcos
-39,390016,servicios de lanchaje
-39,390016,servicios de gabarraje
-39,390017,acarreo
-39,390018,transporte por ferrocarril
-39,390019,alquiler de caballos
-39,390020,distribución de paquetes
-39,390020,reparto de paquetes
-39,390021,servicios de portes
-39,390022,empaquetado de productos
-39,390022,acondicionamiento de productos
-39,390023,corretaje marítimo
-39,390024,organización de cruceros
-39,390025,servicios de transporte para visitas turísticas
-39,390026,descarga de mercancías
-39,390027,reparto de mercancías
-39,390027,distribución [reparto] de productos
-39,390028,almacenamiento de mercancías
-39,390030,distribución de agua
-39,390031,distribución de electricidad
-39,390032,accionamiento de compuertas de esclusas
-39,390033,servicios de aparcamiento
-39,390033,servicios de estacionamiento
-39,390034,almacenamiento
-39,390034,servicios de depósito
-39,390035,alquiler de almacenes [depósitos]
-39,390036,transporte en transbordador [ferri]
-39,390037,transporte fluvial
-39,390038,flete [transporte de mercancías]
-39,390039,fletamento
-39,390040,alquiler de garajes
-39,390041,transporte por oleoductos
-39,390041,transporte por gasoductos
-39,390042,alquiler de plazas de aparcamiento
-39,390042,alquiler de plazas de estacionamiento
-39,390042,alquiler de plazas de parqueo
-39,390043,alquiler de refrigeradores
-39,390043,alquiler de frigoríficos
-39,390044,alquiler de vehículos
-39,390045,alquiler de coches de ferrocarril
-39,390046,alquiler de vagones de carga
-39,390047,transporte de muebles
-39,390048,transporte
-39,390049,transporte en barco
-39,390050,organización de transporte para circuitos turísticos
-39,390051,transporte de pasajeros
-39,390052,servicios de pilotaje
-39,390054,servicios de remolque
-39,390055,reflotamiento de barcos
-39,390056,reservas de plazas de viaje
-39,390057,servicios de salvamento
-39,390058,transporte en taxi
-39,390059,servicios de tranvías
-39,390059,transporte en tranvía
-39,390060,servicios de expedición de fletes
-39,390061,transporte marítimo
-39,390062,transporte en vehículos blindados
-39,390063,transporte de viajeros
-39,390064,transporte y almacenamiento de residuos y desechos
-39,390065,mudanzas
-39,390065,mudanzas de muebles
-39,390071,servicios de depósito de barcos
-39,390072,corretaje de fletes
-39,390073,corretaje de transporte
-39,390074,servicios de chóferes
-39,390074,servicios de choferes
-39,390075,servicios de mensajería [correo o mercancías]
-39,390076,suministro de información sobre almacenamiento
-39,390077,suministro de información sobre transporte
-39,390078,alquiler de campanas de buzo
-39,390079,alquiler de escafandras
-39,390079,alquiler de trajes de buceo
-39,390080,alquiler de contenedores de almacenamiento
-39,390081,alquiler de portaequipajes [bacas] para vehículos
-39,390082,operaciones de salvamento [transporte]
-39,390083,reservas de transporte
-39,390084,reservas de viajes
-39,390085,salvamento submarino
-39,390086,empaquetado de mercancías
-39,390087,distribución de mensajes
-39,390087,reparto de correo
-39,390088,reparto de periódicos
-39,390089,reparto de mercancías encargadas por correspondencia
-39,390090,distribución de energía
-39,390091,alquiler de coches de carreras
-39,390092,alquiler de sillas de ruedas
-39,390093,estiba
-39,390094,almacenamiento físico de datos o documentos archivados electrónicamente
-39,390095,lanzamiento de satélites para terceros
-39,390096,entrega de flores
-39,390096,reparto de flores
-39,390097,franqueo postal
-39,390098,suministro de información sobre tráfico
-39,390099,alquiler de congeladores
-39,390100,servicios de embotellado
-39,390101,servicios logísticos de transporte
-39,390102,alquiler de aeronaves
-39,390103,transporte en chalana
-39,390104,alquiler de autocares
-39,390105,alquiler de motores para aeronaves
-39,390106,transporte protegido de objetos de valor
-39,390107,alquiler de sistemas de navegación
-39,390108,suministro de información sobre itinerarios de viaje
-39,390109,servicios de envoltura de regalos
-39,390110,alquiler de tractores
-39,390111,recogida de productos reciclables [transporte]
-39,390112,alquiler de armarios refrigeradores eléctricos para vino
-39,390113,abastecimiento de efectivo de cajeros automáticos
-39,390114,servicios de uso temporal de vehículos
-39,390115,abastecimiento de distribuidores automáticos
-39,390115,abastecimiento de máquinas expendedoras
-39,390116,servicios de consigna de equipaje
-39,390117,organización de servicios de transporte de pasajeros para terceros mediante una aplicación en línea
-39,390118,servicios de pilotaje de drones civiles
-39,390119,preparación de visados y documentos de viaje para personas que viajan al extranjero
-39,390120,servicios de vehículo compartido
+class|name
+39|Abastecimiento (distribución) de calefacción
+39|Acompañamiento de viajeros
+39|Almacenaje de materiales peligrosos
+39|Almacenaje de productos
+39|Almacenamiento de alimentos agrícolas
+39|Almacenamiento de combustibles de aviación
+39|Almacenamiento de desechos radiactivos
+39|Almacenamiento de equipaje
+39|Almacenamiento de mercancías
+39|Almacenamiento de ropa
+39|Almacenamiento de soportes físicos de datos o documentos electrónicos
+39|Almacenamiento temporal de entregas
+39|Almacenamiento y reparto de productos
+39|Alquilado de embarcaciones
+39|Alquiler de aeronaves
+39|Alquiler de almacenes (depósitos)
+39|Alquiler de aparatos y máquinas de congelación
+39|Alquiler de autobuses
+39|Alquiler de autocaravanas
+39|Alquiler de automóviles
+39|Alquiler de aviones
+39|Alquiler de barcos
+39|Alquiler de bicicleta
+39|Alquiler de bicicletas
+39|Alquiler de camiones
+39|Alquiler de camiones y remolques
+39|Alquiler de canoas
+39|Alquiler de carriolas
+39|Alquiler de coches de carreras
+39|Alquiler de coches de hidrógeno
+39|Alquiler de congeladores para uso comercial
+39|Alquiler de congeladores para uso doméstico
+39|Alquiler de contenedores de almacenamiento
+39|Alquiler de contenedores para transportes
+39|Alquiler de equipos de GPS para navegación
+39|Alquiler de espacio en almacén
+39|Alquiler de garajes
+39|Alquiler de máquinas y aparatos de carga y descarga
+39|Alquiler de motocicletas
+39|Alquiler de palés
+39|Alquiler de plataformas de elevación autopropulsadas para el transporte
+39|Alquiler de plazas de estacionamiento
+39|Alquiler de refrigeradores
+39|Alquiler de refrigeradores y congeladores para uso doméstico
+39|Alquiler de sillas de ruedas
+39|Alquiler de sistemas mecánicos de estacionamiento
+39|Alquiler de vehículos
+39|Alquiler de vehículos de tracción y remolques
+39|Alquiler de vehículos eléctricos
+39|Alquiler de vehículos recreativos
+39|Alquiler de vehículos y aparatos de locomociónaérea
+39|Alquiler o arrendamiento de ambulancias (transporte)
+39|Aparcamiento de aeronaves
+39|Arrendamiento de coches ferroviarios
+39|Arrendamiento de máquinas empacadoras
+39|Arrendamiento de motos para transporte
+39|Arriendo de container de almacenamiento
+39|Coordinación de preparativos de viaje para individuos o para grupos
+39|Corretaje de barcos
+39|Corretaje de transportación de carga
+39|Corretaje de transporte
+39|Corretaje de transporte de carga
+39|Corretaje de transporte de carga y transporte
+39|Custodia temporal de pertenencias personales
+39|Descarga de mercancías
+39|Distribución de agua
+39|Distribución de electricidad
+39|Distribución de energía
+39|Distribución de energía renovable
+39|Distribución de paquetes
+39|Distribución y suministro de agua
+39|Distribución y transmisión de electricidad
+39|Embalaje de mercancías
+39|Embalaje y depósito de mercancías
+39|Entrega de agua embotellada a hogares y oficinas
+39|Entrega de flores
+39|Envío de mercancías
+39|Facilitación de información de viajes
+39|Facilitación de información sobre carreteras y tráfico
+39|Facilitación de información sobre depósito de mercancía en almacenes
+39|Facilitación de instalaciones de atracaderos para navíos
+39|Fletamento de autobuses
+39|Gestión de flujo del tráfico de vehículos mediante redes y tecnologías de comunicación avanzadas
+39|Información de viajes
+39|Información sobre tráfico
+39|Información sobre transporte
+39|Manipulación de carga
+39|Operación de transbordador
+39|Organización de cruceros
+39|Organización de excursiones
+39|Organización de viajes
+39|Organización de viajes y cruceros
+39|Organización de viajes, excursiones y cruceros
+39|Planificación de rutas de viaje
+39|Preparación de visados de viajes, pasaportes y documentos de viaje para personas que viajan al extranjero
+39|Préstamo y alquiler de aviones
+39|Provisión de estacionamiento de vehículos
+39|Recogida y reparto de cartas
+39|Reflotamiento de barcos
+39|Remolcado de aviones
+39|Remolque de automóviles para emergencias
+39|Remolque marítimo
+39|Reparto de mensajes (mensajero)
+39|Reparto de mercancías
+39|Reparto de mercancías encargadas por correspondencia
+39|Reparto de periódicos
+39|Reparto de pizzas
+39|Reparto y almacenamiento de productos
+39|Reserva de billetes de viaje
+39|Reserva para alquiler de automóviles
+39|Reservas de plazas de viaje
+39|Reservas de transporte
+39|Salvamento de barcos
+39|Salvamento de buques en peligro
+39|Servicio de alquiler de coches con conductor
+39|Servicio de rompehielos para la industria marítima
+39|Servicios chárter de yate y barco
+39|Servicios de aeropuerto que consisten en la provisión de salas de espera para el uso de pasajeros en tránsito
+39|Servicios de agencia de viajes, en concreto reservas y contratación de transporte
+39|Servicios de agencia para la organización del transporte de personas
+39|Servicios de almacenaje
+39|Servicios de alquilado de vehículos
+39|Servicios de aparcamiento
+39|Servicios de asesoramiento y consultoría relacionados con el transporte
+39|Servicios de autobuses
+39|Servicios de bicicletas compartidas
+39|Servicios de carga aérea
+39|Servicios de carga de mercancias
+39|Servicios de chóferes
+39|Servicios de co-envío (co-mailing) para fines de transporte, a saber, agrupación y la entrega de correo a la oficina de correos
+39|Servicios de co-paletización (logística de envío y almacenamiento) de productos
+39|Servicios de control del tráfico aéreo
+39|Servicios de depósito de barcos
+39|Servicios de depósito y recepción de equipaje provistos por aerolíneas
+39|Servicios de distribución de gas
+39|Servicios de embalaje de carga
+39|Servicios de envasado de mercancías
+39|Servicios de estacionamiento
+39|Servicios de facturación para aerolíneas
+39|Servicios de fletado de yates
+39|Servicios de flete de mercancías
+39|Servicios de flete y transporte de mercancías
+39|Servicios de lanzadera de pasajeros entre estacionamientos de aeropuerto y las terminales
+39|Servicios de manipulación de cargas de importación y exportación
+39|Servicios de mensajería
+39|Servicios de navegación aérea
+39|Servicios de navegación por sistema de posicionamiento global
+39|Servicios de pilotaje
+39|Servicios de planificación de vuelos
+39|Servicios de portes
+39|Servicios de puerto deportivo (atraque, amarre, almacenamiento)
+39|Servicios de reserva de billetes aéreos
+39|Servicios de reserva de billetes para viajes en tren
+39|Servicios de transportación y reparto por aire, carretera, ferrocarril y mar
+39|Servicios de transporte aéreo
+39|Servicios de transporte masivo para el público en general
+39|Servicios de vuelos chárter
+39|Servicios para organizar el transporte de viajeros
+39|Servicios postales, de carga y mensajería
+39|Suministro de agua
+39|Suministro de agua (distribución)
+39|Suministro de gas (distribución)
+39|Suministro de información sobre viajes a través de internet
+39|Suministro de instalaciones de atraque
+39|Suministro de instalaciones de autoalmacenamiento para terceros
+39|Suministro y distribución de agua
+39|Transportación aérea
+39|Transportación aérea de pasajeros y carga
+39|Transportación custodiada de valores
+39|Transportación de pasajeros y equipaje de pasajeros
+39|Transportación de pasajeros y productos por ferrocarril
+39|Transportación de productos
+39|Transportación en vehículos impulsados por el hombre
+39|Transporte de animales de compañía
+39|Transporte de camiones
+39|Transporte de carga por tren
+39|Transporte de cargamento
+39|Transporte de dinero y valores
+39|Transporte de mercancías por vía aérea
+39|Transporte de pasajeros
+39|Transporte de pasajeros en barcos de crucero
+39|Transporte de pasajeros en tren
+39|Transporte de pasajeros por barco
+39|Transporte de personas
+39|Transporte de personas y productos
+39|Transporte de productos
+39|Transporte de valores
+39|Transporte de viajeros
+39|Transporte en ambulancia
+39|Transporte en automóvil
+39|Transporte en avión propulsado por hélice
+39|Transporte en aviones de turborreactor
+39|Transporte en barco
+39|Transporte en camiones
+39|Transporte en cargueros
+39|Transporte en coche alquilado
+39|Transporte en helicóptero
+39|Transporte en monorriel
+39|Transporte en taxi
+39|Transporte en taxi para personas en sillas de ruedas
+39|Transporte en transbordador
+39|Transporte en vehículos automóviles de dos ruedas
+39|Transporte en vehículos blindados
+39|Transporte ferroviario
+39|Transporte marítimo
+39|Transporte naval
+39|Transporte por aéreo
+39|Transporte por ferrocarril
+39|Transporte por oleoductos
+39|Transporte por teleférico
+39|Transporte protegido de valores
+39|Transporte terrestre
+39|Transporte y almacenamiento de productos
+39|Transporte y almacenamiento de productos en condiciones refrigeradas
+39|Transporte y reparto de productos
+39|Transportes aéreos y almacenamiento de mercancías
+39|Transportes en cisterna
+39|Transportes marítimo

--- a/lib/seeds/class_3_terms.csv
+++ b/lib/seeds/class_3_terms.csv
@@ -1,294 +1,657 @@
-class,reference_id,name
-3,030001,adhesivos para postizos capilares
-3,030002,piedras para suavizar
-3,030003,productos para afilar
-3,030003,productos para amolar
-3,030005,piedras para el afeitado [astringentes]
-3,030005,piedras astringentes para después del afeitado
-3,030006,aceite de almendras
-3,030007,jabón de almendras
-3,030008,ámbar [productos de perfumería]
-3,030009,almidón para dar brillo
-3,030009,almidón de lavandería para dar brillo
-3,030010,almidón [apresto]
-3,030010,almidón de apresto [lavandería]
-3,030010,engrudo [almidón]
-3,030011,rojo para pulir
-3,030011,rojo de joyero
-3,030012,jabones*
-3,030013,jabones para avivar los colores de materias textiles
-3,030014,añil de lavandería
-3,030014,añil para azulear la ropa
-3,030014,azulete
-3,030015,esencia de badiana
-3,030016,preparaciones cosméticas para el baño
-3,030017,jabón de afeitar
-3,030018,lápices de labios [pintalabios]
-3,030018,pintalabios
-3,030019,bastoncillos de algodón para uso cosmético
-3,030019,hisopos para uso cosmético
-3,030020,mascarillas de belleza
-3,030021,esencia de bergamota
-3,030022,blanco de España
-3,030022,blanco de tiza
-3,030023,crema para aclarar la piel
-3,030025,productos blanqueadores para el cuero
-3,030026,sales blanqueadoras
-3,030027,soda para blanquear
-3,030027,sosa para blanquear
-3,030028,productos blanqueadores [lavandería]
-3,030028,productos blanqueadores para lavar la ropa
-3,030029,productos de glaseado para lavar la ropa
-3,030030,maderas aromáticas
-3,030031,enjuagues bucales que no sean para uso médico
-3,030032,esmaltes de uñas
-3,030032,lacas de uñas
-3,030033,productos de maquillaje
-3,030034,lociones capilares*
-3,030035,carburos metálicos [abrasivos]
-3,030036,carburo de silicio [abrasivo]
-3,030037,aceites esenciales de cedro
-3,030038,cenizas volcánicas para limpiar
-3,030039,cremas para el calzado
-3,030040,colorantes para el cabello
-3,030040,tintes para el cabello
-3,030041,preparaciones para ondular el cabello
-3,030042,pestañas postizas
-3,030043,cosméticos para pestañas
-3,030045,preparaciones para pulir
-3,030046,cera para el calzado
-3,030047,encáusticos
-3,030047,productos para pulir muebles y pisos
-3,030047,productos para pulir muebles y suelos
-3,030048,productos para dar brillo
-3,030049,cera de zapatero
-3,030050,pez de zapatero
-3,030052,cera para el bigote
-3,030053,cera para parqué
-3,030054,cera para pulir
-3,030055,cera de sastre
-3,030056,aceites esenciales de limón
-3,030058,agua de Colonia
-3,030060,colorantes de tocador
-3,030060,tintes de tocador
-3,030061,conservantes para el cuero [betunes]
-3,030062,corindón [abrasivo]
-3,030063,cosméticos para animales
-3,030064,neceseres de cosmética
-3,030065,cosméticos
-3,030066,algodón para uso cosmético
-3,030066,guata para uso cosmético
-3,030067,tiza para limpiar
-3,030068,quitamanchas
-3,030069,lápices para uso cosmético
-3,030070,cremas para pulir
-3,030071,cremas cosméticas
-3,030072,soda [cenizas] para limpiar
-3,030072,sosa [cenizas] para limpiar
-3,030073,pastas para suavizadores de navajas de afeitar
-3,030074,cremas para el cuero
-3,030074,ceras para el cuero
-3,030075,detergentes que no sean para procesos de fabricación ni para uso médico
-3,030076,soluciones decapantes
-3,030077,productos desengrasantes que no sean para procesos de fabricación
-3,030078,desmaquilladores
-3,030079,dentífricos*
-3,030081,desincrustantes para uso doméstico
-3,030082,diamantina [abrasivo]
-3,030083,productos antiestáticos para uso doméstico
-3,030084,papel de esmeril
-3,030085,productos para quitar lacas
-3,030086,tela de esmeril
-3,030087,productos para quitar tintes
-3,030088,productos para quitar barnices
-3,030089,lejía
-3,030090,agua de lavanda
-3,030091,aguas perfumadas
-3,030092,aguas de tocador
-3,030093,corteza de quillay para lavar
-3,030094,esmeril
-3,030095,incienso*
-3,030096,productos depilatorios
-3,030096,depilatorios
-3,030097,cera depilatoria
-3,030098,productos para remojar la ropa
-3,030099,esencias etéreas
-3,030100,aceites esenciales
-3,030100,aceites etéreos
-3,030101,extractos de flores [productos de perfumería]
-3,030102,maquillaje
-3,030104,productos de limpieza
-3,030105,bases para perfumes de flores
-3,030106,productos de fumigación [perfumes]
-3,030107,aromatizantes de pastelería [aceites esenciales]
-3,030107,saborizantes de pastelería [aceites esenciales]
-3,030108,aceite de gaulteria
-3,030109,jalea de petróleo para uso cosmético
-3,030110,geraniol
-3,030111,grasas para uso cosmético
-3,030112,peróxido de hidrógeno para uso cosmético
-3,030113,heliotropina
-3,030114,aceites para uso cosmético
-3,030115,aceite de jazmín
-3,030116,aceite de lavanda
-3,030117,aceites de limpieza
-3,030118,aceites de perfumería
-3,030118,aceites para perfumes y fragancias
-3,030119,aceite de rosas
-3,030120,aceites de tocador
-3,030121,iononas [productos de perfumería]
-3,030122,lociones para uso cosmético
-3,030123,leches limpiadoras de tocador
-3,030124,preparaciones de lavandería
-3,030125,preparaciones de tocador*
-3,030126,líquidos limpiaparabrisas
-3,030127,productos para alisar [lavandería]
-3,030128,esencia de menta [aceite esencial]
-3,030129,menta para perfumería
-3,030131,cosméticos para las cejas
-3,030132,almizcle [producto de perfumería]
-3,030133,productos neutralizantes para permanentes
-3,030134,champús*
-3,030135,perfumes
-3,030136,uñas postizas
-3,030137,productos para el cuidado de las uñas
-3,030138,productos para limpiar papel pintado
-3,030138,productos para limpiar papel tapiz
-3,030139,papel para pulir
-3,030140,papel de lija
-3,030140,papel de vidrio [lija]
-3,030141,productos de perfumería
-3,030142,productos cosméticos para el cuidado de la piel
-3,030143,jabones antitranspirantes para los pies
-3,030144,piedras para pulir
-3,030145,piedra pómez
-3,030146,pomadas para uso cosmético
-3,030147,polvos de maquillaje
-3,030148,productos de afeitar
-3,030149,jabones desodorantes
-3,030150,productos para perfumar la ropa
-3,030150,bolsitas para perfumar la ropa
-3,030151,safrol
-3,030152,pastillas de jabón
-3,030153,lejía de soda
-3,030153,lejía de sosa
-3,030154,lápices de cejas
-3,030155,talco de tocador
-3,030156,tintes cosméticos
-3,030157,trementina para desengrasar
-3,030158,esencia de trementina para desengrasar
-3,030158,aceite de trementina para desengrasar
-3,030159,terpenos [aceites esenciales]
-3,030160,tela abrasiva
-3,030161,tela de vidrio [tela abrasiva]
-3,030162,productos antitranspirantes [artículos de tocador]
-3,030163,jabones antitranspirantes
-3,030164,trípoli para pulir
-3,030165,abrasivos*
-3,030166,papeles abrasivos
-3,030167,amoniaco [álcali volátil] [detergente]
-3,030167,álcali volátil [amoniaco] [detergente]
-3,030167,amoníaco [álcali volátil] [detergente]
-3,030168,piedras de alumbre [astringentes]
-3,030169,leche de almendras para uso cosmético
-3,030170,productos desoxidantes
-3,030171,preparaciones cosméticas para el bronceado de la piel
-3,030172,aromas [aceites esenciales]
-3,030173,aromatizantes para bebidas [aceites esenciales]
-3,030173,saborizantes para bebidas [aceites esenciales]
-3,030174,productos químicos de uso doméstico para avivar los colores [lavandería]
-3,030175,sales de baño que no sean para uso médico
-3,030176,tintes para la barba
-3,030177,preparaciones cosméticas adelgazantes
-3,030178,adhesivos para pestañas postizas
-3,030179,productos para quitar pinturas
-3,030180,desodorantes para personas o animales [productos de perfumería]
-3,030181,motivos decorativos para uso cosmético
-3,030181,calcomanías decorativas para uso cosmético
-3,030191,astringentes para uso cosmético
-3,030192,decolorantes para uso cosmético
-3,030193,suavizantes para la ropa
-3,030194,preparaciones para limpiar prótesis dentales
-3,030194,preparaciones para limpiar dentaduras postizas
-3,030195,preparaciones para desatascar desagües
-3,030196,champús para animales de compañía [preparaciones higiénicas no medicinales]
-3,030197,toallitas impregnadas de lociones cosméticas
-3,030198,preparaciones para pulir prótesis dentales
-3,030198,preparaciones para pulir dentaduras postizas
-3,030199,adhesivos [pegamentos] para uso cosmético
-3,030200,lociones para después del afeitado
-3,030201,lacas para el cabello
-3,030202,máscara de pestañas
-3,030203,popurrís aromáticos
-3,030204,productos en aerosol para refrescar el aliento
-3,030205,productos de limpieza en seco
-3,030206,decapantes para cera de parqué
-3,030207,cera antideslizante para suelos
-3,030207,cera antideslizante para pisos
-3,030208,líquidos antideslizantes para suelos
-3,030208,líquidos antideslizantes para pisos
-3,030209,aire comprimido enlatado para limpiar y quitar el polvo
-3,030210,geles blanqueadores para uso dental
-3,030211,paños de limpieza impregnados con detergente
-3,030212,preparaciones para dar brillo a las hojas de las plantas
-3,030213,varillas de incienso
-3,030214,agentes de secado para lavaplatos
-3,030214,agentes de secado para lavavajillas
-3,030215,productos para perfumar el ambiente
-3,030216,tiras para refrescar el aliento
-3,030217,desodorantes para animales de compañía
-3,030218,preparaciones de higiene íntima para uso sanitario o utilizadas como desodorantes
-3,030219,preparaciones de aloe vera para uso cosmético
-3,030220,geles de masaje que no sean para uso médico
-3,030221,brillos de labios
-3,030222,bálsamos que no sean para uso médico
-3,030223,champús en seco*
-3,030224,pegatinas decorativas para uñas
-3,030224,calcomanías decorativas para uñas
-3,030225,preparaciones con filtro solar
-3,030226,aceites esenciales de cidra
-3,030227,henna [tinte cosmético]
-3,030227,alheña [tinte cosmético]
-3,030228,betún para el calzado
-3,030229,estuches para pintalabios
-3,030229,estuches para lápices de labios
-3,030230,preparaciones para el baño que no sean para uso médico
-3,030231,acondicionadores para el cabello
-3,030232,preparaciones para alisar el cabello
-3,030233,toallitas impregnadas de preparaciones desmaquillantes
-3,030234,preparaciones de colágeno para uso cosmético
-3,030235,tiras blanqueadoras dentales
-3,030236,aromatizantes alimentarios [aceites esenciales]
-3,030236,saborizantes alimentarios [aceites esenciales]
-3,030237,preparaciones fito-cosméticas
-3,030238,preparaciones limpiadoras no medicinales para la higiene íntima
-3,030239,extractos de plantas para uso cosmético
-3,030240,quitaesmaltes
-3,030241,ceras para suelos
-3,030241,ceras para pisos
-3,030242,champús para animales [preparaciones higiénicas no medicinales]
-3,030243,preparaciones para baños oculares que no sean para uso médico
-3,030244,duchas vaginales para la higiene íntima o en cuanto desodorantes
-3,030245,preparaciones químicas de limpieza para uso doméstico
-3,030246,difusores de perfumes de ambiente con varillas
-3,030247,preparaciones blanqueadoras [decolorantes] para uso doméstico
-3,030248,velas de masaje para uso cosmético
-3,030249,productos cosméticos para niños
-3,030250,preparaciones de higiene personal para refrescar el aliento
-3,030251,toallitas para bebés impregnadas de preparaciones de limpieza
-3,030252,basma [tinte para uso cosmético]
-3,030253,parches de gel para los ojos de uso cosmético
-3,030254,purpurina para las uñas
-3,030254,brillantina para las uñas
-3,030254,escarcha para las uñas
-3,030255,agua micelar
-3,030256,pintura corporal para uso cosmético
-3,030257,pintura corporal de látex líquido para uso cosmético
-3,030258,pastas de dientes*
-3,030259,algodón impregnado de preparaciones desmaquillantes
-3,030260,toallitas atrapacolor para la ropa
-3,030261,toallitas antiestáticas para secadoras de ropa
-3,030262,purpurina corporal
-3,030262,brillantina corporal
-3,030262,escarcha corporal
-3,030263,cintas adhesivas de doble párpado
+class|name
+3|Ablandadores de cutículas (preparaciones)
+3|Aceite de amla con fines cosméticos
+3|Aceite de baño
+3|Aceite de bergamota
+3|Aceite de coco para uso cosmético
+3|Aceite de lavanda
+3|Aceite de malagueta de uso cosmético
+3|Aceite de menta (artículos de perfumería)
+3|Aceite de ricino para uso cosmético
+3|Aceite de rosa para uso cosmético
+3|Aceite fijador japonés para el cabello (bintsuke-abura)
+3|Aceite para masaje
+3|Aceites aromáticos
+3|Aceites aromáticos para el baño
+3|Aceites aromáticos usados para producir aromas al calentarse
+3|Aceites bronceadores
+3|Aceites bronceadores (cosméticos)
+3|Aceites bronceadores para uso cosmético
+3|Aceites cosméticos
+3|Aceites cosméticos para la epidermis
+3|Aceites de baño
+3|Aceites de baño para el cuidado del cabello
+3|Aceites de baño para uso cosmético
+3|Aceites de baño y sales de baño
+3|Aceites de bebé
+3|Aceites de limpieza
+3|Aceites de perfumería
+3|Aceites de tocador
+3|Aceites esenciales
+3|Aceites esenciales aromáticos
+3|Aceites esenciales como perfume para uso en lavandería
+3|Aceites esenciales de cidra
+3|Aceites esenciales naturales
+3|Aceites esenciales para aromaterapia
+3|Aceites esenciales para la fabricación de productos perfumados
+3|Aceites esenciales para uso doméstico
+3|Aceites esenciales para uso personal
+3|Aceites etéreos
+3|Aceites faciales
+3|Aceites para cutículas de uso cosmético
+3|Aceites para después del sol (cosméticos)
+3|Aceites para el acondicionamiento del cabello
+3|Aceites para el cabello
+3|Aceites para el cuerpo
+3|Aceites para el sol de uso cosmético
+3|Aceites para masaje
+3|Aceites para uso cosmético
+3|Aceites perfumados para la fabricación de preparaciones cosméticas
+3|Aceites y lociones bronceadoras
+3|Aclaradores del cabello
+3|Acondicionador para el cabello
+3|Acondicionadores labiales
+3|Acondicionadores para el cabello
+3|Acondicionadores para el cabello de bebés
+3|Acondicionadores para la cutícula
+3|Acondicionadores para la piel
+3|Adhesivos para fijar uñas postizas
+3|Adhesivos para pestañas postizas
+3|Adhesivos para pestañas postizas, cabello y uñas
+3|Adhesivos para postizos capilares
+3|Adhesivos para uso cosmético
+3|Aditivos de lavandería para ablandar el agua
+3|Agentes de enjuague para lavavajillas
+3|Agentes desparafinadores para limpieza
+3|Agentes y preparaciones de limpieza
+3|Agua de Colonia
+3|Agua de colonia que contiene aceite de serpiente
+3|Agua de lavanda
+3|Agua de perfume
+3|Agua de tocador
+3|Agua de tocador y agua de Colonia
+3|Aguas de Colonia
+3|Aguas de tocador
+3|Aire en lata a presión para finalidades de limpieza
+3|Algodón hidrófilo cosmético
+3|Algodón hidrófilo y bastoncillos de algodón para uso cosmético
+3|Algodón para uso cosmético
+3|Almidón de apresto (lavandería)
+3|Almohadillas de algodón impregnadas de preparados para desmaquillar
+3|Almohadillas de limpieza impregnadas con cosméticos
+3|Almohadillas de limpieza impregnadas con productos de tocador
+3|Ámbar gris
+3|Amoníaco para limpieza
+3|Añil de lavandería
+3|Añil para azulear la ropa
+3|Antitranspirantes
+3|Antitranspirantes para uso personal
+3|Antitranspirantes y desodorantes para uso personal
+3|Aromatizadores de la piel (cosméticos)
+3|Artículos de perfumería
+3|Astringentes para uso cosmético
+3|Bálsamo para después del afeitado
+3|Bálsamo para el cabello
+3|Bálsamo para labios
+3|Bálsamos labiales (no medicinales)
+3|Baños de burbujas
+3|Barnices de uñas
+3|Barnices de uñas para uso cosmético
+3|Barros cosméticos para el cuerpo
+3|Base de maquillaje
+3|Base líquida (mizu-oshiroi)
+3|Bastoncillos de algodón impregnados con preparaciones desmaquillantes
+3|Bastoncillos de algodón para uso cosmético
+3|Betunes para zapatos y botas
+3|Betunes y cremas para calzado
+3|Blanqueador para el cabello
+3|Blanqueadores para el cabello
+3|Bloqueadores solares a prueba de agua
+3|Bloques de alumbre para el afeitado
+3|Bolas de algodón para uso cosmético
+3|Bolas de lavado con detergente
+3|Bolsitas con fragancias
+3|Bolsitas para perfumar (sachets)
+3|Brillantina para uso cosmético
+3|Brillo para labios
+3|Brillos de labios
+3|Brillos de uñas
+3|Calcomanías para uñas
+3|Ceniza volcánica
+3|Cera antideslizante para suelos
+3|Cera de lavandería
+3|Cera de sastre
+3|Cera de zapatero
+3|Cera depilatoria
+3|Cera para calzado
+3|Cera para el bigote
+3|Cera para el cabello
+3|Cera para parqué
+3|Cera para pulir
+3|Ceras de masaje
+3|Ceras para el automóvil
+3|Champú de bebé
+3|Champú para alfombras
+3|Champús
+3|Champús en seco
+3|Champús para animales de compañía
+3|Champús para bebés
+3|Champús para el cabello
+3|Champús y acondicionadores para el cabello
+3|Cinta de doble faz para párpados
+3|Cintas para el blanqueado de dientes impregnadas con preparaciones para blanquear los dientes (cosméticos)
+3|Colonia
+3|Colonia para después del afeitado
+3|Colonias, perfumes y cosméticos
+3|Colorantes para el cabello
+3|Colorantes y tintes para el cabello
+3|Colores para las cejas
+3|Colorete
+3|Coloretes cosméticos
+3|Composiciones decapantes de pintura
+3|Composiciones decapantes de pintura, laca y barniz
+3|Compuestos pulidores de pisos
+3|Corrector facial
+3|Cosméticos
+3|Cosméticos para animales
+3|Cosméticos para las cejas
+3|Cosméticos para uñas
+3|Cosméticos que no sean medicinales
+3|Cosméticos y maquillaje
+3|Cosméticos y preparaciones cosméticas
+3|Crema de afeitar
+3|Crema de ducha
+3|Crema de manos
+3|Crema de noche
+3|Crema de retinol para uso cosmético
+3|Crema facial
+3|Crema hidratante para después del afeitado
+3|Crema no medicada para las ronchas del pañal
+3|Crema para aclarar la piel
+3|Crema para contorno de ojos
+3|Crema para la cutícula
+3|Crema para la piel
+3|Crema para manos
+3|Crema para zapatos y botas
+3|Cremas acondicionadoras de la piel para uso cosmético
+3|Cremas antiarrugas
+3|Cremas antienvejecimiento
+3|Cremas bronceadoras
+3|Cremas bronceadoras (cremas autobronceadoras)
+3|Cremas conservantes para el cuero
+3|Cremas cosméticas
+3|Cremas cosméticas para el cuidado de la piel
+3|Cremas de afeitar
+3|Cremas de belleza
+3|Cremas de belleza para el cuidado del cuerpo
+3|Cremas de belleza para la cara y el cuerpo
+3|Cremas de mano cosméticas
+3|Cremas de masaje cosméticas
+3|Cremas depilatorias
+3|Cremas exfoliantes
+3|Cremas limpiadoras (cosméticos)
+3|Cremas líquidas y sólidas para la piel
+3|Cremas nutritivas cosméticas
+3|Cremas para antes del afeitado
+3|Cremas para calzado
+3|Cremas para cutis claro
+3|Cremas para después del afeitado
+3|Cremas para después del sol
+3|Cremas para el cabello
+3|Cremas para el cuero
+3|Cremas para el cuerpo
+3|Cremas para el cuidado del cabello
+3|Cremas para la cara para uso cosmético
+3|Cremas para la cara y el cuerpo
+3|Cremas para la piel
+3|Cremas para la piel que no sean medicinales
+3|Cremas para los labios
+3|Cremas para peinar el cabello
+3|Cremas para protección solar
+3|Cremas para reducir la celulitis
+3|Cremas perfumadas
+3|Cremas reductoras de manchas de la piel
+3|Cremas reductoras de manchas de uso cosmético
+3|Cremas y betunes para zapatos
+3|Decapantes de pintura
+3|Decolorantes para el cabello
+3|Delineador
+3|Delineador de labios
+3|Delineador de ojos
+3|Delineadores de ojos
+3|Dentífricos en forma de goma de mascar
+3|Dentífricos en forma de pastillas sólidas
+3|Dentífricos ingeribles
+3|Dentífricos no medicinales
+3|Dentífricos y enjuagues bucales
+3|Depilatorios
+3|Desincrustantes para uso doméstico
+3|Desmaquilladores
+3|Desodorantes corporales (artículos de perfumería)
+3|Desodorantes para cuidado personal
+3|Desodorantes para uso personal
+3|Desodorantes para uso personal (artículos de perfumería)
+3|Desodorantes y antitranspirantes para uso personal
+3|Detergentes para lavandería
+3|Detergentes para lavar los platos
+3|Detergentes para lavavajillas
+3|Detergentes para tazas de inodoro
+3|Detergentes para uso doméstico
+3|Detergentes para vehículos
+3|Detergentes preparados de petróleo
+3|Detergentes sintéticos para ropa
+3|Disimuladores de ojeras
+3|Emolientes cutáneos
+3|Emolientes para el cabello
+3|Emulsiones para después del afeitado
+3|Endurecedores de uñas
+3|Enjuague bucal
+3|Enjuagues bucales
+3|Enjuagues bucales que no sean medicinales
+3|Enjuagues para el cabello
+3|Enjuagues para el cabello (acondicionadores para el cabello)
+3|Esencias etéreas
+3|Esmaltes de uñas
+3|Espuma de afeitar
+3|Espuma de baño
+3|Espuma de baño para bebés
+3|Espuma de ducha y baño
+3|Exfoliante corporal
+3|Exfoliantes para la cara
+3|Fijadores de cabello
+3|Fluidos para lavar parabrisas
+3|Fragancias
+3|Fragancias en formato de recarga para dispensadores de aroma no eléctricos
+3|Fragancias para automóviles
+3|Fragancias y artículos de perfumería
+3|Gel de afeitar
+3|Gel de aloe vera para uso cosmético
+3|Gel de ducha
+3|Gel de ducha y baño
+3|Gel para cejas
+3|Gel para después del afeitado
+3|Gel para el cabello
+3|Gel para el peinado del cabello
+3|Gel para uñas
+3|Gel y mousse para el cabello
+3|Gelatina de alga para uso en lavandería (funori)
+3|Geles blanqueadores para uso dental
+3|Geles bronceadores (cosméticos)
+3|Geles de afeitar
+3|Geles de baño
+3|Geles de belleza
+3|Geles de ducha
+3|Geles limpiadores de inodoros
+3|Geles para después del sol (cosméticos)
+3|Geles para el cabello
+3|Geles para el peinado
+3|Geles para uso cosméticos
+3|Geles retardantes de la edad
+3|Geles y sales para baño y ducha que no sean para uso médico
+3|Glaseado del cabello
+3|Grasa para calzado
+3|Henna para uso cosmético
+3|Hidratantes para después del sol
+3|Hidratantes para el cabello
+3|Hidratantes para la piel
+3|Hierbas para el baño
+3|Hisopos para uso cosmético
+3|Incienso
+3|Jabón crema para cuerpo
+3|Jabón de afeitar
+3|Jabón de almendras
+3|Jabón de belleza
+3|Jabón de tocador
+3|Jabón en barra
+3|Jabón líquido
+3|Jabón líquido para lavandería
+3|Jabón para lavandería
+3|Jabón perfumado
+3|Jabones antitranspirantes
+3|Jabones antitranspirantes para los pies
+3|Jabones cosméticos
+3|Jabones de afeitar
+3|Jabones de baño
+3|Jabones de baño en forma líquida, solida o gel
+3|Jabones de tocador
+3|Jabones desodorantes
+3|Jabones en crema
+3|Jabones en polvo
+3|Jabones granulados
+3|Jabones líquidos
+3|Jabones líquidos de baño
+3|Jabones líquidos para manos y cara
+3|Jabones para el cuidado corporal
+3|Jabones para uso personal
+3|Jabones perfumados
+3|Jalea de petróleo para uso cosmético
+3|Labiales cremosos
+3|Labiales líquidos (cosméticos)
+3|Laca para el cabello
+3|Lacas de uñas
+3|Lacas para el cabello
+3|Lacas para el peinado del cabello
+3|Lacas y geles para el cabello
+3|Lápices cosméticos
+3|Lápices de cejas
+3|Lápices de labios (pintalabios)
+3|Lápices de maquillaje
+3|Lápices de ojos
+3|Lápices de rubor
+3|Lápices delineadores de ojos
+3|Lápices para uso cosmético
+3|Lápiz labial
+3|Leche de almendras para uso cosmético
+3|Leche hidratante
+3|Leche limpiadora
+3|Leche limpiadora facial
+3|Leche limpiadora para uso cosmético
+3|Leche para el cuerpo
+3|Leche para la cara y el cuerpo
+3|Leche para uso cosmético
+3|Leche y lociones para la cara
+3|Leche, gel, lociones y cremas desmaquillantes
+3|Leches bronceadoras (cosméticos)
+3|Leches de belleza
+3|Leches desmaquillantes
+3|Leches limpiadoras de tocador
+3|Leches para después del sol (cosméticos)
+3|Leches para el cuerpo
+3|Leches, geles y aceites para el bronceado y para después del sol (cosméticos)
+3|Limpiadores de alfombras
+3|Limpiadores de hornos
+3|Limpiadores de manos (preparaciones para limpieza de manos)
+3|Limpiadores en aerosol para refrescar protectores bucales
+3|Limpiadores faciales
+3|Limpiadores para la piel
+3|Líquidos antideslizantes para suelos
+3|Líquidos de limpieza en seco
+3|Líquidos limpiaparabrisas
+3|Líquidos para refrescar el aliento
+3|Loción facial
+3|Loción para el cabello
+3|Loción para la piel
+3|Loción para limpieza de la piel
+3|Loción tónica para cara, cuerpo y manos
+3|Lociones capilares
+3|Lociones colorantes para el cabello
+3|Lociones corporales
+3|Lociones cosméticas para el bronceado
+3|Lociones de afeitar
+3|Lociones de baño
+3|Lociones de belleza
+3|Lociones de mano
+3|Lociones de protección solar
+3|Lociones desmaquillantes
+3|Lociones para contorno de ojos
+3|Lociones para después del afeitado
+3|Lociones para después del sol
+3|Lociones para el blanqueado de dientes
+3|Lociones para el bronceado de la piel
+3|Lociones para el cuerpo
+3|Lociones para el cuidado de la cara y el cuerpo
+3|Lociones para el cuidado del cabello
+3|Lociones para el peinado
+3|Lociones para el sol de uso cosmético
+3|Lociones para fortalecer las uñas
+3|Lociones para la barba
+3|Lociones para la cara y el cuerpo
+3|Lociones para la piel
+3|Lociones para la reducción de la celulitis
+3|Lociones para permanentes
+3|Lociones para uso cosmético
+3|Lociones y cremas corporales perfumadas
+3|Maderas aromáticas
+3|Manteca de cacao con una finalidad cosmética
+3|Maquillaje
+3|Maquillaje base
+3|Maquillaje base cremoso
+3|Maquillaje de ojos
+3|Maquillaje oleoso para actores
+3|Maquillaje para cara y cuerpo
+3|Maquillajes base
+3|Máscara de pestañas
+3|Máscaras de barro cosméticas
+3|Máscaras de pestañas
+3|Máscaras para cabello
+3|Mascarillas cosméticas para el cuidado de la piel de las manos
+3|Mascarillas de belleza
+3|Mascarillas de belleza faciales
+3|Mascarillas de belleza para el cabello
+3|Mascarillas para cerrar los poros utilizadas como cosméticos
+3|Mascarillas para el cuidado de la piel de las manos
+3|Mascarillas para el cuidado de la piel de los pies
+3|Mechas que desprenden fragancia para perfumar habitaciones
+3|Mezclas personalizadas de aceites esenciales de uso en aromaterapia
+3|Mousse de afeitar
+3|Mousse para el cabello
+3|Mousse para el peinado
+3|Mousses para el cabello
+3|Paletas de sombras de ojos (maquillaje)
+3|Palos de incienso
+3|Paños de limpieza impregnados con detergente
+3|Paños o pañuelos impregnados con limpiadores de cosméticos
+3|Papel abrasivo (papel de lija)
+3|Papel de esmeril
+3|Papel de lija
+3|Papel para pulir
+3|Papel secante de aceite con una finalidad cosmética
+3|Parches impregnados de preparaciones de bloqueador solar de uso cosmético
+3|Pasta abrasiva
+3|Pasta de dientes
+3|Pasta de zapatos
+3|Pasta dental
+3|Pasta dentífrica
+3|Pasta perfumada
+3|Pastas dentales
+3|Pastas dentales y enjuagues bucales
+3|Pastas dentífricas blanqueadoras
+3|Pastillas de jabón
+3|Pegatinas decorativas para uñas
+3|Perfume
+3|Perfumes
+3|Perfumes en forma sólida
+3|Perfumes líquidos
+3|Perfumes para uso industrial
+3|Perfumes y aguas de tocador
+3|Perfumes y colonias
+3|Perlas de baño
+3|Peróxido de hidrógeno para uso cosmético
+3|Pestañas postizas
+3|Pez de zapatero
+3|Piedra pómez
+3|Piedra pómez para uso personal
+3|Piedras cerámicas aromáticas
+3|Piedras de afeitar (astringentes para uso cosmético)
+3|Piedras para pulir
+3|Pintalabios
+3|Pintura de uñas (cosméticos)
+3|Pinturas para la cara
+3|Polveras con maquillaje
+3|Polvo base para la cara en papel
+3|Polvo de baño (cosméticos)
+3|Polvo de maquillaje comprimido para la cara
+3|Polvo de maquillaje cremoso para la cara
+3|Polvo de maquillaje en pasta para la cara
+3|Polvo de maquillaje para la cara
+3|Polvo dentífrico
+3|Polvo para las cejas
+3|Polvo para lavado de cabello
+3|Polvo perfumado
+3|Polvo sólido para polveras (cosméticos)
+3|Polvos cosméticos
+3|Polvos de maquillaje
+3|Polvos faciales cosméticos
+3|Polvos perfumados
+3|Polvos sólidos para estuches de compactos (cosméticos)
+3|Pomadas en barra
+3|Pomadas para el cabello
+3|Popurrís aromáticos
+3|Preparaciones blanqueadoras de uso en lavandería
+3|Preparaciones bloqueadoras del sol
+3|Preparaciones bronceadoras
+3|Preparaciones colorantes con fines cosméticos
+3|Preparaciones colorantes para el cabello
+3|Preparaciones cosméticas
+3|Preparaciones cosméticas bloqueadoras
+3|Preparaciones cosméticas contra el bronceado
+3|Preparaciones cosméticas de protección solar
+3|Preparaciones cosméticas en aerosol para el cabello
+3|Preparaciones cosméticas para ducha y baño
+3|Preparaciones cosméticas para el bronceado
+3|Preparaciones cosméticas para el cuidado de la boca y los dientes
+3|Preparaciones cosméticas para el cuidado de la piel
+3|Preparaciones cosméticas para el cuidado de las uñas
+3|Preparaciones cosméticas para el cuidado del cabello y del cuero cabelludo
+3|Preparaciones cosméticas para peluquería
+3|Preparaciones cosméticas para pestañas
+3|Preparaciones cosméticas para protección de la piel de los rayos solares
+3|Preparaciones cosméticas para secado de uñas
+3|Preparaciones de autobronceadoras (cosméticos}
+3|Preparaciones de espuma limpiadora
+3|Preparaciones de limpieza de hornos
+3|Preparaciones de limpieza para uso doméstico
+3|Preparaciones de limpieza, lavado y pulido
+3|Preparaciones de maquillaje para cara y cuerpo
+3|Preparaciones de protección solar
+3|Preparaciones de protección solar para uso cosmético
+3|Preparaciones de tocador que no sean para uso médico
+3|Preparaciones desengrasantes para uso doméstico
+3|Preparaciones desmaquillantes
+3|Preparaciones en aerosol para fijar el maquillaje
+3|Preparaciones exfoliantes de uso cosmético
+3|Preparaciones inhibidoras del crecimiento de vello cosméticas
+3|Preparaciones limpiadoras de automóviles
+3|Preparaciones limpiadoras de vidrio
+3|Preparaciones limpiadoras para la cara
+3|Preparaciones no medicadas para baños de pies
+3|Preparaciones para alisar el cabello
+3|Preparaciones para baño de burbujas que no sean medicinales
+3|Preparaciones para blanquear el cabello
+3|Preparaciones para blanquear la piel
+3|Preparaciones para blanquear para uso cosmético
+3|Preparaciones para después del afeitado
+3|Preparaciones para el cuidado de la piel, el cabello y el cuero cabelludo que no sean medicinales
+3|Preparaciones para el cuidado del cabello
+3|Preparaciones para el peinado del cabello
+3|Preparaciones para el tratamiento del cabello no medicinales con fines cosméticos
+3|Preparaciones para fijar el cabello
+3|Preparaciones para la decoloración del cabello
+3|Preparaciones para la limpieza de moquetas y alfombras
+3|Preparaciones para lavado y blanqueado de lavandería
+3|Preparaciones para limpiar automóviles
+3|Preparaciones para limpiar de drenajes (desagues)
+3|Preparaciones para limpiar prótesis dentales
+3|Preparaciones para limpieza de los dientes
+3|Preparaciones para limpieza de manos
+3|Preparaciones para limpieza y pulido
+3|Preparaciones para limpieza, pulido y fregado
+3|Preparaciones para ondular el cabello
+3|Preparaciones para ondular y rizar el cabello permanentemente
+3|Preparaciones para pulido, fregado y abrasión
+3|Preparaciones para pulir
+3|Preparaciones para pulir automóviles
+3|Preparaciones para pulir prótesis dentales
+3|Preparaciones para remover barnices
+3|Preparaciones para remover ceras
+3|Preparaciones para retirar uñas de gel
+3|Preparaciones para rizar el cabello
+3|Preparaciones quitamanchas
+3|Preparaciones removedoras de cutícula
+3|Preparaciones removedoras del color del cabello
+3|Preparaciones texturizadoras para el cabello
+3|Preparaciones y substancias para limpieza, fregado y pulido
+3|Preparaciones y sustancias depilatorias
+3|Preparados dentales blanqueadores
+3|Preparados no medicinales para el cuidado de la piel
+3|Preparados para lavavajillas
+3|Preparados para perfumar salas
+3|Preparados reparadores de uñas
+3|Productos blanqueadores (lavandería)
+3|Productos cosméticos en aerosol para el cuidado de la piel
+3|Productos cosméticos para el cuidado de la piel
+3|Productos de afeitar
+3|Productos de glaseado para lavar la ropa
+3|Productos de limpieza
+3|Productos de limpieza en seco
+3|Productos de limpieza nasal para fines sanitarios personales
+3|Productos de limpieza para cristal
+3|Productos de maquillaje
+3|Productos de perfumería
+3|Productos de perfumería sintéticos
+3|Productos de tocador que no sean medicinales
+3|Productos depilatorios
+3|Productos desoxidantes
+3|Productos en aerosol para refrescar el aliento
+3|Productos hidratantes antienvejecimiento utilizados como cosméticos
+3|Productos para dar brillo
+3|Productos para el cuidado de las uñas
+3|Productos para perfumar la ropa
+3|Productos para quitar pinturas
+3|Protectores solares en barra (preparaciones)
+3|Pulidores de automóviles
+3|Pulidores de calzado
+3|Pulidores de dientes
+3|Pulidores preservantes del cuero
+3|Pulverizador desodorante para los pies
+3|Purpurina facial y corporal
+3|Purpurina para el cuerpo
+3|Quitaesmaltes para las uñas
+3|Quitamanchas
+3|Refrescantes de la piel cosméticos
+3|Removedor de esmalte de uñas
+3|Removedores de cera de pisos
+3|Removedores de maquillaje de ojos
+3|Rollos abrasivos
+3|Rubor de mejillas
+3|Saborizantes de alimentos preparados a partir de aceites esenciales
+3|Saborizantes que sean aceites esenciales para alimentos
+3|Sales blanqueadoras
+3|Sales de baño
+3|Sales de baño cosméticas
+3|Sales de baño perfumadas
+3|Sales de baño que no sean medicinales
+3|Salvado de arroz para pulir la piel (arai-nuka)
+3|Sangre falsa como maquillaje teatral
+3|Servilletas de paño para quitar el maquillaje
+3|Soda para blanquear
+3|Soluciones decapantes
+3|Soluciones limpiadoras para aparatos odontológicos de esterilización por ultrasonidos
+3|Sombra de ojos
+3|Sombras de ojos
+3|Suavizantes para la ropa
+3|Suavizantes para tejidos
+3|Sueros de belleza
+3|Tabletas sólidas de pasta de dientes
+3|Talco de bebé
+3|Talco de tocador
+3|Talco perfumado
+3|Talcos de bebé
+3|Tatuajes temporales
+3|Tela de esmeril
+3|Tela para pulir
+3|Tela y papel para pulir
+3|Tintes de pestañas
+3|Tintes labiales (cosméticos)
+3|Tintes para el cabello
+3|Tintes para la barba
+3|Tintura de cabello
+3|Tiras abrasivas
+3|Tiras de cera para eliminar el vello corporal
+3|Tiras para refrescar el aliento
+3|Tiza para maquillaje
+3|Tiza para uso cosmético
+3|Toallitas antiestáticas para secadora
+3|Toallitas húmedas impregnadas con detergente
+3|Toallitas impregnadas con preparaciones limpiadoras
+3|Toallitas impregnadas con un limpiador de piel
+3|Toallitas impregnadas de lociones cosméticas
+3|Toallitas para gafas impregnadas con detergente
+3|Toallitas pre-humedecidas con detergente lavalozas
+3|Tónicos para el cabello
+3|Tónicos para la piel
+3|Tónicos para la piel que no sean medicinales
+3|Uñas artificiales
+3|Uñas postizas
+3|Uñas postizas de metales preciosos
+3|Varillas de incienso

--- a/lib/seeds/class_40_terms.csv
+++ b/lib/seeds/class_40_terms.csv
@@ -1,142 +1,241 @@
-class,reference_id,name
-40,400001,abrasión
-40,400002,procesamiento de películas cinematográficas
-40,400003,purificación del aire
-40,400004,magnetización
-40,400004,imantación
-40,400005,apresto de textiles
-40,400006,apresto del papel
-40,400007,plateado
-40,400008,blanqueo de tejidos
-40,400009,trabajo de la madera
-40,400010,ribeteado de telas
-40,400011,soldadura
-40,400011,soldadura fuerte
-40,400012,confección de prendas de vestir
-40,400013,chapado de cadmio
-40,400013,cadmiado
-40,400014,calandrado de telas
-40,400015,trabajo de la cerámica
-40,400015,horneado de la cerámica
-40,400016,teñido de calzado
-40,400017,cromado
-40,400018,chapado de metales
-40,400018,revestimiento [chapado] de metales
-40,400019,teñido del cuero
-40,400020,acondicionamiento de pieles
-40,400021,corte de telas
-40,400022,estampado de dibujos
-40,400023,revelado de películas fotográficas
-40,400024,dorado [doradura]
-40,400025,tratamiento del agua
-40,400026,revestimiento [chapado] por electrólisis
-40,400026,chapado [revestimiento] por electrólisis
-40,400026,galvanoplastia
-40,400027,estañado [estañadura]
-40,400028,confección de pieles a medida
-40,400029,servicios de forja
-40,400029,servicios de herrería
-40,400030,tratamiento antipolilla de pieles
-40,400031,fresado
-40,400032,prensado de frutas
-40,400033,ahumado de alimentos
-40,400034,galvanización
-40,400035,grabado
-40,400036,impermeabilización de tejidos
-40,400037,ignifugación de tejidos
-40,400037,ignifugación de telas
-40,400037,ignifugación de textiles
-40,400038,tratamiento antiarrugas de tejidos
-40,400039,tratamiento de la lana
-40,400040,laminado
-40,400041,amolado
-40,400042,tratamiento de metales
-40,400043,temple de metales
-40,400044,molienda de grano
-40,400045,niquelado
-40,400046,urdidura
-40,400047,preparación de pieles
-40,400048,pulido por abrasión
-40,400049,encuadernación
-40,400050,cepillado de materiales
-40,400051,servicios de guarnicionería
-40,400051,servicios de talabartería
-40,400052,aserrado de materiales
-40,400053,servicios de sastre
-40,400054,servicios de curtido
-40,400055,taxidermia
-40,400056,servicios de tintorería*
-40,400057,teñido de textiles
-40,400058,tratamiento de textiles
-40,400058,tratamiento de tejidos
-40,400059,tratamiento antipolilla de telas
-40,400060,teñido de telas
-40,400060,teñido de tejidos
-40,400061,tratamiento del papel
-40,400062,soplado de vidrio
-40,400063,servicios de bordado
-40,400064,trabajo del cuero
-40,400065,coloración del vidrio por tratamiento de superficie
-40,400065,entintado del vidrio por tratamiento de superficie
-40,400066,conservación de alimentos y bebidas
-40,400067,tala y corte de madera
-40,400068,reciclaje de residuos y desechos
-40,400069,preencogimiento de telas
-40,400070,lustrado de pieles
-40,400071,satinado de pieles
-40,400072,teñido de pieles
-40,400081,desodorización del aire
-40,400082,enfriamiento del aire
-40,400083,ensamblaje por encargo de materiales para terceros
-40,400084,enmarcado de obras de arte
-40,400085,chapado en oro
-40,400086,trazado por láser
-40,400087,suministro de información sobre el tratamiento de materiales
-40,400088,pulido de vidrio óptico
-40,400089,impresión de fotografías
-40,400090,fotograbado
-40,400091,tratamiento del petróleo
-40,400092,acolchado
-40,400093,refinado
-40,400094,sacrificio de animales
-40,400094,matanza de animales
-40,400094,carneo de animales
-40,400095,decapado
-40,400097,tratamiento de desechos [transformación]
-40,400098,arreglo de prendas de vestir
-40,400099,servicios de calderería
-40,400100,colada de metales
-40,400101,vulcanización [tratamiento de materiales]
-40,400102,servicios de protésicos dentales
-40,400103,producción de energía
-40,400104,alquiler de generadores
-40,400105,destrucción de residuos y desechos
-40,400106,incineración de residuos y desechos
-40,400107,tratamiento de separación de colores
-40,400108,servicios de copia de llaves
-40,400109,descontaminación de materiales peligrosos
-40,400110,impresión litográfica
-40,400111,servicios de impresión
-40,400112,alquiler de máquinas de tejer
-40,400112,alquiler de máquinas de hacer punto
-40,400113,servicios de impresión en offset
-40,400114,servicios de fotocomposición
-40,400115,serigrafía
-40,400116,selección de desechos y material reciclable [transformación]
-40,400117,congelación de alimentos
-40,400118,alquiler de aparatos de aire acondicionado
-40,400119,alquiler de aparatos de calefacción de ambientes
-40,400119,alquiler de aparatos de calefacción auxiliares
-40,400120,abatanado de telas
-40,400121,servicios de criopreservación
-40,400122,servicios de limpieza por chorro de arena
-40,400123,alquiler de calderas
-40,400124,suprarreciclaje [revalorización de materiales de desecho]
-40,400125,servicios de soldadura
-40,400126,servicios de tintado de cristales de coche
-40,400127,impresión 3D por encargo para terceros
-40,400128,elaboración de cerveza para terceros
-40,400129,fabricación de pan por encargo
-40,400130,pasteurización de bebidas y alimentos
-40,400131,servicios de vinificación para terceros
-40,400132,consultoría en el ámbito de la vinificación
+class|name
+40|Abatanado de telas
+40|Afinado de metales
+40|Alquiler de aparatos de aire acondicionado
+40|Alquiler de aparatos de calefacción de ambientes
+40|Alquiler de aparatos para purificar el agua
+40|Alquiler de equipos de tratamiento del agua
+40|Alquiler de filtros de agua
+40|Alquiler de generador de fuerza eléctrica
+40|Alquiler de generadores de electricidad
+40|Alquiler de impresoras 3D
+40|Alquiler de máquinas de coser
+40|Alquiler de máquinas de encuadernación
+40|Alquiler de máquinas de grabado láser
+40|Alquiler de máquinas de hacer punto
+40|Alquiler de máquinas para hacer zapatos
+40|Alquiler de máquinas para la fabricación de cartón corrugado
+40|Alquiler de máquinas para procesar tabaco
+40|Alquiler de máquinas y aparatos de imprimir
+40|Alquiler de máquinas y aparatos para fabricar objetos de cristal
+40|Alquiler de máquinas y aparatos para producción de chapa de madera
+40|Alquiler de máquinas y aparatos para tratar tejidos
+40|Alquiler de máquinas y herramientas para trabajar los metales
+40|Alquiler de prensas tipográficas
+40|Alquiler de soldadores de gas
+40|Alquiler de unidades de filtración de agua para uso comercial
+40|Amolado y pulido de vidrio para gafas
+40|Ampliación de fotografías
+40|Antiencogimiento para textiles o pieles
+40|Aplicación de acabados a telas
+40|Arreglo de prendas de vestir
+40|Arrendamiento de aparatos de refrigeración de espacios de uso doméstico
+40|Arrendamiento de máquinas aplastadoras de desechos
+40|Arrendamiento de máquinas compactadoras de desechos
+40|Arrendamiento de máquinas elaboradoras de vidrio
+40|Arrendamiento de máquinas procesadoras de químicos
+40|Arrendamiento de máquinas y aparatos para fabricación de pulpa y papel
+40|Arrendamiento de máquinas y aparatos para la industria maderera
+40|Arrendamiento de máquinas y aparatos para revelado de películas, impresión fotográfica, amplificación fotográfica y terminación fotográfica
+40|Arrendamiento de sistemas de neblina para enfriamiento de exteriores
+40|Arrendamiento de transformadores eléctricos
+40|Arrendamiento de ventiladores eléctricos para enfriar
+40|Blanqueado de prendas de vestir
+40|Blanqueado de tejidos
+40|Blanqueado de telas
+40|Blanqueado de textiles
+40|Blanqueo de tejidos
+40|Calandrado de telas
+40|Cincado electrolítico
+40|Coloración del vidrio
+40|Congelación de alimentos
+40|Copia de planos (blueprint)
+40|Corte de diamantes
+40|Corte de telas
+40|Costura
+40|Costura y confección de prendas de vestir
+40|Deformación de textiles
+40|Desacidificación de papel
+40|Desalinización del agua
+40|Desintoxicación de materiales peligrosos
+40|Desmagnetización
+40|Desmineralización de agua
+40|Desodorización de cortinas
+40|Destrucción de documentos
+40|Destrucción de residuos
+40|Destrucción de residuos y desechos
+40|Eliminación de basura para otros
+40|Eliminación de residuos tóxicos industriales
+40|Encuadernación
+40|Encuadernación de documentos
+40|Endurecimiento de metales
+40|Enmarcado de obras de arte
+40|Ensamblado de productos para terceros
+40|Esmaltado cerámico
+40|Esmaltado de metales
+40|Estampado de dibujos
+40|Estañado (estañadura)
+40|Fabricación a medida de ataúdes cinerarios
+40|Facilitación de información relacionada con el tratamiento de materiales
+40|Forjado de estaño
+40|Fotograbado
+40|Fresado
+40|Fundiciones de plomo y sus aleaciones
+40|Galvanizado en caliente
+40|Galvanoplastia
+40|Generación de electricidad
+40|Generación de electricidad a partir de energía eólica
+40|Grabado
+40|Grabado con láser
+40|Grabado de sellos de lacre
+40|Grabado de vidrio
+40|Ignifugación para textiles o pieles
+40|Impermeabilización de prendas de vestir
+40|Impermeabilización de tejidos
+40|Impermeabilización de telas
+40|Impermeabilización de textiles o pieles
+40|Impresión de camisetas
+40|Impresión de diseños para terceros
+40|Impresión de fotograbados
+40|Impresión de fotografías
+40|Impresión de libros
+40|Impresión de material publicitario
+40|Impresión de sellos
+40|Impresión digital
+40|Impresión litográfica
+40|Impresión serigráfica
+40|Impresión tipográfica
+40|Incineración de basura
+40|Incineración de desechos
+40|Incineración de residuos
+40|Laminado de hojas de plástico
+40|Laminado de metales
+40|Licuefacción de gas de petróleo
+40|Mezclado de lubricantes para terceros
+40|Moldeado de materiales plásticos
+40|Montaje de obras de arte como parte del proceso de enmarcado
+40|Montaje en seco (fijación de fotografías a través de adhesivos sensibles al calor)
+40|Orfebrería
+40|Procesamiento de bambú
+40|Procesamiento de caucho
+40|Procesamiento de cerámica
+40|Procesamiento de combustible nuclear
+40|Procesamiento de cortezas de árbol
+40|Procesamiento de forrajes
+40|Procesamiento de hojas de té
+40|Procesamiento de hormigón
+40|Procesamiento de materiales combustibles
+40|Procesamiento de metales
+40|Procesamiento de películas cinematográficas
+40|Procesamiento de plástico
+40|Procesamiento de ratán
+40|Procesamiento de silicona
+40|Procesamiento fotográfico
+40|Producción de electricidad
+40|Producción de electricidad a partir de energía solar
+40|Producción de energía
+40|Producción de gas y electricidad
+40|Pulido de cristal
+40|Pulido de diamantes
+40|Pulido de piedras preciosas
+40|Realce del color de películas de vídeo en blanco y negro
+40|Realce del color de películas en blanco y negro
+40|Reciclado de químicos
+40|Reciclado de residuos
+40|Reciclado de residuos y basura
+40|Reciclaje de botellas de bebidas
+40|Reciclaje de botellas de plástico PET
+40|Reciclaje de combustibles nucleares
+40|Reciclaje de desechos
+40|Reciclaje de plástico
+40|Reciclaje de residuos y desechos
+40|Refinación de combustible
+40|Refinado de materiales combustibles
+40|Refinado de metales
+40|Refinado de residuos metálicos odontológicos
+40|Reprocesado de combustibles nucleares
+40|Reproducción de obras de arte de museos
+40|Restauración digital de fotografías
+40|Retoque digital de fotografías
+40|Retratamiento de aguas residuales
+40|Revelado de películas fotográficas
+40|Rotograbado
+40|Sastrería o costura
+40|Selección de desechos y material reciclable
+40|Serigrafía
+40|Servicios contra la polilla
+40|Servicios de acolchado de textiles a medida
+40|Servicios de arenado abrasivo
+40|Servicios de bordado
+40|Servicios de bordado de camisetas
+40|Servicios de compresión de gas
+40|Servicios de conservación de alimentos
+40|Servicios de copia de llaves
+40|Servicios de criopreservación
+40|Servicios de curtido
+40|Servicios de descontaminación de áreas con radiación
+40|Servicios de destilación para bebidas espirituosas
+40|Servicios de destilería de bebidas alcohólicas
+40|Servicios de imprenta
+40|Servicios de impresión en offset
+40|Servicios de licuefacción de gas natural
+40|Servicios de mezcla de petróleo crudo y de petróleos sintéticos
+40|Servicios de mezclado de pinturas
+40|Servicios de modista (corte y confección de vestuario)
+40|Servicios de producción de gas
+40|Servicios de rallado de disco duro
+40|Servicios de reciclado de aceite de cocina y de aceite vegetal
+40|Servicios de refinación de petróleo
+40|Servicios de refinería de petróleo
+40|Servicios de restauración fotográfica
+40|Servicios de revelado y reproducción de fotografías
+40|Servicios de sastre
+40|Servicios de separación de color
+40|Servicios de tintorería para textiles o pieles
+40|Servicios de torneado de madera
+40|Servicios de tratamiento de agua
+40|Servicios de tratamiento de gas
+40|Servicios de triturado de documentos
+40|Soldadura
+40|Suministro de información sobre el alquiler de máquinas para fabricar calzado
+40|Suministro de información sobre el alquiler de máquinas para procesar tabaco
+40|Taxidermia
+40|Templado de vidrio
+40|Temple de metales
+40|Teñido de pieles artificiales
+40|Teñido de tejidos o prendas de vestir
+40|Teñido de telas
+40|Tintado de lentes de contacto
+40|Tipografía
+40|Tostado de alimentos
+40|Tostado y procesamiento de café
+40|Trabajo de la cerámica
+40|Trabajo de la madera
+40|Trabajos de ebanistería
+40|Transformación de productos alimenticios para ser utilizados en procesos de fabricación
+40|Tratamiento antiarrugas de tejidos
+40|Tratamiento antipliegues de telas
+40|Tratamiento antipolilla de materias textiles o pieles
+40|Tratamiento de agua y purificación
+40|Tratamiento de aguas residuales
+40|Tratamiento de cartón ondulado para embalaje
+40|Tratamiento de líquidos peligrosos
+40|Tratamiento de mármol
+40|Tratamiento de materiales por rayos láser
+40|Tratamiento de metales
+40|Tratamiento de pieles
+40|Tratamiento de pieles para evitar el encogimiento
+40|Tratamiento de residuos nucleares
+40|Tratamiento de residuos peligrosos
+40|Tratamiento de resina epoxi
+40|Tratamiento de tela y textiles
+40|Tratamiento de telas
+40|Tratamiento de textiles
+40|Tratamiento de textiles para prevenir el moho
+40|Tratamiento de vestimenta
+40|Tratamiento del agua
+40|Tratamiento del papel
+40|Tratamiento para conservación de la madera (que no sea pintura)
+40|Tratamiento químico de materias textiles
+40|Tratamiento térmico de metales
+40|Triturado de piedras

--- a/lib/seeds/class_41_terms.csv
+++ b/lib/seeds/class_41_terms.csv
@@ -1,165 +1,397 @@
-class,reference_id,name
-41,410002,academias [educación]
-41,410003,servicios de parques de atracciones
-41,410003,servicios de parques de diversiones
-41,410004,servicios de entretenimiento
-41,410005,doma y adiestramiento de animales
-41,410005,adiestramiento de animales
-41,410006,alquiler de aparatos cinematográficos
-41,410007,servicios de artistas del espectáculo
-41,410008,servicios de estudios de cine
-41,410009,representación de espectáculos de circo
-41,410010,organización de concursos [actividades educativas o recreativas]
-41,410011,cursos por correspondencia
-41,410011,enseñanza por correspondencia
-41,410012,servicios de educación física
-41,410013,alquiler de decorados para espectáculos
-41,410014,puesta a disposición de instalaciones recreativas
-41,410015,programas de entretenimiento por radio
-41,410016,publicación de textos que no sean publicitarios
-41,410017,educación
-41,410017,servicios educativos
-41,410017,enseñanza
-41,410017,instrucción [enseñanza]
-41,410018,alquiler de grabaciones sonoras
-41,410019,alquiler de películas cinematográficas
-41,410020,producción de películas que no sean publicitarias
-41,410021,enseñanza de gimnasia
-41,410023,servicios de bibliotecas de préstamo
-41,410024,publicación de libros
-41,410025,alquiler de aparatos de radio y televisión
-41,410026,producción de programas de radio y televisión
-41,410027,representación de espectáculos de variedades
-41,410028,servicios de orquestas
-41,410029,representaciones teatrales
-41,410030,producción de espectáculos
-41,410031,programas de entretenimiento por televisión
-41,410032,alquiler de decorados de teatro
-41,410032,alquiler de escenografía
-41,410033,servicios de parques zoológicos
-41,410033,servicios de jardines zoológicos
-41,410035,explotación de instalaciones deportivas
-41,410036,agencias de modelos para artistas
-41,410041,servicios de bibliotecas ambulantes
-41,410042,servicios de casinos [juego]
-41,410042,explotación de casinos [juego]
-41,410043,servicios de clubes [educación o entretenimiento]
-41,410044,organización y dirección de coloquios
-41,410045,organización y dirección de conferencias
-41,410046,organización y dirección de congresos
-41,410047,servicios de discotecas
-41,410048,suministro de información sobre educación
-41,410049,servicios de pruebas pedagógicas
-41,410050,suministro de información sobre actividades de entretenimiento
-41,410051,organización de exposiciones con fines culturales o educativos
-41,410052,servicios de juegos de apuestas
-41,410053,explotación de campos de golf
-41,410054,clubes deportivos [entrenamiento y mantenimiento físico]
-41,410055,servicios de campamentos de vacaciones [actividades recreativas]
-41,410056,representación de espectáculos en vivo
-41,410057,exhibición de películas cinematográficas
-41,410058,jardines de infancia
-41,410058,guarderías [educación]
-41,410059,organización de competiciones deportivas
-41,410060,organización de fiestas y recepciones
-41,410061,formación práctica [demostración]
-41,410062,servicios de museos [presentaciones, exposiciones]
-41,410063,servicios de estudios de grabación
-41,410064,suministro de información sobre actividades recreativas
-41,410065,alquiler de equipos de buceo
-41,410065,alquiler de equipos de submarinismo
-41,410066,alquiler de equipos deportivos, excepto vehículos
-41,410067,alquiler de estadios
-41,410068,alquiler de aparatos de vídeo
-41,410069,alquiler de cintas de vídeo
-41,410070,organización y dirección de seminarios
-41,410071,servicios de campamentos deportivos
-41,410072,organización y dirección de simposios
-41,410073,cronometraje de eventos deportivos
-41,410075,educación en internados
-41,410076,organización y dirección de talleres de formación
-41,410077,organización de concursos de belleza
-41,410078,reserva de localidades para espectáculos
-41,410079,doblaje
-41,410080,educación religiosa
-41,410081,organización de loterías
-41,410082,organización de bailes
-41,410083,organización de espectáculos [servicios de empresarios]
-41,410084,servicios de salas de juegos
-41,410085,alquiler de equipos de audio
-41,410086,alquiler de equipos de iluminación para escenarios de teatro o estudios de televisión
-41,410087,alquiler de pistas de tenis
-41,410087,alquiler de canchas de tenis
-41,410088,alquiler de cámaras de vídeo
-41,410088,alquiler de videocámaras
-41,410089,redacción de guiones que no sean publicitarios
-41,410090,montaje de cintas de vídeo
-41,410091,publicación en línea de libros y revistas especializadas en formato electrónico
-41,410092,microedición
-41,410093,subtitulado
-41,410094,servicios de juegos disponibles en línea por una red informática
-41,410095,servicios de karaoke
-41,410097,servicios de composición musical
-41,410098,servicios de clubes nocturnos [entretenimiento]
-41,410099,suministro de publicaciones electrónicas en línea no descargables
-41,410100,reportajes fotográficos
-41,410101,servicios fotográficos
-41,410102,orientación profesional [asesoramiento sobre educación o formación]
-41,410102,orientación vocacional [asesoramiento sobre educación o formación]
-41,410103,servicios de reporteros
-41,410104,servicios de traducción
-41,410105,interpretación del lenguaje de los signos
-41,410105,interpretación del lenguaje de señas
-41,410106,grabación [filmación] en cintas de vídeo
-41,410182,microfilmación
-41,410183,servicios de taquilla [espectáculos]
-41,410183,servicios de venta de boletos [espectáculos]
-41,410184,redacción de textos*
-41,410185,organización y dirección de conciertos
-41,410186,servicios de caligrafía
-41,410187,servicios de composición de página que no sean con fines publicitarios
-41,410188,organización de desfiles de moda con fines recreativos
-41,410189,coaching [formación]
-41,410190,alquiler de campos de deporte
-41,410191,servicios de disc-jockey
-41,410191,servicios de pinchadiscos
-41,410192,interpretación lingüística
-41,410193,servicios de preparador físico personal [mantenimiento físico]
-41,410194,clases de mantenimiento físico
-41,410195,cursos de reciclaje profesional
-41,410196,producción musical
-41,410197,alquiler de juguetes
-41,410198,alquiler de material para juegos
-41,410199,servicios educativos prestados por escuelas
-41,410200,suministro en línea de música no descargable
-41,410201,suministro en línea de vídeos no descargables
-41,410202,servicios de tutoría [instrucción]
-41,410203,organización y dirección de foros presenciales educativos
-41,410204,servicios de compositores y autores de música
-41,410205,redacción de guiones televisivos y cinematográficos
-41,410206,servicios de guías turísticos
-41,410207,servicios de formación mediante simuladores
-41,410208,suministro de películas, no descargables, mediante servicios de vídeo a la carta
-41,410209,suministro de programas de televisión, no descargables, mediante servicios de vídeo a la carta
-41,410210,sado [enseñanza de la ceremonia japonesa del té]
-41,410211,enseñanza del aikido
-41,410212,alquiler de obras de arte
-41,410213,alquiler de acuarios de interior
-41,410214,realización de excursiones de escalada guiadas
-41,410215,organización de eventos recreativos en torno a juegos de disfraces [cosplay]
-41,410216,servicios culturales, educativos y recreativos de galerías de arte
-41,410217,distribución de películas
-41,410218,transferencia de conocimientos especializados
-41,410219,servicios de asistencia educativa prestados por asistentes escolares
-41,410220,enseñanza de judo
-41,410221,servicios de exámenes pedagógicos de cualificación para pilotar drones
-41,410222,servicios de ingenieros de sonido para eventos
-41,410223,servicios de montaje de vídeo para eventos
-41,410224,servicios de técnicos de iluminación para eventos
-41,410225,realización de películas no publicitarias
-41,410226,suministro de comentarios de usuarios con fines culturales o de entretenimiento
-41,410227,suministro de clasificaciones de usuarios con fines culturales o de entretenimiento
-41,410227,suministro de evaluaciones de usuarios con fines culturales o de entretenimiento
-41,410228,alquiler de simuladores de entrenamiento
-41,410229,servicios de evaluación de la forma física con fines de entrenamiento
-41,410230,servicios de pintura facial
+class|name
+41|Agencias de modelos para artistas plásticos
+41|Alquiler de aparatos de audio
+41|Alquiler de aparatos de iluminación para escenarios de teatro
+41|Alquiler de aparatos de iluminación para escenarios de teatro o estudios de televisión
+41|Alquiler de aparatos de iluminación para estudios de televisión
+41|Alquiler de aparatos de radio y televisión
+41|Alquiler de aparatos de televisión
+41|Alquiler de aparatos de vídeo
+41|Alquiler de cámaras de vídeo
+41|Alquiler de cámaras fotográficas
+41|Alquiler de campos de deporte
+41|Alquiler de cintas de vídeo
+41|Alquiler de cintas de vídeo, videocasetes y videogramas
+41|Alquiler de cintas magnéticas pregrabadas con imágenes
+41|Alquiler de cometas
+41|Alquiler de decorados de teatro
+41|Alquiler de discos y cintas magnéticas pregrabadas
+41|Alquiler de DVD
+41|Alquiler de equipo de skí en tabla
+41|Alquiler de equipo para buceo
+41|Alquiler de equipos de buceo
+41|Alquiler de equipos de esquí
+41|Alquiler de equipos deportivos, excepto vehículos
+41|Alquiler de equipos para la práctica del golf
+41|Alquiler de grabaciones fonográficas y de música
+41|Alquiler de grabaciones sonoras
+41|Alquiler de instalaciones de juegos para niños
+41|Alquiler de instrumentos musicales
+41|Alquiler de juguetes
+41|Alquiler de libros
+41|Alquiler de máquinas de fuego controlado para espectáculos
+41|Alquiler de máquinas de fuego ficticio para espectáculos
+41|Alquiler de máquinas de humo para espectáculos
+41|Alquiler de máquinas de nieve artificial para espectáculos
+41|Alquiler de máquinas de nube de piso para espectáculos
+41|Alquiler de máquinas lanza confeti
+41|Alquiler de máquinas para correr
+41|Alquiler de máquinas y aparatos cinematográficos
+41|Alquiler de máquinas y aparatos de juegos
+41|Alquiler de máquinas y aparatos de recreativos
+41|Alquiler de pantallas de video
+41|Alquiler de patines
+41|Alquiler de patines de ruedas
+41|Alquiler de patinetas
+41|Alquiler de películas
+41|Alquiler de películas cinematográficas
+41|Alquiler de películas cinematográficas y de registros sonoros
+41|Alquiler de películas de cine
+41|Alquiler de películas en DVD
+41|Alquiler de películas reversibles
+41|Alquiler de películas y videos de cine
+41|Alquiler de pinturas y trabajos caligráficos
+41|Alquiler de pistas de tenis
+41|Alquiler de proyectores cinematográficos y sus accesorios
+41|Alquiler de proyectores y accesorios cinematográficos
+41|Alquiler de radios y televisiones
+41|Alquiler de retroproyectores
+41|Alquiler de revistas
+41|Alquiler de rocolas
+41|Alquiler de salas de conciertos
+41|Alquiler de snorkels
+41|Alquiler de tablas de snowboard
+41|Alquiler de tablas de surf
+41|Alquiler de teatros para las artes escénicas
+41|Alquiler de videocámaras
+41|Alquiler de videocintas y películas cinematográficas
+41|Alquiler de videojuegos
+41|Análisis de puntuaciones de tests y datos educativos para terceros
+41|Arrendamiento de equipo para juegos
+41|Arrendamiento de motos de juguete
+41|Arrendamiento de proyectores de películas cinematográficas
+41|Bibliotecas de referencia de publicaciones y registros documentales
+41|Campamentos (cursillos) de perfeccionamiento deportivo
+41|Capacitación de especialistas en la industria de la fontanería
+41|Capacitación en el campo del diseño, publicidad y tecnologías de la comunicación
+41|Capacitación en mediación
+41|Capacitación en relaciones públicas y en el combate de la falsificación con miras a reconocer falsos
+41|Capacitación práctica en el campo de la soldadura
+41|Capacitación y enseñanza médica
+41|Celebración de seminarios en el ámbito de la oncología
+41|Circos
+41|Clases de submarinismo
+41|Clases de velerismo
+41|Clubes nocturnos
+41|Coaching en el campo de los deportes
+41|Corrección de manuscritos
+41|Cursos de ábaco
+41|Cursos de boxeo
+41|Cursos de formación sobre planificación estratégica en relación con publicidad, promoción, marketing y empresas
+41|Cursos de gimnasia
+41|Cursos de revisión para exámenes estatales
+41|Desarrollo de programas de intercambio estudiantil internacional
+41|Dirección de la producción de programas de radio y de televisión
+41|Dirección de obras de teatro
+41|Distribución de películas
+41|Distribución de programas de televisión para otros
+41|Doblaje
+41|Doblaje de películas
+41|Doma y adiestramiento de animales
+41|Edición de grabaciones de sonidos e imágenes
+41|Edición de libros
+41|Edición de libros y revisiones
+41|Edición de libros y revistas
+41|Edición de periódico
+41|Edición de programas de televisión y radio
+41|Edición de publicaciones electrónicas
+41|Edición de revisiones
+41|Edición de revistas
+41|Edición de revistas en la web
+41|Edición de videocintas
+41|Edición electrónica de libros y publicaciones periódicas en línea
+41|Edición fotográfica
+41|Edición y emisión de documentos científicos en relación a tecnología médica
+41|Enseñanza de arreglo floral
+41|Enseñanza de caligrafía
+41|Enseñanza de conducción de vehículos
+41|Enseñanza de confección de kimonos
+41|Enseñanza de danza
+41|Enseñanza de habilidades de belleza
+41|Enseñanza de judo
+41|Enseñanza de karate
+41|Enseñanza de kendo (enseñanza de esgrima japonesa
+41|Enseñanza de la ceremonia del té
+41|Enseñanza de las bellas artes
+41|Enseñanza de lenguaje
+41|Enseñanza de natación
+41|Enseñanza de piano
+41|Enseñanza de sastrería o costura
+41|Enseñanza de tenis
+41|Enseñanza del yoga
+41|Enseñanza en academias
+41|Enseñanza en el uso formal del kimono
+41|Enseñanza en escuelas primarias
+41|Enseñanza en escuelas secundarias
+41|Enseñanza en institutos de educación secundaria
+41|Enseñanza en materia de quiropráctica
+41|Enseñanza en teneduría de libros
+41|Enseñanza en universidades o escuelas superiores
+41|Enseñanza y capacitación en negocios, industria y tecnología de la información
+41|Entrenamiento canino para guiar personas no videntes
+41|Entrenamiento para el control de perros
+41|Entretenimiento del tipo de parque acuático y centro de recreo
+41|Entretenimiento en forma de carreras automovilísticas
+41|Entretenimiento en forma de competiciones de lanzamiento de hacha
+41|Entretenimiento en forma de competiciones de patinaje
+41|Entretenimiento en la forma de concursos de belleza
+41|Escuelas de baile
+41|Espectáculos de circo
+41|Espectáculos de danza
+41|Espectáculos de variedades
+41|Espectáculos teatrales y musicales proveídos en lugares de actuación
+41|Estudio de películas cinematográficas
+41|Estudios de cine
+41|Estudios de grabación
+41|Exámenes educativos
+41|Exhibición de películas
+41|Explotación de baños de natación
+41|Explotación de campamentos deportivos
+41|Explotación de instalaciones deportivas
+41|Explotación de salas de juegos
+41|Exposiciones de animales
+41|Exposiciones de animales y adiestramiento de animales
+41|Exposiciones de arte
+41|Exposiciones de plantas
+41|Facilitación de campos de béisbol
+41|Facilitación de canchas de tenis
+41|Facilitación de cursos de instrucción de idiomas
+41|Facilitación de cursos en materia de gestión del agua
+41|Facilitación de estudios de audio o video
+41|Facilitación de gimnasios
+41|Facilitación de instalaciones de campo y pista
+41|Facilitación de instalaciones de golf
+41|Facilitación de instalaciones de pistas de tenis
+41|Facilitación de instalaciones para torneos deportivos
+41|Facilitación de instalaciones recreativas
+41|Facilitación de noticias e información sobre lucha libre a través de una red informática global
+41|Facilitación de parques de recreo para niños en estaciones de servicios
+41|Facilitación de parques recreativos
+41|Facilitación de piscinas de natación
+41|Facilitación de pistas de esquí
+41|Facilitación de pistas de patinaje
+41|Facilitación de salas de juego
+41|Facilitación de servicios de ejercicio físico para animales
+41|Facilitación de servicios de parque acuático
+41|Formación en artes marciales
+41|Formación en seguridad de la conducción
+41|Formación para manipular instrumentos y aparatos científicos para la investigación en laboratorios
+41|Formación sobre seguridad vial
+41|Grabación de discos originales (masters)
+41|Grabaciones de audio y video sobre tenis
+41|Impartición de cursos de educación dietética
+41|Información sobre actividades de entretenimiento
+41|Instalaciones para deportes de invierno
+41|Instrucción (enseñanza) sobre Hapkido
+41|Instrucción de ábaco japonés
+41|Instrucción de baloncesto (basketball)
+41|Instrucción de forma física para golf
+41|Instrucción de peluquería
+41|Instrucción de pilates
+41|Instrucción de taekwondo
+41|Instrucción de técnicas de forestación
+41|Instrucción de tenis de mesa (ping-pong)
+41|Instrucción en baile acrobático en barra
+41|Instrucción en conducción de motocicletas
+41|Instrucción en fitness aéreo
+41|Instrucción en materia de fisioterapia
+41|Instrucción para jugar ajedrez japonés (instrucción para el shogi)
+41|Internados
+41|Interpretación de idiomas
+41|Interpretación del lenguaje de los signos
+41|Jardines botánicos
+41|Microedición (autoedición electrónica)
+41|Microfilmación
+41|Modelaje para artistas
+41|Montaje de programas de radio y televisión
+41|Operación de equipos de video y audio para la producción de programas de radio y televisión.
+41|Operación de una discoteca
+41|Organización de actividades artísticas realizadas por un dueto (conjunto) musical
+41|Organización de carreras ciclistas
+41|Organización de carreras de atletismo
+41|Organización de carreras de barcos
+41|Organización de carreras hípicas
+41|Organización de ceremonias de entrega de premios con fines educacionales
+41|Organización de combates de boxeo
+41|Organización de competencias de polo acuático (water polo)
+41|Organización de competencias deportivas
+41|Organización de competiciones de juegos electrónicos
+41|Organización de competiciones de pesca deportiva
+41|Organización de competiciones de sumo
+41|Organización de competiciones deportivas
+41|Organización de concursos
+41|Organización de concursos de belleza
+41|Organización de conferencias y simposios en el campo de la ciencia médica
+41|Organización de cursos de capacitación en instituciones educativas
+41|Organización de desfiles de modas con fines de entretenimiento
+41|Organización de espectáculos con fines culturales
+41|Organización de espectáculos culturales
+41|Organización de eventos con fines culturales
+41|Organización de eventos culturales y artísticos
+41|Organización de eventos de baile
+41|Organización de eventos de carreras automovilísticas
+41|Organización de eventos deportivos en el campo del fútbol
+41|Organización de exposiciones con fines culturales o educativos
+41|Organización de juegos
+41|Organización de loterías
+41|Organización de maratones
+41|Organización de partidos de béisbol
+41|Organización de partidos de fútbol
+41|Organización de seminarios
+41|Organización de seminarios, grupos de trabajo, grupos de estudio y convenciones en el campo de la medicina
+41|Organización de talleres profesionales y cursos de capacitación
+41|Organización de torneos de golf
+41|Organización de torneos de golf profesionales
+41|Organización de triatlones
+41|Organización y conducción de competencias deportivas universitarias y eventos atléticos
+41|Organización y conducción de competencias y campeonatos de patinaje de velocidad y artístico
+41|Organización y dirección de carreras de bicicletas
+41|Organización y dirección de carreras de caballos
+41|Organización y dirección de conciertos
+41|Organización y dirección de conferencias educacionales
+41|Organización y dirección de juegos de béisbol
+41|Organización y dirección de regatas
+41|Organización y preparación de exposiciones con fines de entretenimiento
+41|Organización y provisión de instalaciones de deporte para competencias de patinaje de velocidad y artístico
+41|Organización y realización de seminarios de oncología
+41|Organización, preparación y realización de juegos de tenis de mesa (ping pong)
+41|Organización, preparación y realización de partidos de baloncesto (basketball)
+41|Organización, preparación y realización de partidos de tenis
+41|Pintura de retratos (servicios artísticos)
+41|Planificación de fiestas
+41|Preparación de subtítulos para películas
+41|Presentación de espectáculos de teatro musical en vivo
+41|Presentación de espectáculos humorísticos en directo
+41|Presentación de espectáculos musicales
+41|Presentación de obras de teatro
+41|Préstamo de libros
+41|Préstamo de libros y publicaciones periódicas
+41|Préstamos de libros
+41|Producción de animaciones
+41|Producción de canciones para películas cinematográficas
+41|Producción de cintas de video de películas
+41|Producción de efectos especiales para películas
+41|Producción de grabaciones sonoras
+41|Producción de grabaciones sonoras y de imagen en soportes de sonido e imagen
+41|Producción de películas
+41|Producción de películas cinematográficas
+41|Producción de películas en cintas de vídeo
+41|Producción de películas y videos
+41|Producción de programas de radio
+41|Producción de programas de radio o televisión
+41|Producción de programas de radio y televisión
+41|Producción de programas televisión
+41|Producción de vídeos musicales
+41|Producción y distribución de programas de radio
+41|Provisión de cursos de educación relativos a la industria de los viajes
+41|Provisión de información de entretenimiento via sitios web
+41|Provisión de información sobre educación
+41|Provisión de información sobre educación online
+41|Provisión de instalaciones de cines
+41|Provisión de instalaciones de parques temáticos
+41|Provisión de instrucciones de juegos de mesa Go
+41|Provisión de juegos de computador online
+41|Provisión salones de bolos
+41|Publicación de calendarios
+41|Publicación de documentos en el ámbito de la formación, la ciencia, la legislación pública y los asuntos sociales
+41|Publicación de libros
+41|Publicación de libros de texto
+41|Publicación de libros y revisiones
+41|Publicación de libros, revistas, almanaques y diarios
+41|Publicación de libros, revistas, diarios, periódicos, catálogos y brochures
+41|Publicación de manuales
+41|Publicación de material impreso
+41|Publicación de periódico
+41|Publicación de periódicos electrónicos accesibles a través de una red informática mundial
+41|Publicación de revistas
+41|Publicación de revistas electrónicas
+41|Publicación de revistas, libros y manuales en el ámbito de la medicina
+41|Publicación de textos, libros, revistas y otras publicaciones impresas
+41|Publicación y edición de material impreso
+41|Realización de seminarios en el ámbito de la oncología
+41|Redacción de guiones
+41|Redacción de textos que no sean publicitarios
+41|Reportajes fotográficos
+41|Representación de espectáculos en vivo
+41|Representaciones de la ópera de Pekín
+41|Reserva de asientos para espectáculos y eventos deportivos
+41|Reserva de localidades para espectáculos
+41|Reserva de localidades para espectáculos y reserva de boletos de teatro
+41|Reserva de salas de entretenimiento
+41|Retratos fotográficos
+41|Salas cinematográficas
+41|Salas de baile
+41|Servicios de agencia de boletos para eventos de entretenimiento
+41|Servicios de alquiler de equipo de audio y video
+41|Servicios de biblioteca
+41|Servicios de bibliotecas ambulantes
+41|Servicios de cabaret (entretenimiento)
+41|Servicios de caddie de golf
+41|Servicios de caligrafía
+41|Servicios de campamento de baloncesto
+41|Servicios de campamento de deportes
+41|Servicios de club de la comedia
+41|Servicios de composición de página que no sean con fines publicitarios
+41|Servicios de composición musical
+41|Servicios de conservador (curador) de museos
+41|Servicios de consultoría relativos a la formación empresarial
+41|Servicios de edición de posproducción en música, vídeos y películas
+41|Servicios de educación física
+41|Servicios de educación y entrenamiento en técnicas de atención plena (mindfulness)
+41|Servicios de enseñanza impartida a través de diplomados
+41|Servicios de entretenimiento en la forma de carreras de yates
+41|Servicios de entretenimiento prestados por artistas de espectáculos
+41|Servicios de entretenimiento prestados por dúos musicales, cantantes y artistas del espectáculo para televisión
+41|Servicios de entretenimiento prestados por grupos musicales
+41|Servicios de entretenimiento prestados por un grupo musical
+41|Servicios de estudios cinematográficos
+41|Servicios de estudios de grabación
+41|Servicios de exámenes pedagógicos
+41|Servicios de exposiciones de arte
+41|Servicios de formación deportiva
+41|Servicios de fotografía
+41|Servicios de grabación de audio y video
+41|Servicios de instrucción de esquí
+41|Servicios de instrucción de golf
+41|Servicios de instrucción en fútbol
+41|Servicios de instrucción en patinaje sobre ruedas
+41|Servicios de instrucción sobre Jujitsu
+41|Servicios de instrucción sobre snowboard
+41|Servicios de instrucción y entrenamiento en la forma de mentoría (mentoring)
+41|Servicios de interpretación de lenguas
+41|Servicios de intérpretes lingüísticos
+41|Servicios de juegos de realidad virtual prestados en línea desde una red informática
+41|Servicios de juegos electrónicos proveídos a través de internet
+41|Servicios de museo
+41|Servicios de orquestas
+41|Servicios de parques recreativos y parques temáticos
+41|Servicios de producción de presentaciones audiovisuales
+41|Servicios de publicación de música
+41|Servicios de redacción de guiones
+41|Servicios de reporteros de noticias
+41|Servicios de reserva de entradas y contratación de eventos de ocio, deportivos y culturales
+41|Servicios de salas de juego de realidad virtual
+41|Servicios de salas de videojuegos
+41|Servicios de traducción
+41|Servicios de videograbación
+41|Servicios para campos de prácticas de golf
+41|Subtitulado
+41|Suministro de áreas de recreo en forma de áreas de juego para niños
+41|Suministro de información sobre resultados de combates de artes marciales
+41|Suministro de información sobre resultados de combates de boxeo
+41|Suministro de salas de billar
+41|Suministro de salas de máquinas tragaperras
+41|Suministro de salas de pachinko
+41|Suministro de salones de go o shogi
+41|Suministro de salones de mahjong
+41|Transcripción musical para terceros

--- a/lib/seeds/class_42_terms.csv
+++ b/lib/seeds/class_42_terms.csv
@@ -1,121 +1,434 @@
-class,reference_id,name
-42,420007,análisis químico
-42,420008,análisis para la explotación de yacimientos petrolíferos
-42,420011,servicios de arquitectura
-42,420017,investigación bacteriológica
-42,420030,servicios de química
-42,420031,investigación química
-42,420036,consultoría sobre arquitectura
-42,420038,trazado de planos para la construcción
-42,420040,investigación tecnológica
-42,420042,control de pozos de petróleo
-42,420045,investigación en cosmetología
-42,420048,decoración de interiores
-42,420049,servicios de diseño industrial
-42,420050,servicios de diseñadores de embalajes
-42,420050,diseño de embalajes
-42,420058,prueba de materiales
-42,420061,realización de estudios de proyectos técnicos
-42,420062,peritajes geológicos
-42,420063,peritajes de yacimientos petrolíferos
-42,420064,ingeniería
-42,420076,servicios de información meteorológica
-42,420079,servicios de agrimensura
-42,420083,alquiler de ordenadores
-42,420083,alquiler de computadoras
-42,420090,programación informática
-42,420095,prospección de petróleo
-42,420096,investigación en el ámbito de la física
-42,420101,investigación en mecánica
-42,420109,ensayo de textiles
-42,420109,prueba de textiles
-42,420118,prospección geológica
-42,420119,investigación geológica
-42,420132,autenticación de obras de arte
-42,420136,calibración [medición]
-42,420139,diseño de software
-42,420140,actualización de software
-42,420141,consultoría sobre diseño y desarrollo de hardware
-42,420142,diseño de moda
-42,420144,diseño de artes gráficas
-42,420157,control de calidad
-42,420159,alquiler de software
-42,420161,investigación y desarrollo de nuevos productos para terceros
-42,420165,estilismo [diseño industrial]
-42,420167,exploración submarina
-42,420175,recuperación de datos informáticos
-42,420176,mantenimiento de software
-42,420177,análisis de sistemas informáticos
-42,420190,investigación biológica
-42,420192,planificación urbana
-42,420193,peritajes [trabajos de ingenieros]
-42,420194,diseño de sistemas informáticos
-42,420195,inspección técnica de vehículos
-42,420197,duplicación de programas informáticos
-42,420198,conversión de datos o documentos de un soporte físico a un soporte electrónico
-42,420199,creación y mantenimiento de sitios web para terceros
-42,420200,alojamiento de sitios informáticos [sitios web]
-42,420201,instalación de software
-42,420202,siembra de nubes
-42,420203,conversión de datos y programas informáticos, excepto conversión física
-42,420204,consultoría sobre software
-42,420205,alquiler de servidores web
-42,420206,servicios de protección antivirus [informática]
-42,420207,consultoría sobre ahorro de energía
-42,420208,investigación en materia de protección ambiental
-42,420209,provisión de motores de búsqueda para Internet
-42,420210,digitalización de documentos [escaneado]
-42,420211,servicios de grafología
-42,420212,suministro de información, consultoría y asesoramiento científicos sobre la compensación de emisiones de carbono
-42,420213,evaluación de la calidad de la madera en pie
-42,420214,evaluación de la calidad de la lana
-42,420215,control a distancia de sistemas informáticos
-42,420216,análisis del agua
-42,420217,servicios de laboratorios científicos
-42,420218,auditorías sobre energía
-42,420219,consultoría sobre diseño de sitios web
-42,420220,software como servicio [SaaS]
-42,420221,consultoría sobre tecnologías de la información
-42,420222,investigación científica
-42,420223,alojamiento de servidores
-42,420224,ensayos clínicos
-42,420225,servicios de custodia externa de datos
-42,420226,almacenamiento electrónico de datos
-42,420227,suministro de información relativa a la tecnología informática y la programación por sitios web
-42,420228,servicios de cartografía [geografía]
-42,420229,servicios informáticos en la nube
-42,420229,servicios de computación en la nube
-42,420230,servicios externalizados de tecnologías de la información
-42,420230,servicios tercerizados de tecnologías de la información
-42,420231,consultoría tecnológica
-42,420232,consultoría sobre tecnología informática
-42,420233,consultoría sobre tecnología de telecomunicaciones
-42,420234,pronósticos meteorológicos
-42,420235,consultoría sobre seguridad informática
-42,420236,redacción técnica
-42,420237,diseño de interiores
-42,420238,desbloqueo de teléfonos móviles
-42,420239,vigilancia de sistemas informáticos para detectar averías
-42,420240,creación y diseño de índices de información basados en la web para terceros [servicios de tecnología de la información]
-42,420241,consultoría sobre seguridad en Internet
-42,420242,consultoría sobre seguridad de datos
-42,420243,servicios de cifrado de datos
-42,420244,vigilancia de sistemas informáticos para detectar accesos no autorizados o filtración de datos
-42,420245,vigilancia electrónica de información de identificación personal para detectar usurpación de identidad por Internet
-42,420246,vigilancia eletrónica de operaciones por tarjeta de crédito para la detección de fraudes por Internet
-42,420247,desarrollo de software en el marco de la edición de software
-42,420248,plataforma como servicio [PaaS]
-42,420249,desarrollo de plataformas informáticas
-42,420250,diseño de tarjetas de visita
-42,420250,diseño de tarjetas de presentación
-42,420251,investigación científica y tecnológica en el ámbito de las catástrofes naturales
-42,420252,servicios de exploración en las industrias del petróleo, el gas y la minería
-42,420253,investigación científica y tecnológica relacionada con el mapeo de patentes
-42,420254,investigación en el ámbito de la construcción inmobiliaria
-42,420255,investigación en el ámbito de las tecnologías de telecomunicaciones
-42,420256,investigación en el ámbito de la soldadura
-42,420257,investigación médica
-42,420258,diseño gráfico de material promocional
-42,420259,alquiler de contadores para el registro del consumo energético
-42,420260,servicios de autenticación de usuarios por vía tecnológica para transacciones de comercio electrónico
-42,420261,servicios de autenticación de usuarios mediante la tecnología de inicio de sesión único para aplicaciones de software en línea
+class|name
+42|Actualización de cartas náuticas
+42|Actualización de páginas de inicio para terceros
+42|Actualización de páginas iniciales para redes informáticas
+42|Actualización de programas informáticos para terceros
+42|Actualización de sitios web para terceros
+42|Actualización de software de teléfonos inteligentes
+42|Actualización de software informático
+42|Actualización de software informático en relación a seguridad informática y prevención de riesgos informáticos
+42|Actualización y alquiler de software para procesamiento de datos
+42|Actualización y diseño de software informático
+42|Actualización y mantenimiento de software informático
+42|Agrimensura de tierras y carreteras
+42|Alojamiento de contenidos digitales en Internet
+42|Alojamiento de sitios de internet para otros
+42|Alojamiento de sitios web
+42|Alojamiento de sitios web en la Internet
+42|Alquiler de aparatos de procesamiento de datos
+42|Alquiler de aparatos e instrumentos de laboratorio
+42|Alquiler de bancos de carga para comprobar fuentes de energía eléctrica
+42|Alquiler de computadoras
+42|Alquiler de computadoras y periféricos informáticos
+42|Alquiler de computadoras y software informático
+42|Alquiler de hardware informático
+42|Alquiler de hardware informático y software informático
+42|Alquiler de instrumentos de dibujo técnico
+42|Alquiler de memoria en servidores
+42|Alquiler de programas informáticos
+42|Alquiler de servidores de bases de datos para terceros
+42|Alquiler de servidores web
+42|Alquiler de software
+42|Alquiler de software de aplicaciones
+42|Alquiler de software informático
+42|Alquiler de software para acceso a la Internet
+42|Alquiler de software y programas de computadora
+42|Alquiler y mantenimiento de software informático
+42|Alquiles de aparatos de medición
+42|Análisis de amenazas de seguridad informática para proteger datos
+42|Análisis de filtros
+42|Análisis de funcionamiento de aparatos e instrumentos
+42|Análisis de la calidad de agua de corrientes
+42|Análisis de sistemas informáticos
+42|Análisis de yacimientos petrolíferos
+42|Análisis del modo de acción de combinaciones químicas sobre animales
+42|Análisis estructural y funcional de genomas
+42|Análisis para la investigación petrolera
+42|Análisis químico
+42|Arrendamiento de computadores relativos a seguridad computacional y prevención de riesgos computacionales
+42|Arrendamiento de hardware y software
+42|Asesoramiento en arquitectura
+42|Asesoramiento en el campo del diseño de software
+42|Asesoramiento técnico en materia de detección de polución
+42|Asesoramiento técnico relativo a la operación de computadoras
+42|Asesoría en química
+42|Auditorías en materia de energía
+42|Autenticación de antigüedades
+42|Autenticación de diamantes
+42|Autenticación de gemas
+42|Autenticación de joyas
+42|Autenticación de obras de arte
+42|Autentificación de billetes de banco
+42|Autentificación de gemas semipreciosas
+42|Clasificación de minerales
+42|Compresión digital de datos informáticos
+42|Comprobación de aparatos en el campo de la ingeniería eléctrica
+42|Comprobación de equipos informáticos
+42|Comprobación de materiales en bruto
+42|Comprobación de pozos petroleros
+42|Comprobación o investigación sobre electricidad
+42|Comprobación o investigación sobre ingeniería civil
+42|Comprobación o investigación sobre máquinas, aparatos e instrumentos
+42|Comprobación y análisis de materiales
+42|Comprobación y evaluación de materiales
+42|Comprobación, inspección o investigación de farmacéuticos, cosméticos y alimentos
+42|Conducción de sondeos geológicos
+42|Construcción y mantenimiento de sitios web
+42|Consultas técnicas en materia de ingeniería aeroespacial
+42|Consultoría astronómica
+42|Consultoría de programas de ordenador
+42|Consultoría en ingeniería de telecomunicaciones
+42|Consultoría en materia de arquitectura
+42|Consultoría en programación de computadoras
+42|Consultoría en redes computacionales y aplicaciones en la nube
+42|Consultoría en seguridad informática
+42|Consultoría en software
+42|Consultoría en software informático
+42|Consultoría en tecnologías de la información
+42|Consultoría relativa a el diseño de hardware computacional
+42|Consultoría respecto al diseño de páginas web
+42|Consultoría técnica en el campo de la ciencia ambiental
+42|Consultoría técnica en materia de la ingeniería ambiental
+42|Consultoría técnica en relación a la investigación técnica en el campo de alimentos y bebidas
+42|Consultoría técnica en relación a servicios de investigación en relación a suplementos de alimenticios y dietéticos
+42|Consultoría tecnológica en el ámbito de la inteligencia artificial
+42|Control de calidad de productos
+42|Control de calidad de productos y servicios
+42|Control de calidad para terceros
+42|Conversión de datos de información electrónica
+42|Conversión de datos de programas computacionales, no física
+42|Conversión multiplataforma de contenido digital a otras formas de contenido digital
+42|Copiado de software informático
+42|Creación de páginas de inicio para redes computacionales
+42|Creación de páginas web para otros
+42|Creación de programas de control para la medición automática, el ensamblaje, el ajuste y la visualización relacionada con los mismos
+42|Creación de programas informáticos
+42|Creación de sitios web en Internet
+42|Creación y diseño de páginas web para terceros
+42|Creación y mantenimiento de sitios web para terceros
+42|Creación y mantenimiento de software de blogs para terceros
+42|Creación, diseño y desarrollo y mantenimiento de sitios web para terceros
+42|Creación, diseño y mantenimiento de sitios web para terceros
+42|Cribado de ADN para investigaciones científicas
+42|Decoración de interiores
+42|Depuración de programas informáticos para terceros
+42|Desarrollo de equipos de hardware
+42|Desarrollo de hardware informático para juegos de computadora
+42|Desarrollo de preparaciones farmacéuticas y medicamentos
+42|Desarrollo de productos farmacéuticos
+42|Desarrollo de productos para terceros
+42|Desarrollo de programas informáticos grabados en medios de datos (software) diseñados para su uso en la construcción y la fabricación automática CAD/CAM
+42|Desarrollo de programas informáticos para sistemas de cajas registradoras electrónicas
+42|Desarrollo de programas para el procesamiento de datos para terceros
+42|Desarrollo de programas para simular experimentos o series de experimentos en un laboratorio óptico virtual
+42|Desarrollo de sitios web para terceros
+42|Desarrollo de software de controladores y sistemas operativos
+42|Desarrollo de software informático
+42|Desarrollo de software para operaciones de redes seguras
+42|Desarrollo de tecnologías para la fabricación de circuitos para la comunicación inalámbrica, el tratamiento electrónico de datos, la electrónica de consumo y la electrónica de automóviles
+42|Desarrollo y actualización de software informático
+42|Desarrollo y comprobación de métodos de producción química
+42|Desarrollo y creación de programas informáticos para el procesamiento de datos
+42|Desarrollo y diseño de portadoras digitales de imagen y sonido
+42|Desarrollo, diseño y actualización de páginas web
+42|Desarrollo, mantenimiento y actualización de un motor de búsqueda de una red de telecomunicaciones
+42|Diagrafía de sondeo
+42|Dibujo de diseños de embalajes, recipientes, vajillas y utensilios de mesa
+42|Digitalización de documentos (escaneado)
+42|Diseño arquitectónico
+42|Diseño de aparatos e instrumentos mecánicos, electromecánicos y optoelectrónicos
+42|Diseño de aparatos y equipo de telecomunicaciones
+42|Diseño de aparatos y máquinas con una finalidad de relleno
+42|Diseño de aparatos y máquinas en el ámbito del rellenado
+42|Diseño de artes gráficas
+42|Diseño de aviones
+42|Diseño de bases de datos informáticas
+42|Diseño de componentes mecánicos y micromecánicos
+42|Diseño de componentes ópticos y microópticos
+42|Diseño de computadoras
+42|Diseño de estudios sobre yacimientos petrolíferos
+42|Diseño de hardware y software
+42|Diseño de herramientas
+42|Diseño de iluminación escénica
+42|Diseño de iluminación paisajística
+42|Diseño de ilustraciones
+42|Diseño de interiores para tiendas comerciales
+42|Diseño de levantamientos topográficos
+42|Diseño de máquinas, aparatos e instrumentos incluidas sus partes o sistemas compuestos de tales máquinas, aparatos e instrumentos
+42|Diseño de materiales para embalaje y envoltura
+42|Diseño de moda
+42|Diseño de ordenadores para terceros
+42|Diseño de ordenadores y software informático para análisis comercial y elaboración de informes
+42|Diseño de páginas web
+42|Diseño de programas y software informático en relación a aeronaves
+42|Diseño de prótesis
+42|Diseño de redes informáticas para terceros
+42|Diseño de salas de exposiciones
+42|Diseño de sitios web
+42|Diseño de sitios web con fines publicitarios
+42|Diseño de software
+42|Diseño de software informático para el control de terminales de autoservicio
+42|Diseño de software informático para terceros
+42|Diseño de software informático, páginas y sitios web
+42|Diseño de software para teléfonos inteligentes
+42|Diseño de software para tratamiento de imágenes
+42|Diseño de teléfonos
+42|Diseño de teléfonos móviles
+42|Diseño escenográfico para compañías de teatro
+42|Diseño gráfico
+42|Diseño gráfico asistido por computadora
+42|Diseño gráfico de logotipos publicitarios
+42|Diseño industrial
+42|Diseño industrial y diseño gráfico
+42|Diseño y actualización de software informático
+42|Diseño y comprobación de nuevos productos para terceros
+42|Diseño y creación de sitios web para terceros
+42|Diseño y desarrollo (escritura) de software informático
+42|Diseño y desarrollo de bases de datos
+42|Diseño y desarrollo de computadoras y software informático
+42|Diseño y desarrollo de firmware informático
+42|Diseño y desarrollo de hardware informático
+42|Diseño y desarrollo de hardware para uso en la industria manufacturera
+42|Diseño y desarrollo de páginas web en la Internet
+42|Diseño y desarrollo de productos multimedia
+42|Diseño y desarrollo de redes de computación inalámbricos
+42|Diseño y desarrollo de sistemas de seguridad para datos electrónicos
+42|Diseño y desarrollo de sistemas fotovoltaicos
+42|Diseño y desarrollo de software de inicio de sesión único
+42|Diseño y desarrollo de software de juegos y software de realidad virtual
+42|Diseño y desarrollo de software en el ámbito de las aplicaciones para móviles
+42|Diseño y desarrollo de software informático
+42|Diseño y desarrollo de software operativo de red privada virtual (VPN)
+42|Diseño y mantenimiento de sitios informáticos para terceros
+42|Diseño y mantenimiento de sitios web para terceros
+42|Diseño, actualización y alquiler de software informático
+42|Diseño, creación, alojamiento y mantenimiento de sitios de Internet para terceros
+42|Diseño, desarrollo y aplicación de software informático
+42|Diseño, desarrollo, instalación y mantenimiento de software informático
+42|Diseño, instalación, actualización y mantenimiento de software informático
+42|Diseño, mantenimiento, desarrollo y actualización de software informático
+42|Diseño, mejora y alquiler de software informático
+42|Diseño, planificación e ingeniería de estaciones de aire comprimido
+42|Diseños de páginas web informáticas
+42|Duplicación de programas informáticos
+42|Ejecución de análisis químicos
+42|Elaboración de bases de datos informáticas
+42|Elaboración de planos para la construcción
+42|Elaboración y mantenimiento de sitios web para terceros
+42|Ensayo de la funcionalidad de máquinas
+42|Ensayo de materiales
+42|Ensayo de productos químicos
+42|Ensayo de seguridad de productos
+42|Ensayo de software
+42|Ensayo de textiles
+42|Ensayos clínicos de productos farmacéuticos
+42|Ensayos de cosméticos
+42|Ensayos de hardware
+42|Escritura de programas de procesamiento de datos
+42|Escritura y actualización de programas informáticos
+42|Estudios topográficos e ingeniería
+42|Evaluación de la calidad de la lana
+42|Evaluación de la calidad de la madera en pie
+42|Evaluación de la calidad del producto
+42|Evaluación de productos farmacéuticos
+42|Exploración de gas
+42|Exploración geofísica para la industria de la minería
+42|Exploración geofísica para la industria del gas
+42|Exploración geofísica para la industria del petróleo
+42|Exploración submarina
+42|Exploración y búsqueda de petróleo y de gas
+42|Facilitación de información climática
+42|Facilitación de información médica y científica en materia de productos farmacéuticos y ensayos clínicos
+42|Facilitación de información meteorológica
+42|Facilitación de motores de búsqueda en la Internet
+42|Facilitación de motores de búsqueda para Internet
+42|Facilitación de uso temporal de software en línea no descargable
+42|Facilitación de uso temporal de software no descargable
+42|Facilitación del uso temporal de herramientas de desarrollo de software no descargable en línea
+42|Geodesia topográfica
+42|Información sobre recursos de investigación en el campo de la genética de plantas
+42|Informes meteorológicos
+42|Ingeniería en control de olores
+42|Inspección de campos petroleros
+42|Inspección técnica de vehículos
+42|Instalación de programas informáticos
+42|Instalación y mantenimiento de software informático
+42|Instalación, mantenimiento y reparación de software informático
+42|Instalación, mantenimiento y reparación de software para sistemas informáticos
+42|Instalación, reparación y mantenimiento de software informático
+42|Investigación agrícola
+42|Investigación alimentaria
+42|Investigación arquitectónica
+42|Investigación bacteriológica
+42|Investigación básica y clínica en el ámbito de la ciencia y la medicina respiratorias
+42|Investigación biológica
+42|Investigación científica con fines médicos en oncología
+42|Investigación científica en el campo de la genética y la ingeniería genética
+42|Investigación científica integrada en materia de animales dañinos en invernaderos y cultivos
+42|Investigación en el área de la tecnología de procesamiento de semiconductores
+42|Investigación en el campo de la energía
+42|Investigación en física
+42|Investigación en la reducción de emisiones de carbón
+42|Investigación en materia de cambio climático
+42|Investigación en materia de cuidado del cabello
+42|Investigación en materia de física
+42|Investigación en materia de productos farmacéuticos
+42|Investigación en materia de protección ambiental
+42|Investigación en materia de química
+42|Investigación en materia de soldadura
+42|Investigación en relación con la ingeniería mecánica
+42|Investigación geológica
+42|Investigación hidrológica
+42|Investigación mecánica en deportes de motor
+42|Investigación médica
+42|Investigación relacionada con la química
+42|Investigación relativa a la biotecnología
+42|Investigación sobre alimentos
+42|Investigación sobre células madre
+42|Investigación sobre construcción de edificios o urbanismo
+42|Investigación técnica en el campo de la aeronáutica
+42|Investigación y análisis químico, bioquímico, biológico y bacteriológico
+42|Investigación y desarrollo científico
+42|Investigación y desarrollo de nuevos productos
+42|Investigación y desarrollo de nuevos productos para terceros en materiales plásticos
+42|Investigación y desarrollo de software informático
+42|Investigación y desarrollo de vacunas y medicamentos
+42|Investigación y desarrollo farmacéutico
+42|Investigación y pruebas de prevención de contaminación
+42|Investigación, desarrollo, diseño y mejora de software informático
+42|Investigación, inspección y pruebas en agricultura, reproducción de ganado y pesca
+42|Investigaciones científicas
+42|Investigaciones científicas con fines médicos
+42|Investigaciones geológicas
+42|Localización y reparación de problemas de software (asistencia técnica)
+42|Mantenimiento de páginas web y alojamiento de servicios web online para terceros
+42|Mantenimiento de software
+42|Mantenimiento de software informático en relación a seguridad informática y prevención de riegos informáticos
+42|Mantenimiento de software para acceso a la Internet
+42|Mantenimiento de software para su uso en el funcionamiento de aparatos y máquinas de llenado
+42|Mantenimiento y actualización de software informático
+42|Mantenimiento y mejora de software informático
+42|Mantenimiento y modernización de software
+42|Marcado de agua digital
+42|Medición y análisis de emisiones de gases de efecto invernadero
+42|Mejora de software
+42|Muestreo de suelos para análisis
+42|Peritaje marítimo, aéreo y terrestre
+42|Peritajes (trabajos de ingenieros)
+42|Peritajes de yacimientos petrolíferos
+42|Peritajes técnicos
+42|Planificación urbana
+42|Planificación y diseño de cocinas
+42|Preparación, actualización, instalación y mantenimiento de software informático
+42|Programación de aplicaciones multimedia
+42|Programación de computadoras
+42|Programación de computadoras en materia médica
+42|Programación de computadoras y alquiler de programas de computo
+42|Programación de computadoras y análisis de sistemas de computo
+42|Programación de computadoras y diseño de software
+42|Programación de computadoras y mantenimiento de programas de computo
+42|Programación de equipos multimedia
+42|Programación de juegos de ordenador
+42|Programación de videojuegos
+42|Pronósticos meteorológicos
+42|Proporcionar el uso temporal de software de inicio de sesión único no descargable en línea
+42|Prospección geológica
+42|Prospección petrolífera
+42|Provisión de información científica en el campo del cambio climático y calentamiento global
+42|Provisión de información en el campo del diseño de interiores a través de páginas web
+42|Provisión de información tecnológica sobre innovaciones amigables con el medio ambiente
+42|Provisión de servicios de autenticación de usuarios utilizando hardware biométrico y tecnología de software para transacciones de comercio electrónico
+42|Prueba de ordenadores
+42|Pruebas de elementos de ferretería arquitectónica
+42|Pruebas de seguridad de productos de consumo
+42|Realización de evaluaciones tempranas en relación con productos farmacéuticos nuevos
+42|Realización de peritajes de ingeniería
+42|Reconstitución de bases de datos
+42|Recuperación de datos de teléfonos inteligentes
+42|Recuperación de datos informáticos
+42|Redacción de planos de construcción para locales recreativos
+42|Redacción de sitios electrónicos
+42|Reparación de software (mantenimiento y actualización)
+42|Servicios arquitectónicos
+42|Servicios biológicos de clonación
+42|Servicios científicos consistentes en el desarrollo para terceros de químicos y sustancias químicas biobasadas
+42|Servicios de actualización de software informático
+42|Servicios de almacenamiento en la nube para archivos electrónicos
+42|Servicios de almacenamiento en la nube para datos electrónicos
+42|Servicios de alquiler de computadoras
+42|Servicios de alquiler en relación a equipos de procesamiento de datos y computadoras
+42|Servicios de análisis de monedas (autentificación)
+42|Servicios de análisis para la exploración de campos petroleros
+42|Servicios de análisis químico
+42|Servicios de análisis sísmicos
+42|Servicios de arquitectura e ingeniería
+42|Servicios de asesoramiento en materia de desarrollo y mejora de la calidad del software
+42|Servicios de asesoramiento tecnológico relacionados con programas informáticos
+42|Servicios de asesoramiento tecnológico relativo a análisis de ingeniería de máquinas
+42|Servicios de autenticación de firma electrónica
+42|Servicios de autenticación de usuarios con tecnología de inicio de sesión para aplicaciones de software en línea
+42|Servicios de calibrado
+42|Servicios de cartografía
+42|Servicios de certificación (control de calidad)
+42|Servicios de cifrado de datos
+42|Servicios de cifrado y descodificación de datos
+42|Servicios de clasificación de estados de conservación de monedas
+42|Servicios de configuración de redes informáticas
+42|Servicios de consultoría en diseño de modas
+42|Servicios de consultoría en el ámbito del desarrollo tecnológico
+42|Servicios de consultoría profesional y asesoramiento sobre química agrícola
+42|Servicios de consultoría técnica en el área de la minería
+42|Servicios de consultoría tecnológica en el campo de la generación de energía alternativa
+42|Servicios de control de la calidad del agua
+42|Servicios de copias de seguridad de datos
+42|Servicios de cultivo de células con fines científicos o de investigación, para terceros
+42|Servicios de desarrollo de fármacos
+42|Servicios de desarrollo de videojuegos
+42|Servicios de descifrado de datos
+42|Servicios de dibujo de ingeniería civil
+42|Servicios de dibujo técnico
+42|Servicios de diseñadores de embalajes
+42|Servicios de diseño de animación para otros
+42|Servicios de diseño de calzado
+42|Servicios de diseño de closets
+42|Servicios de diseño de distribución para entornos de salas limpias
+42|Servicios de diseño de embalajes
+42|Servicios de diseño de gráficos computacionales
+42|Servicios de diseño de moda
+42|Servicios de diseño de ordenadores
+42|Servicios de diseño industrial
+42|Servicios de diseño relativos a sistemas de ordenadores
+42|Servicios de diseño técnico
+42|Servicios de enología
+42|Servicios de ensayo e inspección ambientales
+42|Servicios de escaneo de ultrasonido, no médicos
+42|Servicios de exploración de minerales
+42|Servicios de fotogrametría
+42|Servicios de hospedaje de sitios web
+42|Servicios de ilustración gráfica para terceros
+42|Servicios de información del clima
+42|Servicios de inspección de tuberías
+42|Servicios de inspección de vehículos nuevos y usados por cuenta de compradores o vendedores particulares de vehículos
+42|Servicios de inspección estructural subacuática
+42|Servicios de integración de sistemas informáticos
+42|Servicios de investigación agroquímica
+42|Servicios de investigación biomédica
+42|Servicios de investigación de laboratorio relacionada con productos farmacéuticos
+42|Servicios de investigación farmacéutica
+42|Servicios de investigación médica
+42|Servicios de investigación y desarrollo en física
+42|Servicios de laboratorios científicos
+42|Servicios de mantenimiento de software informático
+42|Servicios de migración de datos
+42|Servicios de programación informática para análisis comercial y elaboración de informes
+42|Servicios de protección antivirus (informática)
+42|Servicios de protección antivirus a distancia para teléfonos inalámbricos y aparatos móviles y de comunicación
+42|Servicios de pruebas de programas informáticos
+42|Servicios de reproducción de programas informáticos
+42|Servicios de topografía aérea
+42|Servicios de topografía marina
+42|Sondeos topográficos
+42|Topografía técnica
+42|Trabajo y evaluación de análisis químicos
+42|Trabajo y evaluación de síntesis químicas
+42|Transferencia de datos de documentos desde un formato informático a otro

--- a/lib/seeds/class_43_terms.csv
+++ b/lib/seeds/class_43_terms.csv
@@ -1,45 +1,114 @@
-class,reference_id,name
-43,430004,servicios de agencias de alojamiento [hoteles, pensiones]
-43,430010,servicios de catering
-43,430010,servicios de banquetes
-43,430010,servicios de bebidas y comidas preparadas
-43,430013,servicios de residencias para la tercera edad
-43,430024,servicios de cafés
-43,430025,servicios de cafeterías
-43,430026,explotación de campings
-43,430027,servicios de comedores
-43,430028,alquiler de alojamiento temporal
-43,430066,servicios de pensiones
-43,430071,servicios de casas de vacaciones
-43,430073,servicios hoteleros
-43,430098,servicios de guarderías infantiles
-43,430102,servicios de restaurantes
-43,430104,reserva de pensiones
-43,430105,reserva de hoteles
-43,430107,servicios de restaurantes de autoservicio
-43,430108,servicios de bares de comida rápida
-43,430134,servicios de residencias para animales
-43,430138,servicios de bar
-43,430145,servicios de campamentos de vacaciones [hospedaje]
-43,430160,alquiler de construcciones transportables*
-43,430162,reserva de alojamiento temporal
-43,430183,servicios de motel
-43,430186,alquiler de sillas, mesas, mantelería y cristalería
-43,430187,alquiler de salas de reunión
-43,430189,alquiler de tiendas de campaña
-43,430189,alquiler de carpas
-43,430190,alquiler de aparatos de cocción
-43,430190,alquiler de aparatos para cocinar
-43,430191,alquiler de dispensadores de agua potable
-43,430192,alquiler de equipos de iluminación*
-43,430193,escultura de alimentos
-43,430194,servicios de recepción para alojamiento temporal [gestión de llegadas y salidas]
-43,430195,servicios de restaurante washoku
-43,430196,servicios de restaurantes de fideos udon y fideos soba
-43,430197,decoración de alimentos
-43,430198,decoración de pasteles
-43,430199,información y asesoramiento en materia de preparación de comidas
-43,430200,servicios de chefs de cocina a domicilio
-43,430201,servicios de bares de shisha
-43,430201,servicios de bares de narguile
-43,430201,servicios de bares de hookah
+class|name
+43|Alojamiento temporal en casas
+43|Alojamientos para animales de compañía
+43|Alquiler de almohadas
+43|Alquiler de alojamiento temporal
+43|Alquiler de cafeteras
+43|Alquiler de calentadores de vajilla
+43|Alquiler de calientaplatos
+43|Alquiler de camas
+43|Alquiler de cocinas (fogones) para cocinar
+43|Alquiler de construcciones modulares portátiles
+43|Alquiler de construcciones transportables*
+43|Alquiler de cortinas para hoteles
+43|Alquiler de dispensadores de agua
+43|Alquiler de edredones
+43|Alquiler de encimeras de cocina
+43|Alquiler de encimeras de cocina destinadas a preparar comidas de consumo inmediato
+43|Alquiler de equipos de cocina para uso industrial
+43|Alquiler de fregaderos de cocina para uso comercial
+43|Alquiler de fregaderos de cocina para uso doméstico
+43|Alquiler de fuentes de chocolate
+43|Alquiler de fuentes dispensadoras de bebidas
+43|Alquiler de futones
+43|Alquiler de hornos microondas para uso doméstico
+43|Alquiler de mantas
+43|Alquiler de mantelería
+43|Alquiler de máquinas y aparatos para la preparación de alimentos y bebidas
+43|Alquiler de mobiliario
+43|Alquiler de muebles para hoteles
+43|Alquiler de placas calentadoras eléctricas para uso doméstico
+43|Alquiler de platos
+43|Alquiler de salas de reunión
+43|Alquiler de salones para eventos sociales
+43|Alquiler de sillas y mesas
+43|Alquiler de tiendas de campaña
+43|Alquiler de tostadoras eléctricas para uso doméstico
+43|Alquiler de vajilla
+43|Arrendamiento de cocinas no eléctricas
+43|Arrendamiento de máquinas dispensadoras de bebidas
+43|Asesoría en materia de recetas de cocina
+43|Bar de zumos
+43|Cafés-restaurantes
+43|Casas de vacaciones
+43|Explotación de campings
+43|Facilitación de información relacionada con bares
+43|Facilitación de instalaciones de exposición
+43|Facilitación de instalaciones para conferencias
+43|Facilitación de instalaciones para convenciones
+43|Facilitación de instalaciones para exposiciones
+43|Facilitación de salas de conferencia
+43|Heladerías
+43|Hostales
+43|Organización de alojamientos temporales
+43|Pensiones
+43|Pensiones para caballos
+43|Pizzerías
+43|Posadas para turistas
+43|Preparación de alimentos
+43|Preparación de alimentos y bebidas
+43|Provisión de albergue temporal en campamentos de vacaciones
+43|Provisión de centros de cuidado de niños
+43|Provisión de instalaciones para ceremonias de matrimonio
+43|Provisión de instalaciones para conferencias, exhibiciones y reuniones
+43|Pubs
+43|Reserva de alojamiento en camping
+43|Reserva de alojamiento en hoteles
+43|Reserva de alojamientos temporales
+43|Reserva de alojamientos temporales por Internet
+43|Reservaciones de hotel para terceros
+43|Residencias para animales
+43|Residencias para la tercera edad
+43|Restaurantes de autoservicio
+43|Restaurantes de comida rápida
+43|Salones de té
+43|Servicios de agencia de reserva de alojamiento temporal
+43|Servicios de agencia de reservas de alojamiento en hotel
+43|Servicios de albergues juveniles
+43|Servicios de alojamiento en complejos turísticos
+43|Servicios de alojamiento en hoteles
+43|Servicios de alojamiento públicos
+43|Servicios de bar
+43|Servicios de braserías
+43|Servicios de catering
+43|Servicios de catering al aire libre
+43|Servicios de catering destinados a residencias de ancianos
+43|Servicios de catering móvil
+43|Servicios de catering para comedores de empresas
+43|Servicios de catering para escuelas
+43|Servicios de catering para hospitales
+43|Servicios de catering para hoteles
+43|Servicios de catering para residencias con asistencia médica
+43|Servicios de comedor
+43|Servicios de guarderías infantiles
+43|Servicios de hotel para animales de compañía
+43|Servicios de información de restaurantes
+43|Servicios de motel
+43|Servicios de provisión de alojamiento para huéspedes
+43|Servicios de provisión de café para oficinas (provisión de bebidas)
+43|Servicios de refugios de emergencia (suministro de vivienda temporal)
+43|Servicios de reserva en restaurantes
+43|Servicios de restaurante
+43|Servicios de restaurante de sushi
+43|Servicios de restaurante y catering
+43|Servicios de restaurante y hotel
+43|Servicios de restaurantes de comida japonesa
+43|Servicios de restaurantes de comida para llevar
+43|Servicios de restaurantes de tempura
+43|Servicios de restaurantes móviles
+43|Servicios de salón de café
+43|Servicios de salón de cóctel
+43|Servicios de snack-bar
+43|Servicios de tabernas
+43|Suministro de información hotelera a través de sitios web
+43|Suministro de información sobre cocina a través de sitios web

--- a/lib/seeds/class_44_terms.csv
+++ b/lib/seeds/class_44_terms.csv
@@ -1,96 +1,349 @@
-class,reference_id,name
-44,440009,cría de animales
-44,440012,servicios de jardineros paisajistas
-44,440018,servicios de baños públicos con fines higiénicos
-44,440019,servicios de baños turcos
-44,440020,servicios de salones de belleza
-44,440021,servicios de clínicas médicas
-44,440032,quiropráctica
-44,440034,servicios de peluquería
-44,440037,confección de coronas [arte floral]
-44,440043,servicios de casas de convalecencia
-44,440059,servicios hospitalarios
-44,440060,servicios de salud
-44,440072,horticultura
-44,440077,jardinería
-44,440084,alquiler de material para explotaciones agrícolas
-44,440084,alquiler de equipos agrícolas
-44,440086,masajes
-44,440087,asistencia médica
-44,440092,servicios de ópticos
-44,440094,servicios de viveros
-44,440097,fisioterapia
-44,440097,terapia física
-44,440106,servicios de sanatorios
-44,440111,asistencia veterinaria
-44,440113,servicios de odontología
-44,440114,servicios de residencias con asistencia médica
-44,440115,pulverización aérea o terrestre de fertilizantes y otros productos químicos para uso agrícola
-44,440131,aseo de animales
-44,440133,servicios de bancos de sangre
-44,440143,arreglos florales
-44,440147,servicios de hospicios [casas de asistencia]
-44,440148,mantenimiento del césped
-44,440148,mantenimiento del pasto
-44,440151,servicios de manicura
-44,440152,servicios de comadronas
-44,440152,servicios de parteras
-44,440153,servicios de enfermeros
-44,440154,asesoramiento en materia de farmacia
-44,440156,cirugía estética
-44,440156,cirugía plástica
-44,440166,cirugía arbórea
-44,440168,exterminación de animales dañinos para la agricultura, la acuicultura, la horticultura y la silvicultura
-44,440171,eliminación de malas hierbas
-44,440173,servicios de aseo para animales domésticos
-44,440180,implantación de cabello
-44,440185,servicios de psicólogos
-44,440188,alquiler de instalaciones sanitarias
-44,440193,servicios de aromaterapia
-44,440194,servicios de inseminación artificial
-44,440195,servicios de desintoxicación para toxicómanos
-44,440195,rehabilitación de toxicómanos
-44,440196,servicios de fecundación in vitro
-44,440197,servicios de tatuaje
-44,440198,servicios de telemedicina
-44,440199,diseño de parques y jardines [paisajismo]
-44,440199,paisajismo [diseño de parques y jardines]
-44,440200,servicios de sauna
-44,440201,servicios de solárium
-44,440201,servicios de bronceado artificial
-44,440202,servicios de estaciones termales
-44,440202,servicios de spa
-44,440203,servicios de estilistas [visagistas]
-44,440203,servicios de visagistas
-44,440204,preparación de recetas médicas por farmacéuticos
-44,440205,servicios terapéuticos
-44,440206,plantación de árboles para compensar las emisiones de carbono [sumideros de carbono]
-44,440207,servicios de acuicultura
-44,440208,alquiler de equipos médicos
-44,440209,servicios de centros de salud
-44,440209,servicios de dispensarios médicos
-44,440210,servicios de medicina alternativa
-44,440211,logopedia
-44,440211,servicios de ortofonía
-44,440212,asesoramiento sobre la salud
-44,440213,depilación con cera
-44,440214,servicios de ortodoncia
-44,440215,asesoramiento médico para personas con discapacidad
-44,440216,perforación corporal
-44,440217,servicios de reforestación
-44,440218,servicios de cuidados paliativos
-44,440219,servicios de casas de reposo
-44,440220,servicios de control de plagas para la agricultura, la acuicultura, la horticultura y la silvicultura
-44,440221,servicios de bancos de tejidos humanos
-44,440222,alquiler de animales para pastar
-44,440223,alquiler de colmenas
-44,440224,terapia asistida con animales [zooterapia]
-44,440225,servicios de análisis médicos prestados por laboratorios médicos con fines diagnósticos y terapéuticos
-44,440226,exploración médica
-44,440227,servicios de viticultura
-44,440228,consultoría en el ámbito de la viticultura
-44,440229,servicios de cuidados de enfermería a domicilio
-44,440230,alquiler de aparatos de peinado
-44,440231,cultivo de plantas
-44,440232,alquiler de robots quirúrgicos
-44,440233,asesoramiento sobre dietética y nutrición
+class|name
+44|Abono aéreo de fertilizantes
+44|Acupuntura
+44|Adaptación de lentes de contacto
+44|Ajuste a dispositivos ortopédicos
+44|Ajuste de dispositivos protésicos
+44|Alquiler de aparatos de diagnóstico por ultrasonido
+44|Alquiler de aparatos de rayos X para uso médico
+44|Alquiler de aparatos e instrumentos médicos
+44|Alquiler de arreglos florales
+44|Alquiler de baños portátiles para eventos
+44|Alquiler de camas especialmente hechas para tratamientos médicos
+44|Alquiler de cortadoras de césped
+44|Alquiler de equipo para uso médico
+44|Alquiler de equipos para recortar el césped
+44|Alquiler de maquinaria de pulverización agrícola
+44|Alquiler de máquinas y aparatos para uso en salones de belleza o barberías
+44|Alquiler de máquinas y aparatos para uso médico
+44|Alquiler de material agrícola
+44|Alquiler de material para explotaciones agrícolas
+44|Alquiler de plantas en tiesto
+44|Alquiler de robots quirúrgicos
+44|Análisis del comportamiento con una finalidad médica
+44|Análisis médicos para el diagnóstico y tratamiento de personas
+44|Aplicación de extensiones de cabello tipo cortina
+44|Asesoramiento en cuidados capilares
+44|Asesoramiento en materia de masajes
+44|Asesoramiento en nutrición
+44|Asesoramiento médico para perder peso
+44|Asesoramiento psicológico
+44|Asesoramiento técnico en materia de alimentación y cría de peces, camarones y otras especies cultivadas
+44|Asistencia de enfermería a domicilio
+44|Asistencia médica ambulatoria
+44|Atención médica
+44|Atención psicológica
+44|Bancos de sangre
+44|Barberías
+44|Casas de convalecencia
+44|Casas de reposo
+44|Cirugía láser para la vista
+44|Cirugía veterinaria
+44|Clínica dental odontológica
+44|Clínicas médicas
+44|Consultoría en asistencia médica provista por doctores y personal médico especializado
+44|Consultoría en exámenes auditivos
+44|Consultoría en materia de horticultura
+44|Consultoría en materia de salud
+44|Consultoría médica
+44|Consultoría psicológica
+44|Consultoría y asesoramiento en materia de estética
+44|Control de malas hierbas
+44|Cosecha de cultivos para terceros
+44|Cría de animales
+44|Cría y cubrición de animales
+44|Cría y reproducción de ganado
+44|Cribado de ADN para fines médicos
+44|Cuidado de jardines y lechos de flores
+44|Cuidado y aseo de animales
+44|Cuidados de belleza
+44|Cuidados de higiene para personas
+44|Cuidados de higiene y belleza
+44|Cuidados estéticos de los pies
+44|Cuidados médicos de los pies
+44|Cuidados médicos, higiénicos y de belleza
+44|Cultivo de plantas para terceros
+44|Diagnóstico de enfermedades
+44|Diseño de parques y jardines (paisajismo)
+44|Eliminación de malas hierbas
+44|Evaluación de personalidad con fines psicológicos
+44|Evaluaciones y exámenes psicológicos
+44|Exámenes de rayos X para uso médico
+44|Exámenes ginecológicos de PAP
+44|Exámenes vasculares
+44|Exterminación de animales dañinos para la agricultura, horticultura o silvicultura
+44|Facilitación de información médica
+44|Facilitación de instalaciones de baños turcos
+44|Facilitación de servicios a programas de pérdida de peso
+44|Fonoaudiología
+44|Fumigación de productos fitosanitarios para fines agrícolas
+44|Gestión de servicios de asistencia sanitaria
+44|Hidroterapia
+44|Horticultura
+44|Hospicios (casas de asistencia)
+44|Implantación de cabello
+44|Información a pacientes en administración de medicamentos
+44|Información de identificación de plantas y flores para horticultura
+44|Información en relación con masajes
+44|Información médica
+44|Inseminación artificial de animales
+44|Limpieza facial (servicios cosméticos)
+44|Marcado de animales
+44|Masaje y masaje shiatsu terapéutico
+44|Masajes
+44|Masajes con piedras de calor
+44|Moxibustión
+44|Odontología estética
+44|Odontología veterinaria
+44|Orientación dietética y nutricional
+44|Orientación médica en materia de estrés
+44|Paisajismo para terceros
+44|Prestación de información relativa al tratamiento de enfermedades cardiovasculares y cerebrovascular
+44|Protetización
+44|Provisión de baños públicos
+44|Provisión de baños públicos con fines sanitarios
+44|Provisión de instalaciones de rehabilitación física
+44|Provisión de instalaciones de rehabilitación mental
+44|Pruebas (análisis) genéticos para uso médico
+44|Pruebas genéticas de animales
+44|Pruebas psicológicas
+44|Pruebas psiquiátricas
+44|Pulverización de insecticidas para la agricultura
+44|Pulverización de insecticidas para uso hortícola
+44|Pulverización terrestre de fertilizantes
+44|Quiropráctica
+44|Recolección y conservación de sangre humana
+44|Rehabilitación de pacientes adictos al alcohol
+44|Rehabilitación de pacientes drogadictos
+44|Restauración de hábitats forestales
+44|Salones de belleza
+44|Salones de belleza para corte de pelucas
+44|Salones de peluquería
+44|Salones de tatuaje
+44|Salones para el cuidado de la piel
+44|Saunas
+44|Screening (cribado) médico
+44|Screening (cribado) médico relacionado con el corazón
+44|Sembrado de árboles para jardines
+44|Servicios cosméticos para el cuidado del cuerpo
+44|Servicios de aclarado (decoloración) del cabello
+44|Servicios de acupuntura
+44|Servicios de ajuste de lentes (gafas)
+44|Servicios de análisis médico para el diagnostico de enfermedades y tratamiento médico de pacientes
+44|Servicios de análisis médicos en relación con el tratamiento de pacientes
+44|Servicios de análisis médicos en relación con el tratamiento de personas
+44|Servicios de análisis médicos para el diagnóstico del cáncer
+44|Servicios de apicultura
+44|Servicios de aplicación de maquillaje
+44|Servicios de aromaterapia
+44|Servicios de asesoramiento dietético
+44|Servicios de asesoramiento en lactancia
+44|Servicios de asesoramiento en materia de control de peso
+44|Servicios de asistencia médica
+44|Servicios de asistencia médica en residencias especialmente adaptadas para estos fines
+44|Servicios de atención geriátrica
+44|Servicios de banco de células cultivadas para trasplantes médicos
+44|Servicios de banco de células madre
+44|Servicios de banco de esperma
+44|Servicios de banco de ojos
+44|Servicios de bancos de sangre
+44|Servicios de barbero
+44|Servicios de blanqueado de dientes
+44|Servicios de borrado de tatuajes mediante láser
+44|Servicios de bronceado artificial
+44|Servicios de bronceado de la piel para personas con una finalidad cosmética.
+44|Servicios de cirugía cosmética
+44|Servicios de cirugía de visión por láser
+44|Servicios de cirugía dental
+44|Servicios de cirugía plástica
+44|Servicios de clínicas de salud
+44|Servicios de clínicas médicas móviles
+44|Servicios de consulta en línea o en persona sobre maquillaje
+44|Servicios de consulta en línea sobre maquillaje
+44|Servicios de consultas relacionadas con el cuidado de la salud
+44|Servicios de consultas relacionados con la belleza
+44|Servicios de consultoría médica provistos a pacientes
+44|Servicios de consultoría relacionados con la eliminación del vello corporal
+44|Servicios de consultoría sobre maquillaje
+44|Servicios de control de plagas para horticultura
+44|Servicios de corte de cabello
+44|Servicios de corte de césped
+44|Servicios de cosmetólogo
+44|Servicios de cría de ganado bovino
+44|Servicios de cría de gatos
+44|Servicios de cría de insectos
+44|Servicios de cría de ovejas
+44|Servicios de criaderos de caballos
+44|Servicios de crioterapia
+44|Servicios de cuidado corporal cosmético proporcionados por spas de salud
+44|Servicios de cuidado de la salud
+44|Servicios de cuidado de la salud ofrecidos a través de proveedores de cuidado de la salud en base a contratos
+44|Servicios de cuidado de las uñas
+44|Servicios de cuidado de plantas
+44|Servicios de cuidados de salud para el tratamiento del Alzheimer
+44|Servicios de cuidados higiénicos para mascotas
+44|Servicios de cultivo de huerta urbana para la agricultura
+44|Servicios de cultivos hidropónicos
+44|Servicios de depilación corporal por cera para el cuerpo humano
+44|Servicios de depilación corporal por cera para seres humanos
+44|Servicios de depilación personal
+44|Servicios de depilación por laser
+44|Servicios de depilación y reducción permanente del vello
+44|Servicios de desintoxicación para toxicómanos
+44|Servicios de diagnóstico por imagen de cáncer de próstata
+44|Servicios de diagnóstico psicológico
+44|Servicios de donación de esperma humano
+44|Servicios de enfermería pediátrica
+44|Servicios de enfermeros
+44|Servicios de estaciones termales para la salud y el bienestar del cuerpo y el espíritu
+44|Servicios de esteticista para animales
+44|Servicios de evaluación de la personalidad (servicios de salud mental)
+44|Servicios de evaluación médica para pacientes que reciben rehabilitación con el fin de orientar el tratamiento y evaluar su efectividad.
+44|Servicios de evaluaciones médicas en relación con la apnea del sueño
+44|Servicios de evaluaciones y exámenes psicológicos
+44|Servicios de examen de cáncer de cuello uterino
+44|Servicios de examen de cáncer de testículo
+44|Servicios de exámenes de cáncer intestinal
+44|Servicios de exámenes médicos
+44|Servicios de exámenes médicos en relación con el asma
+44|Servicios de exámenes oncológicos
+44|Servicios de farmacéuticos para elaborar recetas médicas
+44|Servicios de fecundación in vitro
+44|Servicios de fertilización in vitro para animales
+44|Servicios de flebotomía
+44|Servicios de ganadería
+44|Servicios de ginecología
+44|Servicios de higienistas dentales
+44|Servicios de información médica prestados por Internet
+44|Servicios de información médica provistos a través de redes mundiales de computación
+44|Servicios de información medica, a saber, información para pacientes y profesionales de la salud relacionada con condiciones médicas, tratamientos y productos farmacéuticos
+44|Servicios de información relativa al alquiler de maquinaria agrícola
+44|Servicios de información sobre quiropraxia
+44|Servicios de información veterinaria prestados por Internet
+44|Servicios de inseminación artificial
+44|Servicios de jardinería
+44|Servicios de jardinero y jardinería
+44|Servicios de jardineros paisajistas
+44|Servicios de kinesiología
+44|Servicios de laboratorio para la toma de muestras y exámenes médicos
+44|Servicios de limpieza dental
+44|Servicios de liposucción
+44|Servicios de lombricultura para la generación de compost
+44|Servicios de manicura
+44|Servicios de manicura a domicilio
+44|Servicios de masaje equino
+44|Servicios de masaje para embarazadas
+44|Servicios de masaje tailandés
+44|Servicios de masajes de pies
+44|Servicios de masajes para deportistas
+44|Servicios de masajes tradicionales japoneses
+44|Servicios de medicina alternativa
+44|Servicios de medicina deportiva
+44|Servicios de microdermoabrasión
+44|Servicios de micropigmentación
+44|Servicios de nutricionista
+44|Servicios de obstetricia
+44|Servicios de oftalmología
+44|Servicios de ondulado del cabello
+44|Servicios de ópticos
+44|Servicios de optometría
+44|Servicios de orientación psicológica en el ámbito de los deportes
+44|Servicios de ortofonía
+44|Servicios de pedicura
+44|Servicios de peinado del cabello
+44|Servicios de peluquería
+44|Servicios de peluquería femenina
+44|Servicios de peluquerías
+44|Servicios de peluquerías para hombres
+44|Servicios de planificación y supervisión nutricional de dietas para adelgazar
+44|Servicios de pruebas de mamografía
+44|Servicios de pruebas médicas para el diagnóstico y tratamiento de enfermedades
+44|Servicios de pruebas médicas, en concreto, evaluación del estado físico
+44|Servicios de pruebas psicológicas
+44|Servicios de psicoterapia
+44|Servicios de quimioterapia
+44|Servicios de quiropraxia para animales
+44|Servicios de reflexología
+44|Servicios de rizado permanente de pestañas
+44|Servicios de salón de belleza
+44|Servicios de salón de belleza para animales domésticos
+44|Servicios de salón de bronceado por pulverización
+44|Servicios de salón de peluquería para niños
+44|Servicios de salones de bronceado
+44|Servicios de sanatorio
+44|Servicios de sauna
+44|Servicios de sauna infrarrojos
+44|Servicios de sementales (monta)
+44|Servicios de sementales para ganado
+44|Servicios de solárium
+44|Servicios de tatuaje
+44|Servicios de tatuaje de animales de compañía para su identificación
+44|Servicios de telemedicina
+44|Servicios de terapia con células madre
+44|Servicios de terapia con ventosas
+44|Servicios de terapia contra el insomnio
+44|Servicios de terapia de quelación
+44|Servicios de terapia matrimonial (sicología)
+44|Servicios de terapia ocupacional
+44|Servicios de terapia ocupacional para la rehabilitación física de personas
+44|Servicios de terapias de reiki (terapias alternativas)
+44|Servicios de tinturado de cejas
+44|Servicios de tinturado de pestañas
+44|Servicios de tratamiento de belleza
+44|Servicios de tratamiento de fertilidad humana
+44|Servicios de tratamiento de las adicciones
+44|Servicios de tratamiento de pacientes hospitalizados y en régimen ambulatorio
+44|Servicios de tratamiento para dejar de fumar
+44|Servicios de trenzado de cabello
+44|Servicios de un psicólogo
+44|Servicios de unión de huesos
+44|Servicios de valoración psicológica
+44|Servicios ginecológicos
+44|Servicios hospitalarios
+44|Servicios hospitalarios para mascotas
+44|Servicios médicos
+44|Servicios médicos de terapia de moxibustión
+44|Servicios médicos en el campo de la diabetes
+44|Servicios médicos para el tratamiento del cáncer de piel
+44|Servicios médicos relacionados con la extracción, el tratamiento y la transformación de células humanas
+44|Servicios médicos relacionados con la extracción, el tratamiento y la transformación de células madre
+44|Servicios médicos relacionados con la extracción, el tratamiento y la transformación de sangre humana
+44|Servicios médicos, en concreto, fertilización in vitro
+44|Servicios móviles de cuidados dentales
+44|Servicios para el cuidado del cabello
+44|Servicios prestados por un dietista
+44|Servicios psiquiátricos
+44|Servicios quiroprácticos
+44|Servicios quiroprácticos móviles
+44|Servicios quiroprácticos para adultos
+44|Servicios quiroprácticos para niños
+44|Servicios quiroprácticos para personas con enfermedadescrónicas
+44|Servicios terapéuticos basados en sicología de atención plena (mindfulness)
+44|Servicios veterinarios
+44|Siembra agrícola por aire
+44|Siembra de cultivos
+44|Suministro de información de salud
+44|Suministro de información médica
+44|Suministro de información sobre acupuntura
+44|Suministro de información sobre instalaciones de baños públicos
+44|Suministro de información sobre la cría de animales
+44|Suministro de información sobre la eliminación de animales dañinos en la agricultura, horticultura y silvicultura
+44|Suministro de información sobre la plantación de árboles de jardín
+44|Suministro de información sobre masajes tradicionales japoneses
+44|Suministro de información sobre moxibustión
+44|Suministro de información sobre servicios de enfermería
+44|Terapia anti-tabaco
+44|Terapia de moxibustión
+44|Terapia de raspado (Gua Sha)
+44|Terapia física
+44|Terapia láser para el tratamiento de afecciones médicas
+44|Terapia musical para fines físicos, psicológicos y cognitivos
+44|Terapia para mejorar el habla y audición
+44|Tests psicológicos con fines médicos
+44|Tintado del cabello
+44|Tratamiento mediante láser para eliminar las venas varicosas
+44|Tratamiento médico o kinesiológico para la dislocación articular, esguinces, fracturas o similares (judo-seifuku)
+44|Tratamientos cosméticos de láser para la piel
+44|Tratamientos de desintoxicación para toxicómanos
+44|Tratamientos psicológicos
+44|Viveros de arboricultura

--- a/lib/seeds/class_45_terms.csv
+++ b/lib/seeds/class_45_terms.csv
@@ -1,86 +1,133 @@
-class,reference_id,name
-45,450001,servicios de guardaespaldas
-45,450001,servicios de protección de personas
-45,450002,acompañamiento en sociedad [personas de compañía]
-45,450002,servicios de chaperones
-45,450003,servicios de agencias de detectives
-45,450005,servicios de clubes de encuentro
-45,450005,servicios de citas
-45,450006,servicios de agencias de vigilancia nocturna
-45,450033,apertura de cerraduras
-45,450046,alquiler de trajes de noche
-45,450047,servicios de crematorio
-45,450053,servicios de investigación sobre personas desaparecidas
-45,450053,búsqueda de personas desaparecidas
-45,450056,servicios de inhumación
-45,450057,servicios funerarios
-45,450081,alquiler de prendas de vestir
-45,450099,servicios de guardias
-45,450112,servicios de agencias matrimoniales
-45,450117,consultoría sobre seguridad física
-45,450146,elaboración de horóscopos
-45,450179,servicios de extinción de incendios
-45,450179,servicios de lucha contra el fuego
-45,450184,organización de reuniones religiosas
-45,450193,servicios de agencias de adopción
-45,450194,inspección de alarmas antirrobo y de seguridad
-45,450195,cuidado de niños a domicilio
-45,450195,servicios de niñeras
-45,450196,control de seguridad de equipajes
-45,450197,cuidado de viviendas en ausencia de los dueños
-45,450198,cuidado de animales de compañía a domicilio
-45,450199,investigación de antecedentes personales
-45,450200,devolución de objetos perdidos
-45,450201,mediación
-45,450202,inspección de fábricas con fines de seguridad
-45,450203,alquiler de alarmas de incendio
-45,450204,alquiler de extintores
-45,450205,servicios de arbitraje
-45,450206,consultoría sobre propiedad intelectual
-45,450207,gestión de derechos de autor
-45,450208,concesión de licencias de propiedad intelectual
-45,450209,servicios de vigilancia de los derechos de propiedad intelectual con fines de asesoramiento jurídico
-45,450210,investigación jurídica
-45,450211,servicios de contenciosos
-45,450212,concesión de licencias de software [servicios jurídicos]
-45,450213,registro de nombres de dominio [servicios jurídicos]
-45,450214,servicios de solución extrajudicial de controversias
-45,450215,alquiler de cajas de caudales
-45,450215,alquiler de cajas fuertes
-45,450216,investigación genealógica
-45,450217,planificación y preparación de ceremonias nupciales
-45,450218,servicios de redes sociales en línea
-45,450219,suelta de palomas para acontecimientos especiales
-45,450220,servicios de tanatopraxia
-45,450221,servicios de preparación de documentos jurídicos
-45,450222,localización de objetos robados
-45,450223,administración jurídica de licencias
-45,450224,consultoría astrológica
-45,450225,consultoría espiritual
-45,450226,servicios de cartomancia
-45,450227,asesoramiento personalizado sobre estilismo en vestuario
-45,450228,redacción de correspondencia personal
-45,450229,celebración de ceremonias funerarias
-45,450230,servicios jurídicos relacionados con la negociación de contratos para terceros
-45,450231,celebración de ceremonias religiosas
-45,450232,servicios de paseo de perros
-45,450233,alquiler de nombres de dominio en Internet
-45,450234,asistencia para vestir un kimono
-45,450235,asesoramiento jurídico para responder a convocatorias de licitación
-45,450235,asesoramiento jurídico para responder a solicitudes de propuestas [RFPs]
-45,450236,concesión de licencias [servicios jurídicos] en el marco de edición de software
-45,450237,servicios de vigilancia jurídica
-45,450238,organización de reuniones políticas
-45,450239,servicios de asesoramiento jurídico sobre mapeo de patentes
-45,450240,servicios de defensa jurídica
-45,450241,servicios de conserjería [asistencia personal]
-45,450242,asesoramiento sobre el duelo
-45,450243,servicios de socorristas acuáticos
-45,450243,servicios de salvavidas
-45,450243,servicios de guardavidas
-45,450244,servicios jurídicos en el ámbito de la inmigración
-45,450245,servicios de lectura del tarot para terceros
-45,450246,servicios de auditoría con fines de observancia reglamentaria
-45,450246,servicios de auditoría de cumplimiento reglamentario
-45,450247,servicios de auditoría de observancia jurídica
-45,450247,servicios de auditoría de cumplimiento jurídico
+class|name
+45|Agencias de adopción
+45|Agencias de detectives
+45|Alquiler de alarmas de incendio
+45|Alquiler de altares
+45|Alquiler de armadura corporal
+45|Alquiler de barreras de control de multitudes
+45|Alquiler de cajas de caudales
+45|Alquiler de chalecos salvavidas
+45|Alquiler de esmóquines
+45|Alquiler de extintores
+45|Alquiler de prendas de vestir
+45|Alquiler de ropa formal
+45|Alquiler de sombreros
+45|Alquiler de uniformes
+45|Alquiler de vestidos
+45|Alquiler de vestidos de novia
+45|Alquiler de zapatos
+45|Análisis forense de videos de vigilancia para prevención de fraudes y robos
+45|Arrendamiento de joyas
+45|Arrendamiento de relojes de pulsera
+45|Asesoramiento en litigios
+45|Asesoramiento en materia contenciosa
+45|Asesoramiento jurídico
+45|Asesoramiento jurídico relacionado con publicidad televisiva, entretenimiento televisivo y deportes
+45|Autorizaciones de seguridad para la preparación de tarjetas de identificación
+45|Búsqueda de personas desaparecidas
+45|Compradores personales para terceros
+45|Concesión de licencias de marcas (servicios jurídicos)
+45|Concesión de licencias de patentes
+45|Concesión de licencias de propiedad intelectual (servicios jurídicos)
+45|Concesión de licencias de software (servicios jurídicos)
+45|Concesión de licencias para personajes de dibujos animados (servicios jurídicos)
+45|Conducción de ceremonias de matrimonio civil
+45|Confección de carta astral
+45|Consultoría de seguridad frente a la radiación
+45|Consultoría en concesión de licencias de software informático
+45|Consultoría en derechos de propiedad industrial
+45|Consultoría en el campo de la seguridad en el trabajo
+45|Consultoría en gestión de derechos de autor
+45|Consultoría en propiedad intelectual para inventores
+45|Consultoría jurídica profesional en relación a franquicias
+45|Consultoría relacionada con la concesión de licencias de derechos de autor
+45|Control de seguridad de personas y equipaje en aeropuertos
+45|Cuidado de animales de compañía a domicilio
+45|Cuidado de niños a domicilio
+45|Cuidado de viviendas en ausencia de los dueños
+45|Devolución de objetos perdidos (servicios de objetos perdidos y encontrados)
+45|Dibujos y modelos (Registro y licencia de -)
+45|Elaboración de horóscopos
+45|Facilitación de información en materia de asuntos jurídicos
+45|Facilitación de información sobre modas
+45|Gestión de derechos de autor
+45|Guardaespaldas
+45|Inspección de equipaje con fines de seguridad
+45|Inspección de fábricas con fines de seguridad
+45|Inspección de seguridad a equipaje para aerolíneas
+45|Investigación de antecedentes personales
+45|Investigación de genealogía
+45|Investigación de titularidad de inmuebles
+45|Investigación genealógica
+45|Investigación jurídica relacionada con transacciones inmobiliarias
+45|Investigación sobre personas desaparecidas
+45|Investigaciones jurídicas
+45|Mediación (servicios jurídicos)
+45|Monitorización de alarmas
+45|Monitorización de alarmas antirrobo y de seguridad
+45|Monitorización de sistemas de seguridad
+45|Organización de reuniones de familiares de difuntos para conmemorar su fallecimiento
+45|Predicción astrológica
+45|Provisión de información en el campo de la propiedad intelectual
+45|Provisión de servicios de oficiamiento de matrimonios
+45|Provisión deinformación sobre servicios legales a través de un sitio web
+45|Provisión y conducción de matrimonios civiles no confesionales ni religiosos
+45|Redacción de cartas personales
+45|Referencias de abogados
+45|Registro de nombres de dominio para la identificación de usuarios en una red informática global (servicios jurídicos)
+45|Seguimiento de vehículos robados
+45|Servicios de abogado
+45|Servicios de agencia de relaciones personales
+45|Servicios de agencias matrimoniales
+45|Servicios de apoyo en litigación
+45|Servicios de apoyo espiritual
+45|Servicios de arbitraje
+45|Servicios de arbitraje en materia de relaciones industriales
+45|Servicios de asesorías jurídica profesional en trámites de índole legal
+45|Servicios de auditoría legal de prácticas y procedimientos a particulares para el cumplimiento de leyes y reglamentos
+45|Servicios de bomberos
+45|Servicios de búsqueda de mascotas perdidas
+45|Servicios de capilla para bodas
+45|Servicios de comprobación de antecedentes (investigación)
+45|Servicios de consultoría en el campo de las necesidades de seguridad de empresas comerciales e industriales
+45|Servicios de consultoría en seguridad para la prevención de incendios
+45|Servicios de consultoría legal
+45|Servicios de contenciosos (servicios de abogado)
+45|Servicios de detección de bombas
+45|Servicios de entierros
+45|Servicios de estilista de modas (servicios personales)
+45|Servicios de guardias de seguridad
+45|Servicios de inspección de seguridad de equipaje en aeropuertos
+45|Servicios de inspección de seguridad para terceros
+45|Servicios de investigación de antecedentes pre-empleo
+45|Servicios de investigación paranormal
+45|Servicios de lectura psíquica
+45|Servicios de lobby que no sean para fines comerciales
+45|Servicios de mediación de divorcios
+45|Servicios de oficina de objetos perdidos y encontrados
+45|Servicios de organización de funerales
+45|Servicios de pompas fúnebres
+45|Servicios de presentación o de citas matrimoniales
+45|Servicios de proyección de seguridad para pasajeros de aerolíneas
+45|Servicios de reconocimiento y vigilancia
+45|Servicios de recuperación de fugitivos
+45|Servicios de recuperación de vehículos robados
+45|Servicios de redes sociales en línea
+45|Servicios de respuesta y verificación de alarmas
+45|Servicios de salvavidas
+45|Servicios de solución extrajudicial de controversias
+45|Servicios de vigilancia
+45|Servicios de vigilancia de marcas
+45|Servicios de vigilantes nocturnos
+45|Servicios funerarios en el marco de la incineración
+45|Servicios funerarios para animales de compañía en el marco de la incineración
+45|Servicios jurídicos
+45|Servicios jurídicos en el ámbito de la creación y el registro de empresas
+45|Servicios jurídicos en el ámbito de la explotación de derechos de autor sobre material impreso
+45|Servicios jurídicos en el ámbito de la explotación de derechos de difusión
+45|Servicios jurídicos en el ámbito de la explotación de los derechos de autor de películas
+45|Servicios legales relacionados con reclamaciones de seguros sociales
+45|Servicios litúrgicos
+45|Servicios personales de asesoría, consultoría e información respecto a la organización de espacios
+45|Suministro de información sobre derechos de propiedad industrial
+45|Supervisión de alarmas de incendios

--- a/lib/seeds/class_4_terms.csv
+++ b/lib/seeds/class_4_terms.csv
@@ -1,123 +1,140 @@
-class,reference_id,name
-4,040001,cera de abeja
-4,040002,alcohol de quemar
-4,040002,alcohol desnaturalizado
-4,040002,alcohol metílico
-4,040003,alcohol [combustible]
-4,040004,combustibles a base de alcohol
-4,040005,tiras de papel para encender el fuego
-4,040006,virutas de madera para encender el fuego
-4,040007,productos para encender el fuego
-4,040008,antracita
-4,040009,antideslizantes para correas [preparaciones]
-4,040010,velas para árboles de Navidad
-4,040011,grasa para armas
-4,040012,compuestos para asentar el polvo al barrer
-4,040013,leña
-4,040014,carbón de leña [combustible]
-4,040015,velas [iluminación]
-4,040015,candelas
-4,040015,cirios
-4,040016,briquetas de carbón
-4,040016,aglomerados de carbón
-4,040017,briquetas de turba [combustibles]
-4,040018,briquetas de madera
-4,040019,briquetas combustibles
-4,040020,mezclas de carburantes gasificados
-4,040021,cera de carnauba
-4,040022,ceresina
-4,040023,carbón [combustible]
-4,040023,hulla
-4,040024,turba [combustible]
-4,040025,combustibles*
-4,040026,grasa para el calzado
-4,040027,ceras [materias primas]
-4,040028,cera para correas
-4,040029,cera de iluminación
-4,040030,cera para uso industrial
-4,040031,coque
-4,040032,combustibles minerales
-4,040033,grasa para correas
-4,040034,grasa para el cuero
-4,040035,grasas industriales
-4,040036,aceites de desencofrado
-4,040037,sebo*
-4,040038,preparaciones para quitar el polvo
-4,040039,aceites de iluminación
-4,040040,gas de alumbrado
-4,040041,combustibles para la iluminación
-4,040042,aceites lubricantes
-4,040043,gasolina [carburante]
-4,040044,éter de petróleo
-4,040045,ligroína
-4,040046,mechas para velas
-4,040047,jalea de petróleo para uso industrial
-4,040048,diésel
-4,040048,gasóleo
-4,040049,gases combustibles
-4,040050,gas de petróleo
-4,040052,grafito lubrificante
-4,040052,grafito lubricante
-4,040053,aceite de alquitrán de hulla
-4,040054,aceite de hulla
-4,040055,aceite para conservar obras de albañilería
-4,040056,aceites de remojo
-4,040057,aceite de pescado no comestible
-4,040058,preparaciones de aceite de soja para revestimientos antiadherentes de utensilios de cocción
-4,040058,preparaciones de aceite de soya para revestimientos antiadherentes de utensilios de cocción
-4,040059,queroseno
-4,040059,keroseno
-4,040059,querosén
-4,040060,grasas lubricantes
-4,040061,mechas de lámpara
-4,040062,lignito
-4,040063,lubricantes
-4,040063,lubrificantes
-4,040064,fuel
-4,040065,aceite de colza para uso industrial
-4,040066,nafta
-4,040067,aceite de hueso para uso industrial
-4,040068,oleína
-4,040069,ozocerita
-4,040069,ozoquerita
-4,040070,parafina
-4,040071,petróleo crudo o refinado
-4,040072,polvo de carbón [combustible]
-4,040073,estearina
-4,040074,lanolina
-4,040074,grasa de lana
-4,040075,aceite de girasol para uso industrial
-4,040076,lamparillas [velas]
-4,040079,aglomerantes de polvo
-4,040080,aceites para tejidos
-4,040080,aceites de ensimaje
-4,040081,carburantes
-4,040081,combustibles de motor
-4,040084,aceites combustibles
-4,040085,aditivos no químicos para carburantes
-4,040085,aditivos no químicos para combustibles de motor
-4,040086,grasas para conservar el cuero
-4,040087,aceites industriales
-4,040088,gases solidificados [combustibles]
-4,040089,aceite de ricino para uso industrial
-4,040090,aceites para conservar el cuero
-4,040101,aceites de corte
-4,040101,fluidos de corte
-4,040102,aceites para pinturas
-4,040103,gas pobre
-4,040104,aceites de motor
-4,040105,velas perfumadas
-4,040106,energía eléctrica
-4,040107,etanol [combustible]
-4,040108,yesca
-4,040109,compuestos para absorber el polvo
-4,040110,bencina
-4,040111,biocombustibles
-4,040112,carburante de benceno
-4,040113,carburante de xileno
-4,040114,cera para esquís
-4,040115,lanolina para ser utilizada en la fabricación de cosméticos
-4,040116,cera de abejas para ser utilizada en la fabricación de cosméticos
-4,040117,carbón para shisha
-4,040117,carbón para narguile 
-4,040117,carbón para hookah
+class|name
+4|Aceite de alquitrán de hulla
+4|Aceite de pescado para uso industrial
+4|Aceite de ricino no comestible
+4|Aceite lubricante para motores de vehículos automóviles
+4|Aceite mineral para motores
+4|Aceite mineral para uso en la fabricación de cosméticos y productos para el cuidado de la piel
+4|Aceite para alumbrado
+4|Aceite para conservar obras de albañilería
+4|Aceite para motor
+4|Aceites combustibles
+4|Aceites de calefacción
+4|Aceites de coco para uso industrial
+4|Aceites de corte
+4|Aceites de ensimaje
+4|Aceites de iluminación
+4|Aceites de motor
+4|Aceites de nuez para uso industrial
+4|Aceites endurecidos (aceites hidrogenados para uso industrial)
+4|Aceites lubricantes
+4|Aceites lubricantes (lubricantes para uso industrial)
+4|Aceites lubricantes minerales
+4|Aceites lubricantes para máquinas de coser
+4|Aceites lubricantes sintéticos
+4|Aceites para desmoldar
+4|Aceites para engranajes
+4|Aceites para motores de automóviles
+4|Aceites para uso industrial
+4|Aceites pesados
+4|Aceites y grasas lubricantes
+4|Aceites y grasas minerales para uso industrial que no sean para combustible
+4|Aceites y grasas para conservar el cuero
+4|Aceites y grasas para uso industrial que no sean para combustible
+4|Aditivos no químicos para aceite de motores
+4|Aditivos no químicos para aceites y combustibles
+4|Aditivos no químicos para carburantes
+4|Aditivos no químicos para combustibles, lubricantes y grasas
+4|Aglomerados de carbón
+4|Alcohol (combustible)
+4|Alcoholes metílicos para combustible (alcoholes de combustible desnaturalizados)
+4|Antracita
+4|Biocarburantes
+4|Biocombustibles
+4|Briquetas combustibles (briquetas de carbón)
+4|Briquetas de carbón de leña
+4|Briquetas de madera
+4|Candelas
+4|Carbón (combustible)
+4|Carbón de leña (combustible)
+4|Carbón en trozos
+4|Cera de carnauba
+4|Cera de zumaque
+4|Cera para skateboards
+4|Cera para snowboards
+4|Cera para tablas de surf
+4|Cera parafina
+4|Ceras (materia prima)
+4|Combustible a base de petróleo crudo
+4|Combustible biodiesel
+4|Combustible diésel
+4|Combustible para aviación
+4|Combustible para encendedores
+4|Combustible para lámparas
+4|Combustibles
+4|Combustibles a base de alcohol
+4|Combustibles a base de carbón
+4|Combustibles de etanol
+4|Combustibles de motor
+4|Combustibles de origen biológico
+4|Combustibles gaseosos
+4|Combustibles líquidos
+4|Combustibles para cocinar
+4|Combustibles para la iluminación
+4|Combustibles sólidos
+4|Composición granular absorbente a base de aceite para absorber derrames de los suelos
+4|Composiciones para asentar el polvo
+4|Compuestos de supresión de polvo a base de petróleo
+4|Coque
+4|Diésel
+4|Gas butano (combustible)
+4|Gas de carbón
+4|Gas licuado de petróleo
+4|Gas licuado para encendedores de cigarrillos
+4|Gas natural
+4|Gas natural a presión
+4|Gas natural licuado
+4|Gas solidificado (combustible)
+4|Gases combustibles
+4|Gases licuados de petróleo
+4|Gases licuados de petróleo para uso doméstico, industrial y en vehículos automóviles
+4|Gasóleo para calefacción doméstica
+4|Gasolina
+4|Gasolina (carburante)
+4|Gasolina (combustible)
+4|Gasolina para uso industrial
+4|Grafito como lubricante
+4|Gránulos de combustible
+4|Grasa para máquinas
+4|Grasas para uso industrial
+4|Grasas para usos técnicos
+4|Hidrocarburos combustibles
+4|Lanolina para fabricación de cosméticos
+4|Leña
+4|Lignito
+4|Ligroína
+4|Líquido de encendedores de cigarrillos
+4|Lubricantes de motores de vehículos
+4|Lubricantes para cadenas de bicicleta
+4|Lubricantes para máquinas
+4|Lubricantes para perforación
+4|Lubricantes para uso industrial
+4|Mechas de lámpara
+4|Mechas para estufas de aceite
+4|Mechas para velas
+4|Mechas para velas de iluminación
+4|Nafta
+4|Papel de iluminación
+4|Parafina
+4|Parafinas industriales
+4|Pastillas de madera para la calefacción (combustibles)
+4|Petróleo
+4|Petróleo artificial
+4|Petróleo crudo
+4|Petróleos crudos
+4|Polvo de carbón (combustible)
+4|Productos para encender el fuego
+4|Productos para encender el fuego (madera para el encendido)
+4|Queroseno
+4|Sebo
+4|Velas (iluminación)
+4|Velas aromáticas
+4|Velas de fragancia para aromaterapia
+4|Velas de sebo
+4|Velas para iluminación nocturna
+4|Velas para los oídos de uso terapéutico
+4|Velas perfumadas
+4|Velas que contienen repelentes de insectos
+4|Velas y mechas para velas de iluminación
+4|Virutas de madera para encender el fuego
+4|Yesca

--- a/lib/seeds/class_5_terms.csv
+++ b/lib/seeds/class_5_terms.csv
@@ -1,556 +1,550 @@
-class,reference_id,name
-5,050001,abrasivos para uso odontológico
-5,050002,aconitina
-5,050003,adhesivos para prótesis dentales
-5,050003,adhesivos para dentaduras postizas
-5,050005,productos para purificar el aire
-5,050006,alimentos a base de albúmina para uso médico
-5,050007,preparaciones albuminosas para uso médico
-5,050008,alcoholes medicinales
-5,050009,aldehídos para uso farmacéutico
-5,050010,aleaciones de metales preciosos para uso odontológico
-5,050012,amalgamas dentales
-5,050013,almidón para uso dietético o farmacéutico
-5,050017,anestésicos
-5,050018,esencia de eneldo para uso médico
-5,050019,esparadrapos
-5,050020,corteza de angostura para uso médico
-5,050021,productos para eliminar animales dañinos
-5,050022,té antiasmático
-5,050023,bálsamo anticongelante para uso farmacéutico
-5,050025,productos antihemorroidales
-5,050025,productos para las hemorroides
-5,050026,preparaciones antimoho
-5,050028,productos antipolillas
-5,050029,productos antiparasitarios
-5,050030,antisépticos
-5,050031,algodón antiséptico
-5,050032,productos antiúricos
-5,050033,lápices antiverrugas
-5,050034,algodón aséptico
-5,050035,papel atrapamoscas
-5,050036,caldos de cultivo para uso bacteriológico
-5,050036,medios de cultivo bacteriológico
-5,050037,preparaciones bacteriológicas para uso médico o veterinario
-5,050038,venenos bacterianos
-5,050039,preparaciones bacterianas para uso médico o veterinario
-5,050040,anillos para los callos de los pies
-5,050040,aros para los callos de los pies
-5,050041,preparaciones de baño para uso médico
-5,050042,sales para baños de aguas minerales
-5,050043,baños de oxígeno
-5,050044,agua de mar para baños medicinales
-5,050045,preparaciones terapéuticas para el baño
-5,050046,preparaciones balsámicas para uso médico
-5,050049,vendas para apósitos
-5,050050,bálsamos para uso médico
-5,050051,productos para lavar el ganado [insecticidas]
-5,050052,biocidas
-5,050053,preparaciones de bismuto para uso farmacéutico
-5,050054,agua blanca
-5,050055,insecticidas
-5,050056,carbón vegetal para uso farmacéutico
-5,050057,caramelos medicinales
-5,050058,lodos medicinales
-5,050058,barros medicinales
-5,050059,lodo para baños
-5,050059,barro para baños
-5,050061,productos para las quemaduras
-5,050062,cachú para uso farmacéutico
-5,050063,productos para las callosidades
-5,050064,calomelano [fungicida]
-5,050065,polvo de cantáridas
-5,050066,caucho para uso odontológico
-5,050067,jarabes para uso farmacéutico
-5,050068,cápsulas para medicamentos
-5,050069,preparaciones farmacéuticas
-5,050070,cataplasmas
-5,050072,guata para uso médico
-5,050073,hilas para uso médico
-5,050074,preparaciones farmacéuticas a base de cal
-5,050075,productos para lavar perros [insecticidas]
-5,050076,repelentes para perros
-5,050077,preparaciones químico-farmacéuticas
-5,050079,cloral hidratado para uso farmacéutico
-5,050080,cloroformo
-5,050081,cigarrillos sin tabaco para uso médico
-5,050082,cementos dentales
-5,050083,cemento para pezuñas
-5,050084,ceras dentales para modelar
-5,050085,pastillas fumigantes
-5,050085,varillas fumigantes
-5,050086,cocaína
-5,050087,collares antiparasitarios para animales
-5,050088,colirio
-5,050089,compresas [vendas]
-5,050090,preparaciones de vitaminas*
-5,050091,conductores químicos para electrodos de electrocardiógrafo
-5,050092,corteza de condurango para uso médico
-5,050093,medicamentos para el estreñimiento
-5,050093,medicamentos para la constipación [estreñimiento]
-5,050094,soluciones para lentes de contacto
-5,050094,soluciones para lentillas
-5,050095,anticonceptivos químicos
-5,050096,sustancias de contraste radiológico para uso médico
-5,050098,productos para los callos de los pies
-5,050098,callicidas
-5,050099,algodón para uso médico
-5,050100,preparaciones farmacéuticas para el tratamiento de quemaduras solares
-5,050102,lápices cáusticos
-5,050103,productos para los sabañones
-5,050104,lápices hemostáticos
-5,050105,corteza de crotón
-5,050106,curare
-5,050107,vacunas
-5,050108,detergentes para uso médico
-5,050109,decocciones para uso farmacéutico
-5,050110,materiales para empastes dentales
-5,050111,materiales para impresiones dentales
-5,050112,lacas dentales
-5,050113,masillas dentales
-5,050114,artículos para apósitos
-5,050115,porcelana para prótesis dentales
-5,050116,preparaciones para facilitar la dentición
-5,050117,depurativos
-5,050118,desinfectantes para uso higiénico
-5,050119,desodorantes que no sean para personas ni para animales
-5,050120,productos para eliminar ratones
-5,050121,pan para diabéticos de uso médico
-5,050122,digestivos para uso farmacéutico
-5,050123,digitalina
-5,050124,analgésicos
-5,050125,drogas para uso médico
-5,050126,botiquines de viaje
-5,050127,magnesia para uso farmacéutico
-5,050128,agua de melisa para uso farmacéutico
-5,050129,aguas minerales para uso médico
-5,050130,sales de aguas minerales
-5,050131,aguas termales
-5,050132,cortezas para uso farmacéutico
-5,050133,elixires [preparaciones farmacéuticas]
-5,050134,disolventes para quitar el esparadrapo
-5,050135,productos anticriptogámicos
-5,050136,esponjas vulnerarias
-5,050137,sales para uso médico
-5,050138,ésteres para uso farmacéutico
-5,050139,éteres para uso farmacéutico
-5,050140,telas para apósitos
-5,050140,vendajes quirúrgicos
-5,050141,eucaliptol para uso farmacéutico
-5,050142,eucalipto para uso farmacéutico
-5,050143,purgantes
-5,050143,evacuantes
-5,050144,harinas para uso farmacéutico
-5,050145,harinas lacteadas para bebés
-5,050146,productos febrífugos
-5,050146,productos antipiréticos
-5,050147,hinojo para uso médico
-5,050148,infusiones medicinales
-5,050149,té medicinal
-5,050150,aceite de hígado de bacalao
-5,050151,fungicidas
-5,050152,nervinos
-5,050153,guayacol para uso farmacéutico
-5,050154,vermífugos
-5,050154,antihelmínticos
-5,050155,gasa para apósitos
-5,050156,laxantes
-5,050157,gelatina para uso médico
-5,050158,genciana para uso farmacéutico
-5,050159,germicidas
-5,050160,glicerofosfatos
-5,050161,gomas para uso médico
-5,050162,semillas [granos] de lino para uso farmacéutico
-5,050162,linaza para uso farmacéutico
-5,050163,grasas para uso médico
-5,050164,grasas para uso veterinario
-5,050165,grasa para ordeñar
-5,050166,preparaciones químicas para diagnosticar el embarazo
-5,050167,aceites para uso médico
-5,050168,productos hematógenos
-5,050169,hemoglobina
-5,050170,hierbas medicinales
-5,050171,hormonas para uso médico
-5,050172,aceite de mostaza para uso médico
-5,050174,hidrastina
-5,050175,hidrastinina
-5,050176,algodón hidrófilo
-5,050177,semen para la inseminación artificial
-5,050178,repelentes de insectos
-5,050179,tintura de iodo
-5,050180,peptonas para uso farmacéutico
-5,050181,iodoformo
-5,050182,musgo de Irlanda para uso médico
-5,050183,jalapa
-5,050184,pasta de azufaifa
-5,050185,regaliz para uso farmacéutico
-5,050186,extractos de tabaco [insecticidas]
-5,050187,fermentos lácteos para uso farmacéutico
-5,050188,leche malteada para uso médico
-5,050189,productos para lavar animales [insecticidas]
-5,050190,harina de linaza para uso farmacéutico
-5,050191,lociones para uso farmacéutico
-5,050192,lactosa para uso farmacéutico
-5,050192,azúcar de leche para uso farmacéutico
-5,050193,productos para eliminar larvas
-5,050194,levadura para uso farmacéutico
-5,050195,productos para eliminar babosas
-5,050196,linimentos
-5,050197,lupulina para uso farmacéutico
-5,050198,gomas de mascar para uso médico
-5,050198,chicles para uso médico
-5,050199,corteza de mangle para uso farmacéutico
-5,050200,bragas higiénicas
-5,050200,bombachas higiénicas
-5,050200,bombachas para la menstruación
-5,050200,bragas para la menstruación
-5,050200,blúmers higiénicos
-5,050200,blúmers para la menstruación
-5,050200,pantaletas higiénicas
-5,050200,pantaletas para la menstruación
-5,050200,calzones para la menstruación
-5,050201,menta para uso farmacéutico
-5,050202,preparaciones químicas para tratar el mildiu
-5,050203,malta para uso farmacéutico
-5,050204,herbicidas
-5,050204,preparaciones para eliminar plantas nocivas
-5,050204,preparaciones para eliminar las malas hierbas
-5,050205,mechas azufradas [desinfectantes]
-5,050207,pomadas para uso médico
-5,050208,tinturas para uso médico
-5,050209,sueros
-5,050210,mentol
-5,050211,ungüentos a base de mercurio
-5,050212,sustancias nutritivas para microorganismos
-5,050213,cultivos de microorganismos para uso médico o veterinario
-5,050214,pastillas para uso farmacéutico
-5,050214,tabletas [pastillas] para uso farmacéutico
-5,050216,raticidas
-5,050217,pegamento atrapamoscas
-5,050217,adhesivos para atrapar moscas
-5,050218,preparaciones matamoscas
-5,050219,mostaza para uso farmacéutico
-5,050220,lociones para uso veterinario
-5,050221,corteza de mirobálano para uso farmacéutico
-5,050222,preparaciones químicas para tratar el tizón del trigo
-5,050223,narcóticos
-5,050224,sales contra el desmayo
-5,050224,sales aromáticas contra el desmayo
-5,050225,ungüentos para uso farmacéutico
-5,050226,opiáceos
-5,050227,opio
-5,050228,opodeldoch
-5,050229,productos opoterápicos
-5,050229,productos de organoterapia
-5,050230,amalgamas dentales de oro
-5,050231,pectina para uso farmacéutico
-5,050232,tampones higiénicos
-5,050232,tampones para la menstruación
-5,050234,compresas higiénicas
-5,050234,compresas sanitarias
-5,050234,toallas sanitarias
-5,050236,fenol para uso farmacéutico
-5,050237,papel para sinapismos
-5,050237,papel para cataplasmas de mostaza [sinapismos]
-5,050238,parasiticidas
-5,050239,preparaciones farmacéuticas para cuidar la piel
-5,050240,tisanas medicinales
-5,050241,preparaciones farmacéuticas para el tratamiento anticaspa
-5,050242,pepsinas para uso farmacéutico
-5,050243,sellos para uso farmacéutico
-5,050244,botiquines de primeros auxilios
-5,050245,fosfatos para uso farmacéutico
-5,050246,productos químicos para tratar la filoxera
-5,050247,remedios para la transpiración de los pies
-5,050248,plasma sanguíneo
-5,050249,venenos
-5,050251,sales de potasio para uso médico
-5,050252,polvo de pelitre
-5,050253,quebracho para uso médico
-5,050254,cuasia para uso médico
-5,050255,quina para uso médico
-5,050256,quinina para uso médico
-5,050257,quinoleína para uso médico
-5,050258,productos radioactivos para uso médico
-5,050259,radio para uso médico
-5,050260,raíces medicinales
-5,050261,raíces de ruibarbo para uso farmacéutico
-5,050262,tónicos reconstituyentes [medicamentos]
-5,050263,subnitrato de bismuto para uso farmacéutico
-5,050264,zarzaparrilla para uso médico
-5,050265,sangre para uso médico
-5,050266,sanguijuelas para uso médico
-5,050267,vendajes escapulares para uso quirúrgico
-5,050268,calmantes
-5,050268,sedantes
-5,050268,tranquilizantes
-5,050269,cornezuelo del centeno para uso farmacéutico
-5,050270,medicamentos sueroterapéuticos
-5,050271,sinapismos
-5,050271,cataplasmas de mostaza
-5,050271,emplastos de mostaza
-5,050272,preparaciones para esterilizar suelos
-5,050273,somníferos
-5,050274,sales de soda para uso médico
-5,050274,sales de sosa para uso médico
-5,050275,preparaciones para esterilizar
-5,050276,estricnina
-5,050277,preparaciones estípticas [astringentes]
-5,050278,azúcar para uso médico
-5,050279,sulfamidas [medicamentos]
-5,050280,supositorios
-5,050281,tártaro para uso farmacéutico
-5,050282,trementina para uso farmacéutico
-5,050283,esencia de trementina para uso farmacéutico
-5,050283,aceite de trementina para uso farmacéutico
-5,050284,timol para uso farmacéutico
-5,050285,medicamentos antitranspirantes
-5,050286,papel antipolillas
-5,050287,preparaciones veterinarias
-5,050288,preparaciones químicas para tratar las enfermedades de la vid
-5,050289,productos para eliminar parásitos
-5,050290,sustancias vesicantes
-5,050291,acetatos para uso farmacéutico
-5,050292,ácidos para uso farmacéutico
-5,050294,cintas adhesivas para uso médico
-5,050294,tiras adhesivas para uso médico
-5,050296,alcaloides para uso médico
-5,050297,alimentos dietéticos para uso médico
-5,050298,alimentos para bebés
-5,050299,acetato de aluminio para uso farmacéutico
-5,050300,leche de almendras para uso farmacéutico
-5,050301,ungüentos para quemaduras solares
-5,050302,sales de baño para uso médico
-5,050303,palos de regaliz para uso farmacéutico
-5,050304,bicarbonato de soda para uso farmacéutico
-5,050304,bicarbonato de sosa para uso farmacéutico
-5,050305,preparaciones biológicas para uso médico
-5,050306,bromo para uso farmacéutico
-5,050307,bebidas dietéticas para uso médico
-5,050308,aceite alcanforado
-5,050309,alcanfor para uso médico
-5,050310,azúcar candi para uso médico
-5,050310,azúcar piedra para uso médico
-5,050311,carbonilo [antiparasitario]
-5,050312,alguicidas
-5,050313,lecitina para uso médico
-5,050314,gases para uso médico
-5,050315,protege-slips [compresas higiénicas]
-5,050316,jalea real para uso farmacéutico
-5,050317,preparaciones medicinales para adelgazar
-5,050318,ésteres de celulosa para uso farmacéutico
-5,050319,productos cáusticos para uso farmacéutico
-5,050320,éteres de celulosa para uso farmacéutico
-5,050321,subproductos del procesamiento de cereales para uso dietético o médico
-5,050323,preparaciones químicas para uso farmacéutico
-5,050324,colodión para uso farmacéutico
-5,050325,crémor tártaro para uso farmacéutico
-5,050326,creosota para uso farmacéutico
-5,050327,medicamentos para uso odontológico
-5,050327,remedios para uso odontológico
-5,050328,medicamentos para uso médico
-5,050328,remedios para uso médico
-5,050329,medicamentos para uso veterinario
-5,050329,remedios para uso veterinario
-5,050330,preparaciones de diagnóstico para uso médico
-5,050331,glicerina para uso médico
-5,050332,pociones medicinales
-5,050333,fermentos para uso farmacéutico
-5,050334,flor de azufre para uso farmacéutico
-5,050335,aldehído fórmico para uso farmacéutico
-5,050336,hierbas de fumar para uso médico
-5,050337,productos de fumigación para uso médico
-5,050338,ácido gálico para uso farmacéutico
-5,050339,jalea de petróleo para uso médico
-5,050340,glucosa para uso médico
-5,050341,goma-guta para uso médico
-5,050342,bálsamo de gurjun para uso médico
-5,050343,extractos de lúpulo para uso farmacéutico
-5,050344,aceite de ricino para uso médico
-5,050345,agua oxigenada para uso médico
-5,050345,peróxido de hidrógeno [agua oxigenada] para uso médico
-5,050346,iodo para uso farmacéutico
-5,050347,ioduros para uso farmacéutico
-5,050348,ioduros alcalinos para uso farmacéutico
-5,050349,isótopos para uso médico
-5,050350,sustancias dietéticas para uso médico
-5,050351,pañales higiénicos para la incontinencia
-5,050361,preparaciones biológicas para uso veterinario
-5,050362,preparaciones químicas para uso médico
-5,050363,preparaciones químicas para uso veterinario
-5,050364,reactivos químicos para uso médico o veterinario
-5,050365,preparaciones para limpiar lentes de contacto
-5,050365,preparaciones para limpiar lentillas
-5,050366,diastasas para uso médico
-5,050367,fibras alimentarias
-5,050368,enzimas para uso médico
-5,050369,enzimas para uso veterinario
-5,050370,preparaciones enzimáticas para uso médico
-5,050371,preparaciones enzimáticas para uso veterinario
-5,050372,bragas absorbentes para la incontinencia
-5,050372,blúmers absorbentes para la incontinencia
-5,050372,bombachas absorbentes para la incontinencia
-5,050372,pantaletas absorbentes para la incontinencia
-5,050372,calzones absorbentes para la incontinencia
-5,050373,desecativos para uso médico
-5,050374,toallitas impregnadas de lociones farmacéuticas
-5,050375,preparaciones de oligoelementos para el consumo humano y animal
-5,050376,aminoácidos para uso médico
-5,050377,aminoácidos para uso veterinario
-5,050378,almohadillas de lactancia
-5,050379,madera de cedro para repeler insectos
-5,050380,desinfectantes para inodoros químicos
-5,050381,harina de pescado para uso farmacéutico
-5,050382,complementos alimenticios minerales
-5,050382,suplementos alimenticios minerales
-5,050383,enjuagues bucales para uso médico
-5,050384,complementos nutricionales
-5,050384,suplementos nutricionales
-5,050385,cemento de hueso para uso quirúrgico y ortopédico
-5,050386,incienso repelente para insectos
-5,050387,acaricidas
-5,050388,antibióticos
-5,050389,supresores del apetito para uso médico
-5,050390,preparaciones broncodilatadoras
-5,050391,almohadillas para juanetes
-5,050392,molesquín para uso médico
-5,050393,duchas vaginales para uso médico
-5,050394,preparaciones medicinales para el crecimiento del cabello
-5,050395,esteroides
-5,050396,adyuvantes para uso médico
-5,050397,implantes quirúrgicos compuestos de tejidos vivos
-5,050398,parches oculares para uso médico
-5,050399,oxígeno para uso médico
-5,050400,desodorantes para prendas de vestir y materias textiles
-5,050401,desodorantes de ambiente
-5,050402,preparaciones de irrigación interna para uso médico
-5,050403,células madre para uso médico
-5,050404,células madre para uso veterinario
-5,050405,cultivos de tejidos biológicos para uso médico
-5,050406,cultivos de tejidos biológicos para uso veterinario
-5,050407,aerosoles fríos para uso médico
-5,050408,lubricantes sexuales
-5,050408,lubricantes íntimos
-5,050409,preparaciones de aloe vera para uso farmacéutico
-5,050410,polvo de perlas para uso médico
-5,050411,preparaciones para reducir la actividad sexual
-5,050412,pañales para bebés
-5,050413,pañales-braga para bebés
-5,050413,pañales-calzón para bebés
-5,050414,preparaciones medicinales para baños oculares
-5,050415,píldoras supresoras del apetito
-5,050415,pastillas supresoras del apetito
-5,050416,píldoras para adelgazar
-5,050416,pastillas para adelgazar
-5,050417,pastillas bronceadoras
-5,050417,píldoras bronceadoras
-5,050418,píldoras antioxidantes
-5,050418,pastillas antioxidantes
-5,050419,complementos alimenticios para animales
-5,050419,suplementos alimenticios para animales
-5,050420,complementos alimenticios a base de albúmina
-5,050420,suplementos alimenticios a base de albúmina
-5,050421,complementos alimenticios a base de semillas de lino
-5,050421,complementos alimenticios a base de linaza
-5,050421,suplementos alimenticios a base de semillas de lino
-5,050421,suplementos alimenticios a base de linaza
-5,050422,complementos alimenticios a base de aceite de linaza
-5,050422,complementos alimenticios a base de aceite de lino
-5,050422,suplementos alimenticios a base de aceite de linaza
-5,050422,suplementos alimenticios a base de aceite de lino
-5,050423,complementos alimenticios a base de germen de trigo
-5,050423,suplementos alimenticios a base de germen de trigo
-5,050424,complementos alimenticios a base de levadura
-5,050424,suplementos alimenticios a base de levadura
-5,050425,complementos alimenticios a base de jalea real
-5,050425,suplementos alimenticios a base de jalea real
-5,050426,propóleos para uso farmacéutico
-5,050427,complementos alimenticios a base de propóleos
-5,050427,suplementos alimenticios a base de propóleos
-5,050428,complementos alimenticios a base de polen
-5,050428,suplementos alimenticios a base de polen
-5,050429,complementos alimenticios a base de enzimas
-5,050429,suplementos alimenticios a base de enzimas
-5,050430,complementos alimenticios a base de glucosa
-5,050430,suplementos alimenticios a base de glucosa
-5,050431,complementos alimenticios a base de lecitina
-5,050431,suplementos alimenticios a base de lecitina
-5,050432,complementos alimenticios a base de alginatos
-5,050432,suplementos alimenticios a base de alginatos
-5,050433,alginatos para uso farmacéutico
-5,050434,complementos alimenticios a base de caseína
-5,050434,suplementos alimenticios a base de caseína
-5,050435,complementos alimenticios a base de proteínas
-5,050435,suplementos alimenticios a base de proteínas
-5,050436,complementos de proteínas para animales
-5,050436,suplementos de proteínas para animales
-5,050437,papel reactivo para uso médico
-5,050438,alcohol para uso farmacéutico
-5,050439,pesticidas
-5,050440,pañales para animales de compañía
-5,050441,desinfectantes
-5,050442,adhesivos [pegamentos] quirúrgicos
-5,050442,colas quirúrgicas
-5,050443,reactivos con biomarcadores para el diagnóstico médico
-5,050444,preparaciones para el tratamiento del acné
-5,050445,alimentos medicinales para animales
-5,050446,preparaciones de diagnóstico para uso veterinario
-5,050447,bastoncillos de algodón para uso médico
-5,050447,hisopos para uso médico
-5,050448,preparaciones alimenticias para bebés
-5,050449,leche en polvo para bebés
-5,050450,trasplantes [tejidos vivos]
-5,050451,colágeno para uso médico
-5,050452,extractos de plantas para uso farmacéutico
-5,050453,productos farmacéuticos
-5,050454,preparaciones de microorganismos para uso médico o veterinario
-5,050455,preparaciones de fitoterapia para uso médico
-5,050456,extractos de plantas para uso médico
-5,050457,geles de estimulación sexual
-5,050458,inmunoestimulantes
-5,050459,preparaciones nutracéuticas para uso terapéutico o médico
-5,050460,comida liofilizada para uso médico
-5,050461,comida homogeneizada para uso médico
-5,050462,jeringas prellenadas para uso médico
-5,050463,carne liofilizada para uso médico
-5,050464,papel reactivo para uso veterinario
-5,050465,astringentes para uso médico
-5,050466,dentífricos medicinales
-5,050467,preparaciones de tratamiento antipiojos [pediculicida]
-5,050468,champús pediculicidas
-5,050469,champús insecticidas para animales
-5,050470,productos de lavado insecticidas para uso veterinario
-5,050471,jabones antibacterianos
-5,050472,productos antibacterianos para lavar las manos
-5,050473,lociones medicinales para después del afeitado
-5,050474,champús medicinales
-5,050475,preparaciones de tocador medicinales
-5,050476,lociones capilares medicinales
-5,050477,champús en seco medicinales
-5,050478,champús medicinales para animales de compañía
-5,050479,jabones desinfectantes
-5,050480,jabones medicinales
-5,050481,velas de masaje para uso terapéutico
-5,050482,suplementos dietéticos a base de acai en polvo
-5,050482,complementos dietéticos a base de acai en polvo
-5,050483,parches de suplementos vitamínicos
-5,050484,suplementos dietéticos con efecto cosmético
-5,050484,complementos dietéticos con efecto cosmético
-5,050485,gomas de mascar de nicotina para dejar de fumar
-5,050486,parches de nicotina para dejar de fumar
-5,050487,cápsulas de polímeros dendriméricos para productos farmacéuticos
-5,050488,preparaciones químicas para tratar las enfermedades de las plantas de cereales
-5,050489,rellenos dérmicos inyectables
-5,050490,pulseras impregnadas de repelente de insectos
-5,050491,pastas de dientes medicinales
-5,050492,geles de masaje para uso médico
-5,050493,aplicadores en barrita para aliviar el dolor de cabeza
-5,050494,esponjas anticonceptivas
-5,050495,pañales de natación desechables para bebés
-5,050496,pañales de natación reutilizables para bebés
-5,050497,cambiadores desechables para bebés
-5,050498,rellenos óseos compuestos de tejidos vivos
-5,050499,botellas de oxígeno llenas para uso médico
-5,050500,cánnabis para uso médico
-5,050500,marihuana para uso médico
-5,050501,desodorantes para bandejas de arena higiénica
+class|name
+5|Abrasivos para uso odontológico
+5|Aceite alcanforado
+5|Aceite de coco para uso médico
+5|Aceite de hígado de bacalao
+5|Aceite de ricino para uso médico
+5|Aceites antitábanos
+5|Aceites para bebé medicinales
+5|Aceites para uso médico
+5|Acetaminofén (para el alivio del dolor)
+5|Adhesivos atrapamoscas
+5|Adhesivos dentales
+5|Adhesivos médicos para cerrar heridas
+5|Adhesivos médicos para cerrar tejido interno
+5|Adhesivos para uso dental y odontológico
+5|Adhesivos para uso en arte dental y odontológico
+5|Adyuvantes para uso médico
+5|Aerosol contra insectos
+5|Aerosol de vendaje líquido
+5|Aerosoles antipulgas
+5|Aerosoles fríos para uso médico
+5|Aerosoles para la garganta medicinales
+5|Aerosoles perfumados para desodorizar textiles
+5|Agentes (preparaciones) viscoelásticos para uso oftálmico
+5|Agentes de quimioterapia
+5|Agentes de tratamiento de enfermedades por radiación
+5|Agentes exterminadores de insectos
+5|Agentes hipolipidémicos (productos farmacéuticos)
+5|Agentes limpiadores gastrointestinales
+5|Agentes repelentes de insectos
+5|Agentes selladores para uso dental
+5|Agua de mar para baños medicinales
+5|Agua desmineralizada con una finalidad médica
+5|Alcanfor para uso médico
+5|Alcohol para friegas (de uso farmacéutico)
+5|Alcohol para uso farmacéutico
+5|Alcohol para uso médico
+5|Alcoholes medicinales
+5|Aleaciones de metales preciosos para uso odontológico
+5|Aleaciones de metales preciosos para uso odontológico y en tecnología dental.
+5|Aleaciones dentales
+5|Alginato ortodóncico para uso dental
+5|Algodón antiséptico
+5|Algodón aséptico
+5|Algodón para uso médico
+5|Alguicidas químicos para mantenimiento de piscinas de natación
+5|Alguicidas químicos para piscinas de natación
+5|Alimento para bebé
+5|Alimentos para bebés
+5|Almohadillas para juanetes
+5|Almohadillas para la lactancia
+5|Amalgama de oro para uso dental
+5|Amalgamas dentales
+5|Amalgamas dentales de oro
+5|Aminoácidos para uso médico o veterinario
+5|Analgésicos
+5|Analgésicos antipiréticos
+5|Analgésicos orales
+5|Anestésicos
+5|Anestésicos generales
+5|Anestésicos inhalados
+5|Anestésicos locales
+5|Anestésicos para uso quirúrgico
+5|Anhidróticos
+5|Anillos para los callos de los pies
+5|Antiácidos
+5|Antibióticos
+5|Antibióticos para peces
+5|Antibióticos para su uso dental
+5|Antibióticos para uso humano
+5|Anticoagulantes
+5|Anticonceptivos (preparaciones)
+5|Anticonceptivos orales
+5|Antidepresivos
+5|Antídotos
+5|Antieméticos
+5|Antieméticos para las náuseas matutinas
+5|Antihelmínticos
+5|Antihipertensivos
+5|Antihistamínicos
+5|Antimicóticos vaginales
+5|Antimicrobianos para uso dermatológico
+5|Antisépticos
+5|Antitoxinas
+5|Antitusivos
+5|Antivirales
+5|Apósitos auto adhesivos
+5|Apósitos de tafetán adhesivo
+5|Apósitos esterilizados
+5|Apósitos médicos
+5|Apósitos médicos y quirúrgicos
+5|Apósitos para quemaduras
+5|Astringentes (producto farmacéutico)
+5|Azúcar candi para uso médico
+5|Azúcar de leche para uso médico
+5|Azúcar dietética para uso médico
+5|Bactericidas
+5|Bálsamo anticongelante para uso farmacéutico
+5|Bálsamo de gurjun para uso médico
+5|Bálsamo de labios medicinal
+5|Bálsamos de uso farmacéutico
+5|Bálsamos para uso médico
+5|Barras de azufre como desinfectantes
+5|Barras de fumigación como desinfectantes
+5|Bayas de goji secas para uso en medicina china
+5|Betabloqueantes
+5|Biocidas
+5|Biocidas, germicidas, bactericidas, virucidas, fungicidas, insecticidas, pesticidas y herbicidas
+5|Bloqueadores de los canales de calcio (medicamentos)
+5|Bromo para uso farmacéutico
+5|Calmantes
+5|Capsulas de ginseng de uso medico
+5|Cápsulas descongestionantes
+5|Cápsulas vacías para productos farmacéuticos
+5|Caramelos medicinales
+5|Carbón vegetal para uso farmacéutico
+5|Carillas dentales para la restauración dental
+5|Células madre para uso médico
+5|Células madre para uso veterinario
+5|Cemento de hueso para uso quirúrgico y ortopédico
+5|Cemento para huesos para uso médico
+5|Cemento para pezuñas
+5|Cementos de resina dental
+5|Cementos dentales
+5|Cera de modelar para uso dental
+5|Cera dental
+5|Cerámicas dentales
+5|Ceras dentales
+5|Cianuros
+5|Cigarrillos sin tabaco para uso médico
+5|Cintas adhesivas para uso médico
+5|Cinturones para compresas higiénicas
+5|Citostáticos para uso médico
+5|Cloroformo
+5|Colirio
+5|Collares antiparasitarios para animales
+5|Collares antipulgas
+5|Complementos alimenticios a base de linaza
+5|Complementos alimenticios a base de proteínas
+5|Complementos alimenticios minerales
+5|Complementos nutricionales de isoflavonas de soja
+5|Complementos nutricionales en polvo para elaborar bebidas
+5|Complementos probióticos
+5|Compresas higiénicas
+5|Compuestos para sanitizar huevos
+5|Confitería dietética con finalidades médicas
+5|Corteza de crotón de uso médico
+5|Corteza decondurango para uso médico
+5|Crema potenciador de orgasmo
+5|Cremas analgésicas para uso tópico
+5|Cremas antibióticas
+5|Cremas antimicóticas para uso médico
+5|Cremas medicadas para tratamiento de enfermedades dermatológicas
+5|Cremas medicinales para el cuidado de la piel
+5|Crémor tártaro para uso farmacéutico
+5|Creosota para uso farmacéutico
+5|Curare (venenos) de uso medico
+5|Descongestionantes
+5|Desinfectantes para inodoros químicos
+5|Desinfectantes para lentes de contacto
+5|Desinfectantes para uso higiénico
+5|Desinfectantes para uso sanitario
+5|Desodorantes ambientales en aerosol
+5|Desodorantes de tapicerías
+5|Desodorantes para zapatos
+5|Desodorizantes para automóviles
+5|Dextrinas para uso farmacéutico
+5|Diaforéticos
+5|Diastasas para uso médico
+5|Digestivos para uso farmacéutico
+5|Discos cortadores y moledores para aplicaciones dentales
+5|Diuréticos
+5|Dulces para uso médico
+5|Electrolitos para uso médico
+5|Emenagogos
+5|Eméticos
+5|Empapadores desechables para entrenamiento de mascotas
+5|Emplastos adhesivos para uso médico
+5|Emplastos para uso médico
+5|Emplastos, material para apósitos
+5|Enjuague bucal medicinal
+5|Enjuagues bucales medicinales
+5|Enjuagues bucales medicinales para prevenir las caries
+5|Enjuagues dentales medicinales
+5|Enjuagues dentales medicinales para prevenir las caries
+5|Enzimas para uso médico
+5|Esencia de eneldo para uso médico
+5|Espermicidas
+5|Esporicidas
+5|Ésteres de celulosa para uso farmacéutico
+5|Estimulantes (preparaciones) del sistema nervioso central
+5|Estimulantes de alimentación para animales
+5|Éteres de celulosa para uso farmacéutico
+5|Expectorantes
+5|Extractos de hierbas medicinales
+5|Extractos de hierbas medicinales para uso médico
+5|Fermentos lácteos para uso farmacéutico
+5|Fermentos para uso farmacéutico
+5|Fermentos para uso médico o veterinario
+5|Feromonas para uso médico
+5|Fibra dietética para ayudar a la digestión
+5|Formulaciones bacterianas probióticas para uso médico
+5|Forros desechables como insertos para pañales ecológicos reutilizables
+5|Fumigantes
+5|Fungicidas
+5|Fungicidas biológicos
+5|Fungicidas para uso en agricultura
+5|Fungicidas para uso médico
+5|Fungicidas y herbicidas
+5|Galactogogos
+5|Ganoderma lucidum con fines farmacéuticos
+5|Gasa para apósitos
+5|Gasa quirúrgica
+5|Gastrodia elata de uso farmacéutico
+5|Gel de Aloe vera para uso terapéutico
+5|Gelatina de cuero de asno (Ejiao) para uso en la medicina china
+5|Geles estimulantes sexuales
+5|Geles, cremas y soluciones para uso dermatológico
+5|Germicidas
+5|Germicidas y fungicidas
+5|Glicerina para uso médico
+5|Glucosa como aditivo en alimentos para uso médico
+5|Glucosa para uso médico
+5|Goma de mascar para uso médico
+5|Goma de mascar refrescante para propósitos médicos.
+5|Gomas de mascar para uso médico
+5|Gotas contra la tos
+5|Gotas de aceite de hígado de bacalao
+5|Gotas nasales para el tratamiento de las alergias
+5|Gotas para los ojos
+5|Grasas y jaleas de petróleo para uso médico o veterinario
+5|Guata para apósitos
+5|Herbicidas
+5|Herbicidas acuáticos
+5|Herbicidas biológicos
+5|Herbicidas para uso agrícola
+5|Hidrocortisona
+5|Hierbas medicinales
+5|Hierbas medicinales secas o en conserva
+5|Hierbas medicinales tradicionales chinas
+5|Hierbas para uso médico
+5|Hormonas para uso médico
+5|Ibuprofeno utilizado como analgésico oral
+5|Implantes con tejido vivo
+5|Incienso de fumigación (kunko)
+5|Inciensos repelentes de zancudos
+5|Infusiones dietéticas para uso médico
+5|Inhibidores del apetito
+5|Insecticidas
+5|Insecticidas de uso doméstico
+5|Insecticidas para uso agrícola
+5|Insecticidas para uso en agricultura
+5|Insulina
+5|Iodo para uso farmacéutico
+5|Jalea real par uso medico
+5|Laca conductora para propósitos dentales
+5|Lacas dentales
+5|Lágrimas artificiales
+5|Lápices cáusticos
+5|Lápices para la jaqueca
+5|Laxantes (purgantes)
+5|Leche malteada para uso médico
+5|Levadura o extractos de levadura para uso médico, veterinario o farmacéutico
+5|Líquido antipruriginoso
+5|Líquidos intravenosos utilizados para rehidratación, nutrición y suministro de productos farmacéuticos
+5|Loción antimoscas
+5|Lociones farmacéuticas para la piel
+5|Lociones medicadas para tratamiento de enfermedades dermatológicas
+5|Lubricantes sexuales
+5|Lubricantes vaginales
+5|Madera de cedro para repeler insectos
+5|Marcadores de radioisótopos para uso terapéutico o de diagnóstico
+5|Masillas dentales
+5|Material para pegar y empastar dientes
+5|Materiales cerámicos para uso como rellenos dentales
+5|Materiales compuestos dentales
+5|Materiales compuestos para propósitos médicos y dentales
+5|Materiales para coronas dentales y puentes dentales para uso dental
+5|Materiales para coronas y puentes para uso dental y profilaxis oral
+5|Materiales para dientes artificiales
+5|Materiales para empastes dentales
+5|Materiales para hacer impresiones dentales
+5|Materiales para improntas dentales
+5|Materiales para la restauración dental
+5|Materiales para rellenos dentales y propósitos de sellado
+5|Materiales para reparar dientes y para coronas y puentes dentales
+5|Materiales sintéticos para uso como rellenos dentales
+5|Medicamentos antialérgicos
+5|Medicamentos contra el acné
+5|Medicamentos contra la diarrea
+5|Medicamentos para aliviar alergias
+5|Medicamentos para el alivio del dolor de quemaduras
+5|Medicamentos para el mareo de movimiento
+5|Medicamentos para el tratamiento de enfermedades cardiovasculares y cerebrovasculares
+5|Medicamentos para el tratamiento de enfermedades gastrointestinales
+5|Medicamentos para uso odontológico
+5|Medios de contraste para la imaginología in vivo
+5|Medios de contraste para uso con aparatos médicos de ultrasonido
+5|Mentol de uso farmacéutico
+5|Molesquín para su uso como vendaje médico
+5|Moletón para uso como vendaje médico
+5|Nematicidas
+5|Nematocidas
+5|Ovicidas
+5|Óvulos para la inseminación artificial
+5|Oxígeno para uso médico
+5|Oxitócicos
+5|Pan para diabéticos de uso médico
+5|Pañales desechables de bebés
+5|Pañales desechables para la incontinencia
+5|Pañales desechables para mascotas
+5|Pañales para adulto
+5|Pañales para animales de compañía
+5|Pañales para bebés
+5|Pañales para personas incontinentes
+5|Pañales-braga
+5|Pañales-braga para bebés
+5|Paños desinfectantes
+5|Paños menstruales
+5|Papel antipolillas
+5|Papel atrapamoscas
+5|Parasiticidas
+5|Parasiticidas para uso médico
+5|Parches repelentes de mosquitos para bebés
+5|Pastillas efervescentes de vitaminas
+5|Pastillas fumigantes
+5|Pegamento atrapamoscas
+5|Pesticidas
+5|Pesticidas de nematodos
+5|Pesticidas para uso agrícola
+5|Plasma sanguíneo
+5|Pociones medicinales
+5|Polvos medicinales para los pies
+5|Polvos para matar pulgas
+5|Polygonatum sibiricum para fines farmacéuticos
+5|Pomadas medicinales contra la dermatitis del pañal
+5|Preparaciones analgésicas
+5|Preparaciones anti-sarcoma
+5|Preparaciones antibióticas mezcladas
+5|Preparaciones antidiabéticas
+5|Preparaciones antiinflamatorias y antipiréticas
+5|Preparaciones antisépticas
+5|Preparaciones bacterianas y bacteriológicas para uso médico o veterinario
+5|Preparaciones biológicas para el tratamiento del cáncer
+5|Preparaciones broncodilatadoras
+5|Preparaciones de aloe vera con fines terapéuticos
+5|Preparaciones de baño para uso médico
+5|Preparaciones de bismuto para uso farmacéutico
+5|Preparaciones de cloranfenicol
+5|Preparaciones de condroitina
+5|Preparaciones de diagnóstico para uso médico
+5|Preparaciones de diagnóstico para uso médico y veterinario
+5|Preparaciones de enemas
+5|Preparaciones de eritromicina
+5|Preparaciones de hormonas adrenales
+5|Preparaciones de limpieza nasal con fines médicos
+5|Preparaciones de lisina
+5|Preparaciones de metionina
+5|Preparaciones de penicilina
+5|Preparaciones de tratamiento de migraña
+5|Preparaciones de vacunas orales
+5|Preparaciones de vitamina B
+5|Preparaciones de vitamina C
+5|Preparaciones de vitamina D
+5|Preparaciones de vitaminas
+5|Preparaciones desodorantes para cajas de arena para mascotas
+5|Preparaciones farmacéuticas inhaladas para el tratamiento de enfermedades y trastornos respiratorios
+5|Preparaciones farmacéuticas para el cuidado de la piel
+5|Preparaciones farmacéuticas para el cuidado de la piel de los animales
+5|Preparaciones farmacéuticas para el sistema nervioso periférico
+5|Preparaciones farmacéuticas para el tratamiento de alergias
+5|Preparaciones farmacéuticas para el tratamiento de gusanos en animales
+5|Preparaciones farmacéuticas para el tratamiento de la diabetes
+5|Preparaciones farmacéuticas para el tratamiento de problemas de la hipoglicemia
+5|Preparaciones farmacéuticas para el tratamiento de trastornos de la piel
+5|Preparaciones farmacéuticas para el tratamiento de trastornos hormonales y la prevención de osteoporosis
+5|Preparaciones farmacéuticas para heridas
+5|Preparaciones farmacéuticas para heridas cutáneas
+5|Preparaciones farmacéuticas para inhalación para el tratamiento de la hipertensión pulmonar
+5|Preparaciones farmacéuticas para la cirugía ocular o intraocular
+5|Preparaciones farmacéuticas para picaduras de insectos
+5|Preparaciones farmacéuticas para tratamiento de la hipertensión
+5|Preparaciones farmacéuticas para tratamiento de la rinitis alérgica y el asma
+5|Preparaciones farmacéuticas para tratar enfermedades virales
+5|Preparaciones farmacéuticas para uso en dermatología
+5|Preparaciones higiénicas para uso médico
+5|Preparaciones matamoscas
+5|Preparaciones medicadas para el cuidado y tratamiento bucal
+5|Preparaciones medicinales bucales para ser aplicados en la forma de gotas, cápsulas, tabletas y tabletas comprimidas
+5|Preparaciones medicinales para el crecimiento del cabello
+5|Preparaciones medicinales para estimular el crecimiento del cabello
+5|Preparaciones medicinales para la boca y como aerosoles
+5|Preparaciones multivitamínicas
+5|Preparaciones neutralizadoras de olores para prendas de vestir y materias textiles
+5|Preparaciones oftálmicas
+5|Preparaciones oftalmológicas
+5|Preparaciones para baño medicinales
+5|Preparaciones para combatir moscas
+5|Preparaciones para destruir animales dañinos
+5|Preparaciones para destruir parásitos
+5|Preparaciones para el tratamiento de la dismenorrea
+5|Preparaciones para el tratamiento del asma
+5|Preparaciones para limpiar lentes de contacto
+5|Preparaciones para limpieza de la piel para uso médico
+5|Preparaciones para pruebas de embarazo
+5|Preparaciones para revelado de placas dentales
+5|Preparaciones para sanitizar uñas
+5|Preparaciones para vacunas
+5|Preparaciones químicas para el tratamiento del mildiu
+5|Preparaciones químicas para tratamiento de filoxera
+5|Preparaciones repelentes de tiburones
+5|Preparaciones sanitarias esterilizadoras
+5|Preparaciones veterinarias para el tratamiento de bacteria intestinal
+5|Preparaciones vitamínicas mezcladas
+5|Preparaciones vitamínicas y minerales para uso médico
+5|Preparaciones y productos farmacéuticos para manchas del embarazo
+5|Preparaciones y productos farmacéuticos para prevenir manchas de la piel durante el embarazo
+5|Preparaciones y sustancias esterilizadoras
+5|Preparaciones y sustancias farmacéuticas anti-alérgica
+5|Preparaciones y sustancias farmacéuticas para el tratamiento de enfermedades gastro-intestinales
+5|Preparados de glucosa para fines médicos
+5|Preparados farmacéuticos analgésicos efervescentes
+5|Preparados medicinales para adelgazar
+5|Preparados medicinales para baños de pies
+5|Preparados para destruir la planaria
+5|Preparados para el tratamiento del mareo
+5|Preparados para la eliminación de piojos del cabello
+5|Preparados terapéuticos medicinales para baños
+5|Producto farmacéutico para el tratamiento de la disfunción eréctil
+5|Productos andrógenos
+5|Productos antibióticos
+5|Productos antimicóticos
+5|Productos antiparasitarios
+5|Productos antiúricos
+5|Productos contra las infecciones para uso veterinario
+5|Productos de confitería para uso médico
+5|Productos de fumigación para uso médico
+5|Productos desodorizantes de ambiente
+5|Productos farmacéuticos antidiabéticos
+5|Productos farmacéuticos dermatológicos
+5|Productos farmacéuticos para el tratamiento de enfermedades óseas
+5|Productos farmacéuticos para el tratamiento de enfermedades respiratorias y el asma
+5|Productos farmacéuticos para el tratamiento de enfermedades virales e infecciosas, para el tratamiento del cáncer
+5|Productos farmacéuticos para el tratamiento de la disfunción eréctil
+5|Productos farmacéuticos para la prevención y tratamiento del cáncer
+5|Productos farmacéuticos para uso oftalmológico
+5|Productos farmacéuticos que actúan sobre el sistema nervioso central
+5|Productos febrífugos
+5|Productos para eliminar plantas nocivas
+5|Productos para esterilizar
+5|Productos para los sabañones
+5|Productos para purificar el aire
+5|Productos parafarmacéuticos de uso en dermatología
+5|Productos y preparaciones farmacéuticas contra la sequedad de la piel causada por el embarazo
+5|Productos y preparaciones farmacéuticas para el cloasma
+5|Productos y preparaciones farmacéuticas para la hidratación de la piel durante el embarazo
+5|Productos y preparaciones farmacéuticas para prevenir la hinchazón en las piernas
+5|Productos y preparaciones farmacéuticas para prevenir las estrías
+5|Productos y preparaciones para la limpieza de la piel para uso médico
+5|Pruebas de identidad genética compuestas de reactivos para fines médicos
+5|Pseudo ginseng en polvo para uso médico
+5|Purgantes
+5|Quina para uso médico
+5|Quinoleína para uso médico
+5|Raíces medicinales
+5|Raíz de arisaema con fines medicinales
+5|Raíz de glycyrrhizae medicinal
+5|Reactivos de diagnóstico para uso médico
+5|Reactivos de inmunoensayos de uso médico
+5|Reactivos diagnósticos para uso veterinario
+5|Reactivos para uso médico
+5|Reactivos químicos para uso médico o veterinario
+5|Reactivos y medios para diagnóstico médico y veterinario
+5|Relajantes musculares
+5|Rellenos óseos compuestos de materia viva
+5|Repelente de animales
+5|Repelentes de insectos
+5|Repelentes para insectos
+5|Rodenticidas
+5|Ruedas tope y abrasivas para propósitos dentales
+5|Sales de baño y preparaciones de baño para uso médico
+5|Sales minerales para uso médico
+5|Sangre para uso médico
+5|Sedantes hipnóticos
+5|Sellantes de fisura para propósitos detales
+5|Semen de animal para inseminación artificial
+5|Semen para la inseminación artificial
+5|Soluciones de limpieza para uso médico
+5|Soluciones farmacéuticas para uso en diálisis
+5|Soluciones para lentes de contacto
+5|Somníferos
+5|Subproductos del procesamiento de cereales para uso médico
+5|Sucedáneos dietéticos del azúcar para uso médico
+5|Sueros antitóxicos
+5|Sulfamidas como medicamentos
+5|Suplementos dietéticos de ácido fólico
+5|Suplementos dietéticos de Chlorella
+5|Suplementos dietéticos de polen de pino
+5|Suplementos dietéticos de zinc
+5|Suplementos dietéticos en polvo de esporas de Ganoderma lucidum
+5|Suplementos dietéticos para mascotas
+5|Suplementos medicinales para piensos de animales
+5|Suplementos vitamínicos líquidos
+5|Supositorios laxantes
+5|Supresores del apetito para uso médico
+5|Sustancias antibacteriales para uso médico
+5|Sustancias nutritivas para microorganismos para uso médico
+5|Tabletas de alcanfor para repeler insectos
+5|Tabletas de vitaminas
+5|Tampones
+5|Tampones higiénicos
+5|Tampones para la menstruación
+5|Té adelgazante para uso médico
+5|Té medicinal
+5|Tejidos prostéticos para uso parietal, visceral y vascular
+5|Tejidos quirúrgicos
+5|Tintes quirúrgicos
+5|Tiomersal para uso médico
+5|Tiras de prueba para medir niveles de glucosa en la sangre
+5|Tiras reactivas para pruebas de sangre oculta en materia fecal
+5|Tisanas
+5|Toallas absorbentes para lactancia
+5|Toallas higiénicas
+5|Toallas sanitarias
+5|Toallitas desinfectantes desechables
+5|Toallitas impregnadas de repelentes contra insectos
+5|Toallitas para la menstruación
+5|Ungüentos de mercurio para uso medico
+5|Ungüentos medicados para el tratamiento de enfermedades dermatológicas
+5|Ungüentos para las hemorroides
+5|Vacunas
+5|Vacunas contra la influenza
+5|Vacunas contra las infecciones por neumococo
+5|Vacunas para caballos
+5|Vacunas para ganado bovino
+5|Vacunas para uso veterinario
+5|Vasopresores (preparaciones farmacéuticas)
+5|Vendajes antisépticos líquidos
+5|Vendajes líquidos para heridas en la piel
+5|Vendas para apósitos
+5|Veneno estricnina
+5|Venenos bacterianos
+5|Venenos para bacterias
+5|Virucidas
+5|Vitaminas en gomitas
+5|Vitaminas para animales
+5|Vitaminas para animales de compañía
+5|Vitaminas prenatales
+5|Vitaminas y preparaciones vitamínicas
+5|Zarzaparrilla para uso médico

--- a/lib/seeds/class_6_terms.csv
+++ b/lib/seeds/class_6_terms.csv
@@ -1,533 +1,368 @@
-class,reference_id,name
-6,060001,acero en bruto o semielaborado
-6,060002,aleaciones de acero
-6,060003,flejes de acero
-6,060004,alambres de acero
-6,060005,acero fundido
-6,060006,mástiles de acero
-6,060009,persianas enrollables de acero
-6,060010,chapas de acero
-6,060011,tuberías de acero
-6,060011,tubos de acero
-6,060012,grapas metálicas para correas de máquinas
-6,060013,agujas de ferrocarril
-6,060013,cambios de vía [ferrocarriles]
-6,060014,toberas metálicas
-6,060016,argentán
-6,060016,alpaca [metal]
-6,060016,plata alemana
-6,060017,aluminio
-6,060018,bronce
-6,060019,alambre de aluminio
-6,060020,placas de anclaje
-6,060021,boquillas metálicas
-6,060022,pasadores metálicos [artículos de cerrajería]
-6,060023,mástiles [postes] metálicos
-6,060024,barras metálicas
-6,060025,trampas para animales salvajes*
-6,060026,tirantes metálicos para manipular cargas
-6,060026,arneses metálicos para manipular cargas
-6,060027,metal antifricción
-6,060028,protecciones metálicas para árboles
-6,060029,cajas para dinero [metálicas o no metálicas]
-6,060030,soldaduras de plata
-6,060032,aleaciones de estaño plateado
-6,060033,armaduras metálicas para hormigón
-6,060033,armaduras metálicas para concreto
-6,060034,cajas de caudales [metálicas o no metálicas]
-6,060034,cajas fuertes [metálicas o no metálicas]
-6,060035,topes metálicos para ventanas
-6,060036,topes metálicos para puertas
-6,060037,arandelas metálicas
-6,060038,anillas metálicas*
-6,060038,anillos metálicos*
-6,060039,goznes
-6,060040,baldosas metálicas para suelos
-6,060041,alambre de púas
-6,060041,alambre de espino
-6,060042,barrotes de rejas metálicas
-6,060043,berilio [glucinio]
-6,060043,glucinio [berilio]
-6,060044,cadenas para ganado
-6,060045,bigornias
-6,060046,metal blanco
-6,060047,blindajes metálicos
-6,060048,cierres metálicos para cajas
-6,060049,pernos metálicos
-6,060050,bombonas [recipientes] metálicas para gas a presión o aire líquido
-6,060050,cilindros [recipientes] metálicos para gas a presión o aire líquido
-6,060050,garrafas [recipientes] metálicas para gas a presión o aire líquido
-6,060051,pulseras de identificación metálicas
-6,060052,chapas de hierro
-6,060053,aleaciones para soldadura fuerte
-6,060054,bridas metálicas
-6,060055,bronces [monumentos funerarios]
-6,060056,bronces [obras de arte]
-6,060057,cables teleféricos
-6,060058,guardacabos para cables
-6,060058,guardacabos para cuerdas
-6,060059,empalmes metálicos para cables no eléctricos
-6,060061,cadmio
-6,060062,candados metálicos que no sean electrónicos
-6,060063,chuletas metálicas
-6,060064,conteras metálicas para bastones
-6,060065,recipientes metálicos para ácidos
-6,060066,cajas de seguridad
-6,060067,celtio [hafnio]
-6,060067,hafnio [celtio]
-6,060068,cadenas metálicas*
-6,060071,cadenas de seguridad metálicas
-6,060073,empalmes metálicos para cadenas
-6,060074,estructuras metálicas para la construcción
-6,060075,poleas metálicas para ventanas
-6,060075,poleas metálicas para ventanas de guillotina
-6,060076,conductos metálicos para instalaciones de calefacción central
-6,060077,clavos para herraduras
-6,060078,clavijas metálicas
-6,060079,cromo
-6,060080,cromita
-6,060081,minerales de cromo
-6,060082,chavetas metálicas
-6,060083,llaves metálicas
-6,060085,clavos
-6,060086,puntas [clavos]
-6,060086,tachuelas
-6,060087,tacos metálicos
-6,060088,cobalto en bruto
-6,060089,materiales metálicos para vías férreas
-6,060090,pilares metálicos para la construcción
-6,060091,tuberías de agua metálicas
-6,060092,manguitos [artículos de ferretería metálicos]
-6,060093,latas de conserva
-6,060094,contenedores metálicos [almacenamiento, transporte]
-6,060095,contracarriles
-6,060096,coquillas [fundición]
-6,060097,yunques
-6,060098,tapajuntas metálicos para tejados
-6,060099,codos metálicos para tuberías
-6,060100,puertas metálicas*
-6,060101,tensores de correas metálicos
-6,060102,crampones metálicos
-6,060103,llares
-6,060104,fallebas
-6,060105,ganchos [artículos de ferretería metálicos]
-6,060106,herrajes de ventanas
-6,060108,hilos metálicos
-6,060108,alambres
-6,060109,cobre en bruto o semielaborado
-6,060110,anillos de cobre
-6,060111,entibaciones metálicas
-6,060112,recipientes metálicos para gas a presión o aire líquido
-6,060113,limpiabarros metálicos
-6,060114,tuberías de desagüe metálicas
-6,060115,hierro en bruto o semielaborado
-6,060116,eclisas
-6,060118,tornillos metálicos
-6,060119,embalajes de hojalata
-6,060120,buzones de correo metálicos
-6,060121,timbres de puerta metálicos no eléctricos
-6,060122,espuelas
-6,060123,escuadras metálicas para la construcción
-6,060124,escaleras metálicas
-6,060125,cierres metálicos para ventanas
-6,060127,tuberías metálicas
-6,060127,tubos metálicos
-6,060129,rieles metálicos
-6,060129,raíles metálicos
-6,060130,guarniciones metálicas para ventanas
-6,060131,flejes de hierro
-6,060132,alambres de hierro
-6,060133,hierro colado en bruto o semielaborado
-6,060134,minerales de hierro
-6,060135,cierres de puerta metálicos no eléctricos
-6,060135,muelles de puerta metálicos no eléctricos
-6,060136,ferromolibdeno
-6,060137,ferrosilicio
-6,060138,ferrotitanio
-6,060139,ferrotungsteno
-6,060140,herrajes para la construcción
-6,060141,pasadores [artículos de ferretería]
-6,060143,armellas
-6,060143,pernos de ojo
-6,060144,cerraduras metálicas que no sean eléctricas
-6,060145,galena [mineral]
-6,060146,sellos de plomo
-6,060147,germanio
-6,060148,veletas
-6,060148,giraldas
-6,060149,crampones de escalada
-6,060150,moldes metálicos para hielo
-6,060151,racores de engrase
-6,060152,rejas metálicas
-6,060152,verjas metálicas
-6,060153,cerraduras de golpe
-6,060153,cerraduras de muelle
-6,060154,indio
-6,060155,distintivos metálicos para vehículos
-6,060156,celosías metálicas
-6,060157,latón en bruto o semielaborado
-6,060158,persianas de exterior metálicas
-6,060159,rampas de lanzamiento de cohetes metálicas
-6,060160,listones metálicos
-6,060161,limaduras metálicas
-6,060162,zancas de escalera metálicas
-6,060163,limonita
-6,060164,lingotes de metales comunes
-6,060165,dinteles metálicos
-6,060166,ruedas de cama metálicas
-6,060167,pestillos metálicos
-6,060168,lupias [metalurgia]
-6,060169,magnesio
-6,060170,construcciones transportables metálicas
-6,060172,virolas para mangos
-6,060173,manguitos metálicos para tubos
-6,060174,manganeso
-6,060175,palés de manipulación metálicos
-6,060176,palés de transporte metálicos
-6,060177,escaleras de tijera metálicas
-6,060179,marquesinas [estructuras] metálicas 
-6,060180,aldabas metálicas para puertas
-6,060181,esposas
-6,060182,metales comunes en bruto o semielaborados
-6,060183,minerales metalíferos
-6,060183,menas
-6,060184,tejidos metálicos
-6,060184,telas metálicas
-6,060185,metales pirofóricos
-6,060187,ruedas metálicas para muebles
-6,060188,tablestacas metálicas
-6,060189,molibdeno
-6,060190,monumentos metálicos
-6,060191,mordazas [artículos de ferretería metálicos]
-6,060192,chapados murales metálicos para la construcción
-6,060193,níquel
-6,060194,niobio
-6,060195,tapajuntas metálicos para la construcción
-6,060195,limahoyas metálicas para la construcción
-6,060196,números de casa metálicos no luminosos
-6,060197,contraventanas metálicas
-6,060198,empalizadas metálicas
-6,060199,canastos metálicos
-6,060199,cestos metálicos
-6,060200,paneles de señalización metálicos no luminosos ni mecánicos
-6,060201,revestimientos murales interiores metálicos para la construcción
-6,060202,ganchos [garfios] metálicos para prendas de vestir
-6,060202,ganchos [garfios] para prendas de vestir
-6,060203,pistas de patinaje [estructuras] metálicas
-6,060204,pestillos de cerradura
-6,060205,postes metálicos
-6,060206,muelles [artículos de ferretería metálicos]
-6,060206,resortes [artículos de ferretería metálicos]
-6,060207,poleas metálicas que no sean para máquinas
-6,060208,estacas metálicas para tiendas de campaña
-6,060208,estacas metálicas para carpas
-6,060209,techos metálicos
-6,060210,suelos metálicos
-6,060210,pisos metálicos
-6,060211,revestimientos interiores metálicos para la construcción
-6,060212,placas giratorias
-6,060213,tejas metálicas para techados
-6,060214,plomo en bruto o semielaborado
-6,060215,trampolines metálicos
-6,060216,manijas de puerta metálicas
-6,060216,perillas de puerta metálicas
-6,060216,picaportes de puerta metálicos
-6,060217,remaches metálicos
-6,060218,portones metálicos
-6,060219,entrepaños de puerta metálicos
-6,060220,cerrojos de puerta metálicos
-6,060221,anillas abiertas de metales comunes para llaves
-6,060222,postes telegráficos metálicos
-6,060223,zinc
-6,060224,vigas metálicas
-6,060224,jácenas metálicas
-6,060225,viguetas metálicas
-6,060226,plataformas [andenes o muelles] prefabricadas metálicas
-6,060227,artículos de ferretería metálicos
-6,060227,quincalla
-6,060228,mojones metálicos no luminosos ni mecánicos para carreteras
-6,060229,racores metálicos para tuberías
-6,060230,tensores de hilos metálicos [estribos de tensión]
-6,060230,tensores [artículos de ferretería metálicos]
-6,060231,recipientes metálicos para embalar
-6,060232,depósitos metálicos
-6,060232,tanques metálicos
-6,060233,umbrales metálicos
-6,060235,señales metálicas no luminosas ni mecánicas
-6,060236,invernaderos transportables metálicos
-6,060237,cerraduras metálicas para vehículos
-6,060238,topes metálicos
-6,060239,silos metálicos
-6,060240,cencerros
-6,060241,timbres*
-6,060241,campanas*
-6,060241,campanillas*
-6,060241,cascabeles
-6,060242,alambres para soldar
-6,060243,válvulas metálicas que no sean partes de máquinas
-6,060243,compuertas metálicas que no sean partes de máquinas
-6,060244,estatuas de metales comunes
-6,060245,traviesas de ferrocarril metálicas
-6,060245,durmientes de ferrocarril metálicos
-6,060246,tántalo [metal]
-6,060247,pasadores planos
-6,060248,tases
-6,060249,estribos de tensión
-6,060251,titanio
-6,060252,techados metálicos
-6,060253,tumbaga
-6,060254,tumbas metálicas
-6,060255,torniquetes [molinetes] metálicos
-6,060255,molinetes [torniquetes] metálicos
-6,060256,enrejados [celosías] metálicos
-6,060256,entramados metálicos
-6,060257,tungsteno
-6,060257,wolframio
-6,060258,cañerías metálicas
-6,060259,vanadio
-6,060260,tragaluces metálicos
-6,060262,virolas
-6,060263,pajareras [estructuras] metálicas
-6,060264,zirconio
-6,060265,canicas de acero
-6,060265,bolas de acero
-6,060266,construcciones de acero
-6,060267,armazones metálicos para conductos de aire comprimido
-6,060268,alambres de aleaciones de metales comunes, excepto los fusibles
-6,060269,aleaciones de metales comunes
-6,060270,hojas de aluminio*
-6,060271,bolardos de amarre metálicos
-6,060272,muelles flotantes metálicos para amarrar barcos
-6,060273,anclas
-6,060274,arrimadillos metálicos
-6,060275,armazones metálicos para conductos
-6,060275,materiales de refuerzo para conductos
-6,060276,armazones metálicos para la construcción
-6,060276,materiales de refuerzo para la construcción
-6,060277,armazones metálicos para correas
-6,060277,materiales de refuerzo para correas
-6,060278,obras de arte de metales comunes
-6,060279,artesas metálicas para argamasa
-6,060280,bañeras para pájaros [estructuras] metálicas
-6,060282,balizas metálicas no luminosas
-6,060284,tensores de flejes de hierro [estribos de tensión]
-6,060285,cintas metálicas para atar
-6,060286,hilos metálicos para atar
-6,060286,alambres para atar
-6,060287,toneles metálicos
-6,060287,barriles metálicos
-6,060288,cercos metálicos para toneles
-6,060288,cercos metálicos para barriles
-6,060289,barricas metálicas
-6,060290,piscinas [estructuras] metálicas
-6,060290,albercas de natación [estructuras] metálicas
-6,060290,piletas de natación [estructuras] metálicas
-6,060291,materiales de construcción metálicos
-6,060292,encofrados metálicos para hormigón
-6,060292,encofrados metálicos para concreto
-6,060293,instalaciones metálicas para aparcar bicicletas
-6,060294,pavimentos metálicos
-6,060295,cajas de metales comunes
-6,060296,piqueras metálicas
-6,060296,bitoques metálicos
-6,060297,cápsulas de taponado metálicas
-6,060298,hebillas de metales comunes [artículos de ferretería]
-6,060299,tapones metálicos para tapar botellas
-6,060300,cierres metálicos para botellas
-6,060301,pomos [tiradores] metálicos
-6,060302,varillas metálicas de soldadura fuerte
-6,060303,varillas metálicas de soldadura y soldadura fuerte
-6,060304,varillas metálicas para soldar
-6,060305,correas metálicas para manipular cargas
-6,060306,eslingas metálicas para manipular cargas
-6,060307,bustos de metales comunes
-6,060308,cabinas [casetas] metálicas para bañistas
-6,060310,cabinas metálicas para pulverizar pintura
-6,060311,cables metálicos no eléctricos
-6,060312,abrazaderas metálicas para tuberías
-6,060313,bridas de fijación metálicas para cables y tuberías
-6,060314,sujetacables metálicos
-6,060315,marcos de ventana metálicos
-6,060315,bastidores de ventana metálicos
-6,060316,armazones de invernadero metálicos
-6,060317,enrejados metálicos
-6,060318,sombreretes de chimenea metálicos
-6,060319,ataduras metálicas para uso agrícola
-6,060320,dispositivos metálicos no eléctricos para abrir puertas
-6,060321,baldosas metálicas para la construcción
-6,060322,solados metálicos de baldosas
-6,060323,panteones metálicos
-6,060324,guarniciones metálicas para ataúdes
-6,060325,palés de carga metálicos
-6,060325,plataformas [palés] de carga metálicas
-6,060326,gálibos de carga metálicos para ferrocarriles
-6,060327,bisagras metálicas
-6,060328,entramados de construcción metálicos
-6,060329,marcos de puerta metálicos
-6,060329,armaduras de puerta metálicas
-6,060329,armazones de puerta metálicos
-6,060329,bastidores de puerta metálicos
-6,060330,material fijo de funiculares
-6,060331,caperuzas de chimenea metálicas
-6,060332,goterones metálicos
-6,060332,canalones metálicos
-6,060332,canaletas metálicas
-6,060335,sifones de desagüe metálicos
-6,060336,tabiques metálicos
-6,060337,encofrados metálicos para pozos de petróleo
-6,060338,recipientes metálicos para combustibles líquidos
-6,060339,construcciones metálicas
-6,060340,contenedores flotantes metálicos
-6,060341,cuerdas metálicas
-6,060343,cornisas metálicas
-6,060344,molduras metálicas para cornisas
-6,060345,angulares metálicos
-6,060346,ventanas metálicas
-6,060347,herrajes de puerta
-6,060348,ruedecillas metálicas para puertas correderas
-6,060348,ruedecillas metálicas para puertas corredizas
-6,060349,tapas metálicas para bocas de inspección
-6,060350,cubiertas de tejado metálicas
-6,060351,ganchos metálicos para pizarras de techados
-6,060352,ganchos metálicos para percheros
-6,060353,alambres de cobre no aislados
-6,060354,cubas metálicas
-6,060355,peldaños metálicos
-6,060355,escalones metálicos
-6,060356,tubos de canalones metálicos
-6,060357,devanadoras metálicas no mecánicas para tubos flexibles
-6,060358,distribuidores de toallas fijos metálicos
-6,060359,válvulas metálicas para tuberías de agua
-6,060360,andamios metálicos
-6,060361,escalas metálicas
-6,060362,escaleras [escalas] móviles metálicas para el embarque de pasajeros
-6,060363,ligaduras metálicas
-6,060363,ataduras metálicas
-6,060364,tuercas metálicas
-6,060365,postes metálicos para líneas eléctricas
-6,060366,tuberías de ramificación metálicas
-6,060367,cercados metálicos para tumbas
-6,060368,vallas [cercas] metálicas
-6,060369,enrolladores metálicos no mecánicos para tubos flexibles
-6,060370,letreros metálicos
-6,060372,puntales metálicos
-6,060373,estaño
-6,060374,hojalata
-6,060375,láminas de estaño
-6,060376,chapas metálicas
-6,060379,cierres metálicos para bolsas
-6,060380,guarniciones metálicas para muebles
-6,060381,paneles metálicos para la construcción
-6,060381,tablas metálicas para la construcción
-6,060382,figuritas de metales comunes
-6,060382,estatuillas de metales comunes
-6,060383,tensores de cintas metálicas [estribos de tensión]
-6,060384,moldes de fundición metálicos
-6,060385,losas funerarias metálicas
-6,060385,losas sepulcrales metálicas
-6,060386,monumentos funerarios metálicos
-6,060387,placas funerarias metálicas
-6,060388,estelas funerarias metálicas
-6,060389,placas conmemorativas metálicas
-6,060389,chapas conmemorativas metálicas
-6,060390,parachispas metálicos para hornos
-6,060391,soportes metálicos para barriles
-6,060391,soportes metálicos para toneles
-6,060393,guarniciones metálicas para camas
-6,060394,guarniciones metálicas para puertas
-6,060395,cierres metálicos para recipientes
-6,060396,ataduras metálicas para gavillas
-6,060397,barreras de seguridad metálicas para carreteras
-6,060397,guardarraíles metálicos
-6,060397,guardarrieles metálicos
-6,060398,cofres metálicos
-6,060398,arcas metálicas
-6,060398,baúles metálicos
-6,060398,cajas metálicas
-6,060399,placas de identificación metálicas
-6,060400,placas de matriculación metálicas
-6,060400,matrículas metálicas
-6,060401,cermets
-6,060402,espitas metálicas para toneles
-6,060402,canillas metálicas para toneles
-6,060411,columnas publicitarias metálicas
-6,060412,boyas de amarre metálicas
-6,060413,chimeneas metálicas
-6,060414,tubos de chimenea metálicos
-6,060415,conductos metálicos para instalaciones de ventilación y aire acondicionado
-6,060416,láminas metálicas para embalar y empaquetar
-6,060417,soldaduras de oro
-6,060418,tolvas metálicas no mecánicas
-6,060419,letras y números de metales comunes, excepto caracteres de imprenta
-6,060420,colectores múltiples metálicos para canalizaciones
-6,060421,tuberías forzadas metálicas
-6,060422,cabinas telefónicas metálicas
-6,060423,cajas de herramientas metálicas, vacías
-6,060424,cofres de herramientas metálicos, vacíos
-6,060425,gallineros metálicos
-6,060426,cepos para bloquear vehículos
-6,060427,cabos de acero
-6,060428,mosquiteros [bastidores] metálicos
-6,060430,pitones metálicos
-6,060431,morillos
-6,060432,dispositivos metálicos accionados por el viento para ahuyentar aves
-6,060433,jaulas metálicas para animales salvajes
-6,060434,metales en polvo*
-6,060435,materiales de construcción refractarios metálicos
-6,060436,cenadores [estructuras] metálicos
-6,060436,glorietas [estructuras] metálicas
-6,060437,establos metálicos
-6,060438,pocilgas metálicas
-6,060439,casas prefabricadas metálicas [kits]
-6,060440,bandejas metálicas*
-6,060441,cunetas metálicas
-6,060442,tapas de rosca metálicas para botellas
-6,060443,dispositivos metálicos no eléctricos para abrir ventanas
-6,060444,dispositivos metálicos no eléctricos para cerrar ventanas
-6,060445,baldosas metálicas para paredes
-6,060446,losas de pavimentación metálicas
-6,060447,losas metálicas para la construcción
-6,060448,escalerillas [taburetes] metálicas
-6,060449,techados metálicos con células fotovoltaicas integradas
-6,060450,puertas blindadas metálicas
-6,060451,barras de apoyo metálicas para bañeras
-6,060451,asideros metálicos para bañeras
-6,060452,distribuidores metálicos fijos de bolsas para excrementos de perros
-6,060453,metales en hojas o en polvo para impresoras 3D
-6,060454,aldabillas metálicas para ventanas
-6,060455,cierres metálicos para puertas
-6,060456,tejas acanaladas metálicas
-6,060456,tejas flamencas metálicas
-6,060457,balaustres metálicos
-6,060458,recubrimientos metálicos para la construcción
-6,060459,barras de acero laminadas en caliente
-6,060460,barras de acero brillante
-6,060461,barras metálicas descortezadas
-6,060462,barras metálicas estiradas y pulidas
-6,060463,cuelgabolsos metálicos
-6,060464,escuadras metálicas para muebles
-6,060465,etiquetas metálicas
-6,060466,bidones metálicos
-6,060467,tutores metálicos para plantas o árboles
-6,060467,rodrigones metálicos para plantas o árboles
-6,060468,astas de bandera [estructuras] metálicas
-6,060469,pinzas metálicas para cerrar bolsas
-6,060470,clavijas metálicas para el calzado
-6,060471,remaches metálicos para el calzado
-6,060472,cajas de caudales electrónicas
-6,060473,puertas plegables metálicas
-6,060474,molduras metálicas para la construcción
-6,060475,mantos de chimenea metálicos
-6,060476,rampas metálicas utilizadas con vehículos
-6,060477,crucifijos de metales comunes que no sean artículos de joyería
-6,060478,puertas batientes metálicas
-6,060478,puertas de vaivén metálicas
-6,060479,bandejas de vaciado para purgar el aceite
-6,060480,astas de bandera metálicas portátiles
-6,060481,tapones metálicos para insertar en botellas
-6,060482,puertas de acordeón metálicas
-6,060483,rejillas de chimenea metálicas
-6,060484,cabinas insonorizadas metálicas, transportables
-6,060485,paneles acústicos metálicos
-6,060486,armazones metálicos para miniinvernaderos
-6,060486,armazones metálicos para camas frías
+class|name
+6|Abrazaderas metálicas
+6|Abrazaderas metálicas para cables
+6|Acero
+6|Acero bruto o semielaborado
+6|Acero en bruto
+6|Acero en forma de hojas, placas, láminas y bobinas
+6|Acero inoxidable
+6|Acero laminado
+6|Acero para latas
+6|Aceros al carbono
+6|Aceros en forma de hojas, placas, láminas y rieles
+6|Aceros enrollados
+6|Acoplamientos (juntas) hechos de metal para tuberías
+6|Adornos para pasteles de metales comunes
+6|Alambre para gallineros
+6|Alambres de latón
+6|Alambres de púas
+6|Alambres para soldar
+6|Alcantarillas de metal
+6|Aldabas metálicas para puertas
+6|Aleación de aluminio
+6|Aleaciones de acero
+6|Aleaciones de aluminio
+6|Aleaciones de metales comunes
+6|Aleaciones de níquel
+6|Aleaciones de plomo
+6|Aleaciones de titanio
+6|Aleaciones para soldadura fuerte
+6|Aluminio y sus aleaciones
+6|Anclas
+6|Anillas metálicas para llaves
+6|Arcas metálicas
+6|Armazones de acero para la construcción
+6|Armazones metálicos
+6|Aros y cadenas de metal para llaves
+6|Arquetas de desagüe metálicas para construcción de sistemas de impermeabilización de sótanos
+6|Arrabio
+6|Arrecifes artificiales metálicos para peces
+6|Artículos de aluminio o sus aleaciones, semi-acabados, en forma de fundiciones, papel, polvo o extruidos.
+6|Artículos de cerrajería metálica
+6|Artículos de lata o sus aleaciones, semi-acabados, en forma de fundiciones, papel, polvo o extruidos.
+6|Artículos de níquel o sus aleaciones, semi-acabados, en forma de fundiciones, papel, polvo o extruidos.
+6|Artículos de plomo o sus aleaciones, semi-acabados, en forma de fundiciones, papel, polvo o extruidos.
+6|Azulejos de pared metálicos
+6|Azulejos metálicos para construcción
+6|Badenes metálicos
+6|Balizas metálicos no luminosos (estructuras de torre)
+6|Balizas para carreteras que no sean luminosas o mecánicas
+6|Bandas metálicas finas
+6|Bañeras de pájaros metálicas
+6|Barandillas de metal
+6|Barras de acero acabadas en frío
+6|Barras de acero huecas
+6|Barras de cielo metálicas
+6|Barras de estaño
+6|Barras de estaño en bobinas
+6|Barras de metal
+6|Barreras de seguridad metálicas para carreteras
+6|Barrotes de rejas metálicas
+6|Baúles metálicos
+6|Bisagras metálicas
+6|Blindajes metálicos para la construcción
+6|Bolardos de amarre metálicos
+6|Bolas de acero
+6|Bordes de separación metálicos para jardines
+6|Bridas metálicas
+6|Bronce
+6|Buzones de correo metálicos
+6|Cabinas metálicas para la pulverización de pinturas en aerosol
+6|Cabinas metálicas para pulverizar pintura
+6|Cables de titanio
+6|Cables metálicos no eléctricos
+6|Cables y alambres metálicos no eléctricos
+6|Cabos de alambre
+6|Cabos de alambre de acero
+6|Cadenas metálicas para llaves
+6|Cadmio
+6|Cajas de caudales de metal
+6|Cajas de metales comunes
+6|Cajas de seguridad metálicas
+6|Cajas de seguridad metálicas resistentes al fuego
+6|Cajas fuertes de metal en forma de libros
+6|Cajas fuertes electrónicas
+6|Cajas fuertes para guardar armas
+6|Cajas metálicas para dinero
+6|Cajas metálicas para herramientas
+6|Canales de metal para ventilación
+6|Candados para bicicletas
+6|Cañerías metálicas
+6|Casas prefabricadas metálicas
+6|Cenadores transportables principalmente metálicos
+6|Cenefas de metal
+6|Cercas de alambre
+6|Cermets
+6|Cerraduras metálicas de picaporte
+6|Cerrojos metálicos
+6|Chapas de acero
+6|Chatarra de acero al carbono de bajo contenido en cobre
+6|Cierres metálicos para recipientes
+6|Cinta para fijar peluquines a la cabeza
+6|Cintas metálicas para atar
+6|Cintas metálicas para la identificación de animales de compañía
+6|Clavijas metálicas
+6|Clavos
+6|Codos del metal para tuberías incluyendo aquellas de acero aleado y titanio
+6|Cofres metálicos
+6|Colectores múltiples metálicos para canalizaciones
+6|Columnas publicitarias metálicas
+6|Conductos metálicos para instalaciones de aire acondicionado
+6|Conductos metálicos para instalaciones de ventilación
+6|Conectores metálicos para cubiertas y vigas de cubiertas
+6|Construcciones metálicas reubicables
+6|Construcciones prefabricadas de metal
+6|Construcciones prefabricadas hechas principalmente de metal
+6|Construcciones transportables metálicas
+6|Contenedores metálicos para el depósito y transporte de mercancías
+6|Contraventanas metálicas
+6|Contraventanas metálicas exteriores
+6|Corazas y acorazados
+6|Cornisas metálicas
+6|Crampones de escalada
+6|Crampones para hielo
+6|Cubas metálicas
+6|Cubiertas metálicas
+6|Depósitos de agua metálicos para uso doméstico
+6|Depósitos metálicos
+6|Depósitos metálicos de almacenamiento de gas
+6|Dispositivos metálicos accionados por el viento para ahuyentar aves
+6|Distribuidores de toallas metálicos
+6|Ductos y tuberías metálicos para instalaciones de calefacción central
+6|Encofrados metálicos
+6|Enrejados metálicos
+6|Enrejillados metálicos para tomates
+6|Escalas metálicas
+6|Escaleras de tijera y escaleras metálicas
+6|Escaleras metálicas
+6|Escuadras metálicas distanciadoras
+6|Escuadras metálicas para su uso en la construcción y montaje de cubiertas
+6|Escuadras metálicas voladizas
+6|Esculturas metálicas
+6|Esponja de hierro
+6|Espuma de aluminio estabilizada
+6|Estacas metálicas
+6|Estaño y sus aleaciones
+6|Ferroaleaciones
+6|Ganchos metálicos para colgar sombreros
+6|Gaviones de alambre metálicos
+6|Germanio
+6|Guardacabos para cuerdas
+6|Guardavivos metálicos para yeso laminado (materiales de construcción)
+6|Herrajes de metal en forma de anillo
+6|Herrajes de metal para bastones
+6|Herrajes metálicos para puertas
+6|Hierro colado
+6|Hierro colado para uso en sistemas hidráulicos, sanitarios, carreteros y en edificios
+6|Hierro forjado
+6|Hierro granulado
+6|Hierros y aceros
+6|Hilo de soldar metálico
+6|Hojas de acero galvanizado
+6|Hojas de acero revestidas de zinc
+6|Hojas de aluminio
+6|Indio
+6|Instalaciones metálicas para aparcar bicicletas
+6|Invernaderos metálicos
+6|Invernaderos transportables metálicos para uso doméstico
+6|Jambas de puerta metálicas
+6|Jaulas metálicas acampanadas para proteger plantas
+6|Jaulas metálicas para animales salvajes
+6|Jaulas metálicas para aves de corral
+6|Juntas giratorias de metal para tubos
+6|Lámina y chapa metálica para fabricación de circuitos impresos
+6|Láminas y hojas de acero
+6|Lápidas sepulcrales que no sean de metales preciosos
+6|Latas de metal
+6|Latas metálicas para bebidas
+6|Lingotes de aleaciones a base de cobre
+6|Lingotes de aleaciones de aluminio
+6|Lingotes de aleaciones de estaño
+6|Lingotes de aleaciones de magnesio
+6|Lingotes de aleaciones de níquel
+6|Lingotes de aleaciones de plomo
+6|Lingotes de aleaciones de titanio
+6|Lingotes de aleaciones de zinc
+6|Lingotes de aluminio
+6|Lingotes de cobre
+6|Lingotes de estaño
+6|Lingotes de hierro puro
+6|Lingotes de magnesio
+6|Lingotes de níquel
+6|Lingotes de zinc
+6|Llaves ciegas metálicas
+6|Llaves maestras para cerrajeros
+6|Llaves metálicas para cerraduras
+6|Losas funerarias metálicas
+6|Lupias (metalurgia)
+6|Magnesio y sus aleaciones
+6|Manguitos metálicos para la unión de cables
+6|Manijas de puerta (picaportes) metálicas
+6|Manivelas metálicas para ventanas
+6|Marcos de puerta metálicos
+6|Marcos de puertas metálicos para salas refrigeradoras
+6|Marcos de ventana metálicos
+6|Marcos metálicos para puertas correderas
+6|Marquesinas metálicas (materiales de construcción)
+6|Marquesinas metálicas para la construcción
+6|Mástiles (postes) metálicos
+6|Materiales de construcción refractarios metálicos
+6|Materiales de hierro colado para vías del ferrocarril
+6|Materiales de refuerzo, metálicos, para la construcción
+6|Materiales metálicos para andamios
+6|Materiales metálicos para construcción de ferrovías
+6|Materiales metálicos para vías de ferrocarril
+6|Metales comunes y sus aleaciones incluido el acero inoxidable
+6|Metales comunes, no forjados y semitrabajados, para fabricación posterior
+6|Metales de soldar
+6|Metales en papel de aluminio para impresoras 3D
+6|Metales no ferrosos y sus aleaciones
+6|Metales y aleaciones de metales
+6|Minerales de cobalto
+6|Minerales de cobre
+6|Minerales de cromita
+6|Minerales de estaño
+6|Minerales de hierro
+6|Minerales de molibdeno
+6|Minerales de níquel
+6|Minerales de plomo
+6|Minerales de tungsteno
+6|Minerales de zinc
+6|Minerales metálicos
+6|Moldes de metal
+6|Molduras metálicas para ventanas
+6|Mordazas para ruedas
+6|Mosquetones metálicos
+6|Mosquiteros (bastidores) metálicos
+6|Niobio
+6|Níquel y sus aleaciones
+6|Oficinas portátiles de metal
+6|Pajareras metálicas
+6|Palés de transporte metálicos
+6|Palés metálicos para almacenamiento
+6|Palés metálicos para carga y descarga
+6|Paneles metálicos de vallado
+6|Paneles metálicos para suelos
+6|Panteones metálicos
+6|Paredes de metal prefabricadas
+6|Partes de ventanas metálicas
+6|Particiones de metal para construcción
+6|Peldaños metálicos
+6|Perfiles angulares metálicos
+6|Pernos metálicos
+6|Persianas metálicas enrollables de exterior para guiar la luz
+6|Piritas de hierro
+6|Placas de identidad metálicas y placas para puertas
+6|Placas de identificación metálicas
+6|Placas de matriculación metálicas
+6|Placas de matriculación metálicas para vehículos
+6|Placas de metal
+6|Placas del metal incluyendo las de aleación de acero y titanio
+6|Placas numéricas metálicas para carreras de bicicleta
+6|Placas y chapas de acero revestidas
+6|Planchas de acero
+6|Planchas metálicas incluyendo las de aleación de acero y titanio
+6|Plata níquel
+6|Plataformas de clavados metálicas
+6|Plomo para vaciado de figuras
+6|Plomo y sus aleaciones
+6|Poleas metálicas, muelles y válvulas sin incluir elementos de máquinas
+6|Polvos de manganeso
+6|Polvos de tungsteno
+6|Pomos (tiradores) metálicos
+6|Portezuelas de buzones metálicas
+6|Portones de hierro
+6|Postes en T metálicos para vallas
+6|Postes metálicos para cercas móviles
+6|Protecciones metálicas para árboles
+6|Puertas giratorias metálicas
+6|Puertas metálicas
+6|Puertas metálicas blindadas
+6|Puertas metálicas ignífugas
+6|Puertas metálicas para uso en interiores
+6|Puertas y ventanas metálicas
+6|Puertas, ventanas, persianas y persianas listadas metálicas
+6|Puntales de metal
+6|Racores de engrase
+6|Rampas metálicas para lanzamiento de cohetes
+6|Recipientes de metal para gas a presión o aire líquido
+6|Recipientes de metal para químicos, gases a presión y líquidos
+6|Recipientes de metal para transporte
+6|Recipientes metálicos de embalaje para uso industrial
+6|Recipientes metálicos de embalaje para uso industrial no incluidos los tapones, tapaderas y cápsulas
+6|Recipientes metálicos para gas a presión
+6|Redes y mallas de alambre
+6|Remaches, crampones y clavos metálicos
+6|Residuos de aleaciones de acero
+6|Residuos de hierro o acero
+6|Revestimientos exteriores de aluminio
+6|Revestimientos metálicos (construcción)
+6|Revestimientos metálicos para construcción
+6|Revestimientos metálicos para techos
+6|Revestimientos metálicos para tejados
+6|Rieles de acero
+6|Rieles metálicos para ventanas
+6|Ruedecillas de puertas correderas
+6|Sifones de drenaje metálicos
+6|Soldadura blanda
+6|Soportes metálicos para techos
+6|Suelos de aleaciones metálicas
+6|Sujetacables metálicos
+6|Tableros de pisos metálicos
+6|Tablestacas de hierro dúctil
+6|Tablestacas metálicas
+6|Tachuelas metálicas para tapicería
+6|Tambores de acero vacíos
+6|Tanques de almacenamiento de líquidos metálicos
+6|Tanques de almacenamiento metálicos
+6|Tántalio y su aleaciones
+6|Tapas de rosca metálicas para botellas
+6|Tapas flotantes internas de aluminio para su uso con depósitos de almacenamiento de gas o gas licuado
+6|Techumbres metálicas
+6|Tejas metálicas
+6|Tejas metálicas para techos
+6|Timbres de puerta metálicos no eléctricos
+6|Tira de cobre
+6|Titanio
+6|Titanio en bruto o semielaborado
+6|Titanio y sus aleaciones
+6|Toneles metálicos
+6|Topes de armario metálicos
+6|Tornillos de rosca metálicos
+6|Tornillos metálicos
+6|Tornillos metálicos de cabeza hexagonal
+6|Torniquetes (molinetes) metálicos
+6|Tuberías de acero inoxidable
+6|Tuberías de aleaciones de cobre
+6|Tuberías de aleaciones de níquel
+6|Tuberías de conducto metálicas
+6|Tuberías de desagüe metálicas
+6|Tuberías metálicas incluyendo aquellas de aleaciones de acero y titanio
+6|Tuberías metálicas para líquidos y transferencia de gas
+6|Tuberías y tubos metálicos
+6|Tubos de acero
+6|Tubos de canalones metálicos
+6|Tubos de chimenea metálicos
+6|Tubos de ramificación de metal para tuberías
+6|Tubos de ramificación metálicos incluyendo los de acero aleado y titanio
+6|Tubos metálicos
+6|Tubos metálicos incluidos los de aleaciones de acero y titanio
+6|Tubos y tuberías de acero
+6|Tubos y tuberías metálicas
+6|Tumbas metálicas y placas metálicas para tumbas
+6|Uniones de metal para tuberías incluyendo aquellas de acero aleado y titanio
+6|Vallas (cercas) metálicas
+6|Vallas de eslabones metálicos
+6|Válvulas metálicas que no sean partes de máquinas
+6|Válvulas metálicas que no sean partes de máquinas incluyendo las del acero aleado y titanio
+6|Vanadio
+6|Varillas de acero
+6|Varillas metálicas para soldadura y braseado incluyendo las de aleación de acero y titanio
+6|Ventanas de guillotina de metal
+6|Ventanas metálicas
+6|Ventanas metálicas para tejados
+6|Vigas metálicas
+6|Viguetas de hierro o acero
+6|Yunques
+6|Zinc y sus aleaciones
+6|Zirconio

--- a/lib/seeds/class_7_terms.csv
+++ b/lib/seeds/class_7_terms.csv
@@ -1,644 +1,794 @@
-class,reference_id,name
-7,070001,acoplamientos de árbol [máquinas]
-7,070002,aparatos depuradores de acetileno
-7,070003,convertidores de acería
-7,070004,máquinas distribuidoras de cinta adhesiva
-7,070005,bombas de aireación para acuarios
-7,070006,aerocondensadores
-7,070007,agitadores*
-7,070008,máquinas agrícolas
-7,070009,elevadores para uso agrícola
-7,070010,filtros de limpieza para sistemas de refrigeración de motores
-7,070011,condensadores de aire
-7,070012,equipos para tirar cerveza
-7,070013,máquinas de ajuste
-7,070014,apisonadoras
-7,070014,aplanadoras
-7,070015,alimentadores de carburador
-7,070016,dispositivos de encendido para motores de combustión interna
-7,070018,alternadores
-7,070019,válvulas [partes de máquinas]
-7,070019,compuertas [partes de máquinas]
-7,070020,árboles para máquinas
-7,070020,ejes para máquinas
-7,070021,cigüeñales
-7,070022,árboles de transmisión que no sean para vehículos terrestres
-7,070023,ascensores
-7,070024,elevadores
-7,070026,mezcladoras [máquinas]
-7,070027,rodamientos autolubricantes
-7,070028,arados
-7,070029,motores de avión
-7,070030,máquinas para encalar
-7,070031,anillos de engrase [partes de máquinas]
-7,070032,segmentos de pistón
-7,070032,anillos de pistón
-7,070033,escobillas de dínamo
-7,070034,barredoras autopropulsadas
-7,070035,caballetes para aserrar [partes de máquinas]
-7,070036,cintas para transportadores
-7,070036,cintas transportadoras
-7,070037,transportadores de cinta
-7,070038,máquinas batidoras de mantequilla
-7,070038,máquinas batidoras de manteca
-7,070039,tambores de máquinas
-7,070040,carcasas de máquinas
-7,070041,armazones de máquinas
-7,070042,molinos [máquinas]
-7,070043,trilladoras
-7,070044,máquinas para batir
-7,070045,hormigoneras
-7,070045,mezcladoras de hormigón
-7,070046,máquinas para elaborar mantequilla
-7,070046,máquinas para elaborar manteca
-7,070047,dínamos de bicicleta
-7,070048,bielas para máquinas y motores
-7,070049,rodamientos de bolas
-7,070049,cojinetes de bolas
-7,070050,máquinas para preparar bitumen
-7,070051,guadañadoras
-7,070051,cosechadoras
-7,070052,atadoras
-7,070052,agavilladoras
-7,070054,bobinas para telares
-7,070054,carretes para telares
-7,070055,máquinas de carpintería
-7,070056,máquinas para gasificar bebidas
-7,070057,telares para calcetería
-7,070058,enfardadoras de heno
-7,070059,máquinas colectoras de fangos
-7,070061,bujías de precalentamiento para motores diésel
-7,070062,fileteadoras
-7,070063,máquinas enjuagadoras
-7,070064,máquinas llenadoras de botellas
-7,070065,lavadoras de botellas
-7,070066,máquinas para la industria cervecera
-7,070067,bastidores para máquinas de bordar
-7,070068,cepillos [partes de máquinas]
-7,070069,buldóceres
-7,070069,topadoras frontales
-7,070070,palas mecánicas
-7,070071,mortajadoras
-7,070071,escopleadoras
-7,070072,cabrestantes
-7,070073,rezones automáticos para uso marino
-7,070074,correas de máquinas
-7,070075,cubiertas [partes de máquinas]
-7,070076,componedoras [imprenta]
-7,070077,inyectores para motores
-7,070078,carburadores
-7,070079,guarniciones para máquinas de cardar
-7,070080,hojas [partes de máquinas]
-7,070081,cajas para matrices [imprenta]
-7,070082,tamices para cenizas [máquinas]
-7,070083,desnatadoras
-7,070083,separadores de crema
-7,070083,descremadoras
-7,070083,separadores de nata
-7,070084,secadoras centrífugas
-7,070085,lubricadores [partes de máquinas]
-7,070085,engrasadores [partes de máquinas]
-7,070086,centrifugadoras [máquinas]
-7,070087,molinos centrífugos
-7,070088,bombas centrífugas
-7,070089,descascaradoras de cereales
-7,070090,fresadoras
-7,070091,soportes de cojinetes para máquinas
-7,070092,soportes para máquinas
-7,070092,asientos [soportes para máquinas]
-7,070093,escobillas de carbón [electricidad]
-7,070094,rozadoras de carbón
-7,070095,montacargas
-7,070096,rampas de carga
-7,070097,carros para máquinas de tejer
-7,070097,correderas para máquinas de tejer
-7,070098,tornos [máquinas herramientas]
-7,070099,polipastos
-7,070099,poleas*
-7,070100,rejas de arado
-7,070100,manceras de arado
-7,070101,accesorios para calderas de máquinas
-7,070102,prensas de vino
-7,070103,máquinas industriales para fabricar cigarrillos
-7,070104,curvadoras
-7,070105,cizallas eléctricas
-7,070106,tijeras eléctricas
-7,070107,cinceles para máquinas
-7,070108,válvulas de charnela para máquinas
-7,070109,prensas filtradoras
-7,070110,colectores de incrustaciones para calderas de máquinas
-7,070111,sistemas de accionamiento por pedal para máquinas de coser
-7,070112,fotocomponedoras
-7,070113,compresoras [máquinas]
-7,070114,turbocompresores
-7,070115,condensadores de vapor [partes de máquinas]
-7,070116,instalaciones de condensación
-7,070117,poleas [partes de máquinas]
-7,070118,juntas [partes de motores]
-7,070118,juntas de estanqueidad
-7,070119,trenzadoras de cuerdas
-7,070120,fundidoras de caracteres de imprenta
-7,070122,tundidoras [máquinas]
-7,070123,cortadoras [máquinas]
-7,070124,generadores de corriente
-7,070125,coronas de sondeo [partes de máquinas]
-7,070126,correas para dínamos
-7,070127,correas para elevadores
-7,070128,máquinas de coser pliegos
-7,070129,dispositivos para mover cargas por colchón de aire
-7,070130,cojinetes [partes de máquinas]
-7,070131,cuchillos eléctricos
-7,070132,gatos de cremallera
-7,070133,instalaciones de cribado
-7,070135,gatos [máquinas]
-7,070135,crics
-7,070136,máquinas para trabajar el cuero
-7,070137,culatas de cilindros de motor
-7,070138,cultivadoras [máquinas]
-7,070139,cilindros de máquinas
-7,070140,cilindros de imprenta
-7,070141,cilindros de laminadores
-7,070143,máquinas seleccionadoras para uso industrial
-7,070143,máquinas clasificadoras para uso industrial
-7,070145,tolvas de descarga mecánica
-7,070146,recortadoras
-7,070147,desaireadores [desgasificadores] de agua de alimentación
-7,070147,desgasificadores [desaireadores] de agua de alimentación
-7,070148,extractoras de césped
-7,070148,extractoras de pasto
-7,070149,desengrasadoras [máquinas]
-7,070150,arranques para motores
-7,070151,máquinas encajeras
-7,070151,máquinas para hacer encajes
-7,070152,separadores de aceite y vapor
-7,070153,desintegradores
-7,070154,manorreductores de presión [partes de máquinas]
-7,070155,devanadoras mecánicas
-7,070157,desbastadoras de cuero
-7,070158,máquinas de drenaje
-7,070159,máquinas desbarbadoras
-7,070159,máquinas enderezadoras
-7,070159,aparatos de mecanizado
-7,070160,dínamos
-7,070162,pulverizadores para aguas residuales
-7,070163,máquinas para gasificar el agua
-7,070164,aparatos para mineralizar el agua potable
-7,070165,calentadores de agua en cuanto partes de máquinas
-7,070166,descarnadoras
-7,070167,aterrajadoras
-7,070167,roscadoras
-7,070168,despalilladoras [máquinas]
-7,070168,separadoras de raspones
-7,070169,desgranadoras
-7,070170,eyectores
-7,070171,generadores de electricidad
-7,070172,aparatos elevadores
-7,070173,prensas de embutir
-7,070174,embragues que no sean para vehículos terrestres
-7,070175,aparatos entintadores [imprenta]
-7,070176,dispositivos de arrastre [partes de máquinas]
-7,070177,máquinas de envolver
-7,070178,escaleras mecánicas
-7,070179,bombas [partes de máquinas o motores]
-7,070180,timbradoras
-7,070181,máquinas estampadoras
-7,070181,máquinas troqueladoras
-7,070182,etiquetadoras
-7,070183,estiradoras
-7,070184,excavadoras
-7,070185,extractores para minería
-7,070186,henificadoras
-7,070187,tamices [máquinas o partes de máquinas]
-7,070188,cuchillas de segadoras
-7,070189,cuchillas [partes de máquinas]
-7,070190,hiladoras [máquinas]
-7,070191,ruecas
-7,070191,tornos de hilar
-7,070192,filtradoras
-7,070193,acabadoras [máquinas]
-7,070194,mandriles [partes de máquinas]
-7,070195,prensas para forraje
-7,070196,máquinas de fundición
-7,070197,pistones para cilindros
-7,070198,prensaestopas [partes de máquinas]
-7,070199,sopladores para comprimir, aspirar y transportar gases
-7,070201,cortadoras de césped [máquinas]
-7,070201,cortadoras de pasto [máquinas]
-7,070202,alquitranadoras
-7,070202,asfaltadoras
-7,070203,sopladores para comprimir, aspirar y transportar granos
-7,070204,cajas de engrase [partes de máquinas]
-7,070204,cajas de engrase [máquinas]
-7,070205,bombas de engrase
-7,070206,máquinas gofradoras
-7,070206,máquinas para repujar
-7,070207,máquinas de grabado
-7,070208,muescadoras [máquinas herramientas]
-7,070209,guías de máquinas
-7,070210,cortadoras de paja
-7,070211,picadoras de carne [máquinas]
-7,070212,bastidores para telares
-7,070212,engranajes para telares
-7,070213,rastras
-7,070214,pulverizadoras [máquinas]
-7,070214,atomizadoras
-7,070214,máquinas atomizadoras
-7,070215,turbinas hidráulicas
-7,070216,máquinas para imprimir sobre chapas metálicas
-7,070217,planchas de impresión
-7,070218,máquinas de imprimir
-7,070219,prensas de imprimir
-7,070220,rodillos de imprenta para máquinas
-7,070222,máquinas para la industria lechera
-7,070223,cuchillas de cortadoras de paja
-7,070224,lizos de telar
-7,070225,máquinas afiladoras de cuchillas
-7,070226,hojas de sierras [partes de máquinas]
-7,070227,portasierras [partes de máquinas]
-7,070228,máquinas laminadoras
-7,070229,lanzas térmicas [máquinas]
-7,070230,manivelas [partes de máquinas]
-7,070231,lavaplatos [máquinas]
-7,070231,lavavajillas [máquinas]
-7,070233,aparatos de lavado
-7,070234,lavadoras
-7,070234,máquinas para lavar la ropa
-7,070234,lavarropas
-7,070235,instalaciones de lavado de vehículos
-7,070236,lavadoras que funcionan con monedas
-7,070237,aparatos de levantamiento
-7,070239,escurridoras de ropa
-7,070240,máquinas alisadoras
-7,070241,máquinas motrices que no sean para vehículos terrestres
-7,070242,máquinas de vapor
-7,070243,máquinas herramientas
-7,070244,magnetos de encendido
-7,070245,aparatos de manipulación para carga y descarga
-7,070246,marginadores [imprenta]
-7,070246,alimentadores de papel
-7,070247,martillos [partes de máquinas]
-7,070248,martillos pilones
-7,070249,martillos neumáticos
-7,070250,martinetes
-7,070251,mástiles de carga
-7,070252,mecanismos de propulsión que no sean para vehículos terrestres
-7,070253,mecanismos de transmisión que no sean para vehículos terrestres
-7,070254,reguladores [partes de máquinas]
-7,070255,máquinas para procesar tabaco
-7,070256,trituradoras eléctricas para uso doméstico
-7,070257,diafragmas de bombas
-7,070258,máquinas para trabajar metales
-7,070258,máquinas para conformar metales
-7,070259,telares
-7,070260,máquinas hiladoras
-7,070262,muelas de molino
-7,070263,máquinas para moler
-7,070264,taladros de minería
-7,070265,aparatos de tratamiento de minerales metalíferos
-7,070265,aparatos de tratamiento de menas
-7,070266,máquinas para la industria harinera
-7,070267,batidoras*
-7,070268,segadoras
-7,070269,segadoras-agavilladoras
-7,070270,segadoras-trilladoras
-7,070271,montavagones
-7,070272,motores de reacción que no sean para vehículos terrestres
-7,070273,dispositivos anticontaminación para motores
-7,070274,pistones de motor
-7,070275,reguladores de velocidad para máquinas y motores
-7,070276,moldes [partes de máquinas]
-7,070277,molinillos para uso doméstico que no sean manuales
-7,070278,máquinas para hacer molduras
-7,070279,ruedas libres que no sean para vehículos terrestres
-7,070280,lanzaderas [partes de máquinas]
-7,070281,máquinas y aparatos de limpieza eléctricos
-7,070282,máquinas de aspiración para uso industrial
-7,070283,máquinas para hacer dobladillos
-7,070284,herramientas de mano que no sean accionadas manualmente
-7,070285,herramientas [partes de máquinas]
-7,070286,portaherramientas [partes de máquinas]
-7,070287,abrelatas eléctricos
-7,070288,máquinas para cortar pan
-7,070289,cajas de eje [partes de máquinas]
-7,070290,cojinetes para árboles de transmisión
-7,070291,máquinas para fabricar papel
-7,070292,calandrias [máquinas]
-7,070294,máquinas empaquetadoras
-7,070295,amasadoras mecánicas
-7,070296,máquinas eléctricas para elaborar pastas alimenticias
-7,070297,máquinas para pintar
-7,070298,pistolas para pintar
-7,070299,perforadoras*
-7,070300,taladradoras de mano eléctricas
-7,070301,máquinas para trabajar la piedra
-7,070302,pistones [partes de máquinas o de motores]
-7,070303,prensas tipográficas
-7,070304,transportadores neumáticos
-7,070305,punzones para máquinas punzonadoras
-7,070306,máquinas punzonadoras
-7,070307,molinillos de pimienta que no sean manuales
-7,070308,máquinas y aparatos de pulir eléctricos
-7,070309,bombas [máquinas]
-7,070310,bombas de aire [instalaciones para talleres de reparación de automóviles]
-7,070311,bombas para instalaciones de calefacción
-7,070312,bombas de vacío [máquinas]
-7,070313,puentes rodantes
-7,070314,bandas adhesivas para poleas
-7,070315,aparatos electromecánicos para preparar bebidas
-7,070316,prensas [máquinas para uso industrial]
-7,070317,reguladores de presión [partes de máquinas]
-7,070318,válvulas de presión [partes de máquinas]
-7,070319,máquinas de pudelar
-7,070320,purgadores automáticos
-7,070320,purgadores de vapor
-7,070321,cepilladoras
-7,070322,máquinas para colocar rieles
-7,070322,máquinas para colocar raíles
-7,070323,rastrillos para máquinas rastrilladoras
-7,070324,máquinas rastrilladoras
-7,070325,máquinas frisadoras
-7,070325,ratinadoras
-7,070326,rectificadoras
-7,070327,aparatos y máquinas de encuadernación para uso industrial
-7,070328,máquinas de planchar
-7,070329,máquinas de zurcir
-7,070330,resortes [partes de máquinas]
-7,070331,dispositivos eléctricos para correr cortinas
-7,070332,remachadoras
-7,070333,grifos [partes de máquinas o motores]
-7,070334,rotativas [máquinas]
-7,070335,engranajes de máquinas
-7,070335,mecanismos de máquinas
-7,070336,ruedas de máquinas
-7,070337,volantes de máquinas
-7,070338,cojinetes de rodillos
-7,070338,cojinetes de agujas
-7,070339,anillos de bolas para rodamientos
-7,070340,máquinas para construir carreteras
-7,070341,sierras [máquinas]
-7,070342,máquinas de explotación minera
-7,070343,correas para motores
-7,070344,máquinas de escardar
-7,070345,máquinas satinadoras
-7,070346,máquinas para fabricar salchichas
-7,070347,máquinas estampilladoras para uso industrial
-7,070348,sembradoras [máquinas]
-7,070349,soldadoras eléctricas
-7,070350,fuelles [partes de máquinas]
-7,070351,sopladores de fragua
-7,070352,hormas para zapatos [partes de máquinas]
-7,070353,máquinas de decantar
-7,070353,máquinas llenadoras
-7,070354,estatores
-7,070355,máquinas de estereotipar
-7,070356,máquinas para elaborar azúcar
-7,070357,sobrecalentadores
-7,070358,sobrealimentadores
-7,070359,mesas de máquinas
-7,070360,faldones de máquinas
-7,070360,delantales de carro
-7,070362,máquinas de teñir
-7,070364,máquinas de cardar
-7,070365,soportes de carro [partes de máquinas]
-7,070366,gorrones [partes de máquinas]
-7,070367,ordeñadoras [máquinas]
-7,070368,ventosas para ordeñadoras [máquinas]
-7,070369,transmisiones de máquinas
-7,070370,instalaciones neumáticas de transporte por tubos
-7,070371,transportadores [máquinas]
-7,070372,máquinas trenzadoras
-7,070373,cabrias
-7,070374,tejedoras [máquinas]
-7,070374,máquinas de tejer
-7,070375,turbinas que no sean para vehículos terrestres
-7,070376,enrolladores mecánicos para mangueras
-7,070376,devanadoras mecánicas para mangueras
-7,070377,tímpanos [imprenta]
-7,070378,máquinas tipográficas
-7,070379,aventadoras
-7,070380,motores para vehículos de colchón de aire
-7,070381,ventiladores para motores
-7,070382,máquinas para trabajar el vidrio
-7,070383,máquinas para construir vías férreas
-7,070384,aparatos de vulcanización
-7,070385,acoplamientos que no sean para vehículos terrestres
-7,070386,motores de aeronáutica
-7,070387,máquinas afiladoras
-7,070388,instrumentos agrícolas que no sean accionados manualmente
-7,070389,muelas de afilado [partes de máquinas]
-7,070390,bombas de cerveza
-7,070391,motores de aire comprimido
-7,070392,máquinas de aire comprimido
-7,070393,bombas de aire comprimido
-7,070394,bujías de encendido para motores de combustión interna
-7,070394,bujías de encendido para motores de explosión
-7,070395,pistones de amortiguadores [partes de máquinas]
-7,070396,cojinetes antifricción para máquinas
-7,070396,rodamientos antifricción para máquinas
-7,070396,rodamientos [partes de máquinas o motores]
-7,070397,arrancadoras [máquinas]
-7,070397,cavadoras [máquinas]
-7,070398,máquinas de aspiración de aire
-7,070400,economizadores de combustible para motores
-7,070401,máquinas de barco
-7,070402,motores de barco
-7,070402,motores de canoa
-7,070403,batidoras eléctricas
-7,070404,arietes [máquinas]
-7,070404,martinetes [máquinas]
-7,070405,forros de freno que no sean para vehículos
-7,070406,zapatas de freno que no sean para vehículos
-7,070407,segmentos de freno que no sean para vehículos
-7,070408,bobinas para máquinas
-7,070408,canillas [partes de máquinas]
-7,070409,cajas de cambio que no sean para vehículos terrestres
-7,070410,taponadoras de botellas [máquinas]
-7,070411,capsuladoras de botellas [máquinas]
-7,070412,precintadoras de botellas [máquinas]
-7,070413,escobillas eléctricas [partes de máquinas]
-7,070414,trituradoras de residuos
-7,070414,trituradoras de basura
-7,070415,molinillos de café que no sean accionados manualmente
-7,070416,tubos de humos para calderas de máquinas
-7,070417,máquinas de movimiento de tierras
-7,070418,compactadoras de desechos
-7,070418,compactadoras de residuos
-7,070419,máquinas desmenuzadoras para uso industrial
-7,070420,tornos de alfarero
-7,070421,máquinas de manipulación industriales
-7,070422,robots industriales
-7,070423,aparatos electromecánicos para preparar alimentos
-7,070424,cartuchos para máquinas de filtrar
-7,070425,cadenas de accionamiento que no sean para vehículos terrestres
-7,070426,convertidores de par que no sean para vehículos terrestres
-7,070427,cadenas de transmisión que no sean para vehículos terrestres
-7,070427,cadenas motrices que no sean para vehículos terrestres
-7,070428,portabrocas [partes de máquinas]
-7,070429,calderas de máquinas
-7,070430,alimentadores de calderas de máquinas
-7,070431,esquiladoras [máquinas]
-7,070433,motores que no sean para vehículos terrestres
-7,070434,cables de mando para máquinas o motores
-7,070435,dispositivos de mando para máquinas o motores
-7,070436,matrices de imprenta
-7,070437,compresores para refrigeradores
-7,070437,compresores para frigoríficos
-7,070439,separadores de agua
-7,070439,grifos de purga
-7,070440,máquinas de coser
-7,070441,correas de ventilador para motores
-7,070442,incubadoras de huevos
-7,070443,engranajes que no sean para vehículos terrestres
-7,070444,mezcladores eléctricos para uso doméstico
-7,070445,máquinas de cocina eléctricas
-7,070446,cilindros de motor
-7,070447,desmultiplicadores que no sean para vehículos terrestres
-7,070448,máquinas divisoras
-7,070449,coronas de perforación [partes de máquinas]
-7,070450,intercambiadores térmicos [partes de máquinas]
-7,070451,tubos de escape para motores
-7,070452,motores eléctricos que no sean para vehículos terrestres
-7,070453,grúas [aparatos de levantamiento]
-7,070454,máquinas mondadoras
-7,070455,máquinas para rallar hortalizas
-7,070456,pistolas de aire comprimido para extrudir masillas
-7,070457,filtros en cuanto partes de máquinas o motores
-7,070458,zanjadoras [arados]
-7,070458,binadores
-7,070459,batidores eléctricos para uso doméstico
-7,070460,exprimidores de fruta eléctricos para uso doméstico
-7,070461,motores hidráulicos
-7,070462,torres de perforación flotantes o no
-7,070463,convertidores de combustible para motores de combustión interna
-7,070464,radiadores de refrigeración para motores
-7,070471,tubos de calderas [partes de máquinas]
-7,070472,mandos hidráulicos para máquinas y motores
-7,070473,mandos neumáticos para máquinas y motores
-7,070474,cárteres para máquinas y motores
-7,070475,robots de cocina eléctricos
-7,070475,procesadores de alimentos eléctricos
-7,070476,pistolas de cola eléctricas
-7,070477,pistolas [herramientas con cartuchos explosivos]
-7,070478,cabrestantes para la pesca
-7,070478,máquinas para izar redes de pesca
-7,070479,juntas de cardán
-7,070480,prensas de vapor rotativas y portátiles para tejidos
-7,070481,máquinas eléctricas para lavar alfombras y moquetas
-7,070482,convertidores catalíticos
-7,070483,instalaciones centrales de limpieza al vacío
-7,070484,sierras de cadena
-7,070485,aparatos de limpieza a vapor
-7,070486,sopletes cortadores a gas
-7,070487,instalaciones de aspiración de polvo para limpiar
-7,070488,instalaciones de desempolvado para limpiar
-7,070489,martillos eléctricos
-7,070490,máquinas electromecánicas para la industria química
-7,070491,cadenas de elevador [partes de máquinas]
-7,070492,grupos electrógenos de emergencia
-7,070493,depósitos de expansión [partes de máquinas]
-7,070493,tanques de expansión [partes de máquinas]
-7,070494,diamantes de vidriero [partes de máquinas]
-7,070495,aparatos de limpieza de alta presión
-7,070496,máquinas para la industria textil
-7,070497,colectores de escape para motores
-7,070498,máquinas de refinación del petróleo
-7,070499,máquinas de empaquetar
-7,070500,enceradoras de parqué eléctricas
-7,070501,lustradoras de calzado eléctricas
-7,070502,quitanieves
-7,070503,soldadores de gas
-7,070504,sopletes de soldadura a gas
-7,070505,hierros de soldadura a gas
-7,070506,accesorios de aspiradoras para difundir perfumes y desinfectantes
-7,070506,accesorios de aspiradores para difundir perfumes y desinfectantes
-7,070507,tubos de aspiradoras
-7,070507,tubos de aspiradores
-7,070508,aspiradoras
-7,070508,aspiradores
-7,070509,vibradoras [máquinas] para uso industrial
-7,070510,máquinas y aparatos eléctricos para encerar suelos
-7,070510,máquinas y aparatos eléctricos para encerar pisos
-7,070511,máquinas de encordar raquetas
-7,070512,máquinas para montar bicicletas
-7,070513,motocultores
-7,070514,aerógrafos para colorear
-7,070515,dispositivos hidráulicos de apertura de puertas
-7,070516,arranques de pedal para motocicletas
-7,070517,máquinas mecánicas de distribución de alimentos para el ganado
-7,070518,cintas transportadoras de personas
-7,070518,pasillos mecánicos
-7,070519,silenciadores para motores
-7,070520,dispositivos neumáticos de apertura de puertas
-7,070521,bolsas para aspiradoras
-7,070522,sopletes a gas
-7,070523,turbinas eólicas
-7,070524,pastillas de freno que no sean para vehículos
-7,070525,electrodos para soldadoras
-7,070526,aparatos de soldadura eléctrica
-7,070528,soldadores eléctricos
-7,070528,aparatos de soldar eléctricos
-7,070529,hierros de soldadura eléctricos
-7,070530,aparatos de soldadura por arco eléctrico
-7,070531,aparatos de corte por arco eléctrico
-7,070532,lámparas para soldar
-7,070532,sopletes de soldadura
-7,070533,lagares
-7,070534,máquinas de soplado
-7,070535,máquinas de galvanoplastia
-7,070536,máquinas de galvanización
-7,070537,distribuidores automáticos
-7,070537,máquinas expendedoras
-7,070538,cierres eléctricos de puertas
-7,070539,dispositivos eléctricos de apertura de puertas
-7,070540,dispositivos de mando para ascensores
-7,070541,aparatos eléctricos para sellar envases plásticos
-7,070542,surtidores de combustible para estaciones de servicio [gasolineras]
-7,070543,bombas autorreguladoras de combustible
-7,070544,máquinas para el tratamiento [transformación] de materias plásticas
-7,070545,dispositivos eléctricos de apertura de ventanas
-7,070546,dispositivos eléctricos de cierre de ventanas
-7,070547,dispositivos hidráulicos de apertura de ventanas
-7,070548,dispositivos hidráulicos de cierre de ventanas
-7,070549,dispositivos neumáticos de apertura de ventanas
-7,070550,dispositivos neumáticos de cierre de ventanas
-7,070551,dispositivos hidráulicos de cierre de puertas
-7,070552,dispositivos neumáticos de cierre de puertas
-7,070553,molinillos eléctricos de cocina
-7,070554,gatos neumáticos
-7,070555,impresoras 3D
-7,070556,máquinas de tamizado
-7,070557,bancadas de motor que no sean para vehículos terrestres
-7,070557,soportes de motor que no sean para vehículos terrestres
-7,070558,extractores de clavos eléctricos
-7,070558,sacaclavos eléctricos
-7,070559,cepillos para aspiradoras
-7,070560,herramientas eléctricas para afilar cantos de esquís
-7,070561,machacadoras
-7,070562,apisonadores [máquinas]
-7,070563,boquilla de succión para aspiradoras
-7,070564,raspatubos
-7,070565,extractores de zumo eléctricos
-7,070565,extractores de jugo eléctricos
-7,070566,destornilladores eléctricos
-7,070567,palancas de mando [joysticks] en cuanto partes de máquinas, que no sean para máquinas de juego
-7,070568,árboles de levas para motores de vehículos
-7,070569,trenes de rodamiento de caucho en cuanto partes de orugas de máquinas de construcción
-7,070570,trenes de rodamiento de caucho en cuanto partes de orugas de máquinas y aparatos de carga y descarga
-7,070571,trenes de rodamiento de caucho en cuanto partes de orugas de máquinas agrícolas
-7,070572,trenes de rodamiento de caucho en cuanto partes de orugas de máquinas de explotación minera
-7,070573,trenes de rodamiento de caucho en cuanto partes de orugas de quitanieves
-7,070574,drenadores neumáticos de aceite usado
-7,070574,recuperadores neumáticos de aceite usado
-7,070575,bombas para la natación contracorriente
-7,070576,bolígrafos de impresión 3D
-7,070577,máquinas de labranza para uso agrícola
-7,070578,cortadores de verduras, hortalizas en espiral eléctricos
-7,070579,dispensadores de hidrógeno para estaciones de servicio
-7,070580,máquinas de impresión por chorro de tinta para uso industrial
-7,070581,mopas de vapor
-7,070581,trapeadores de vapor
-7,070582,trajes robóticos de exoesqueleto que no sean para uso médico
-7,070583,grúas móviles
-7,070584,unidades flotantes de producción, almacenamiento y descarga [FPAD]
-7,070585,cortadoras de queso eléctricas
-7,070586,peladores eléctricos de verduras y hortalizas
+class|name
+7|Acoplamientos de ejes como piezas de máquinas
+7|Acoplamientos de máquinas y componentes de transmisión excepto para vehículos terrestres
+7|Acoplamientos para máquinas
+7|Acoplamientos y transmisión de máquinas, excepto para vehículos terrestres
+7|Afiladores de taladros de minería
+7|Agarres y aparatos para la transmisión de electricidad que no sean para vehículos terrestres
+7|Agitadores para procesos químicos
+7|Alimentadora de sobres
+7|Alimentadores electrónicos para animales
+7|Alternadores
+7|Alternadores de arranque
+7|Amasadoras mecánicas para el procesamiento químico
+7|Amoladoras angulares
+7|Amoladoras de mano y accionadas eléctricamente
+7|Amoladoras eléctricas
+7|Amoladoras giratorias
+7|Amoladoras y pulidoras
+7|Amortiguadores (herramientas eléctricas)
+7|Aparatos de elevación mecánicos y neumáticos
+7|Aparatos de limpieza a vapor
+7|Aparatos de soldadura eléctrica al arco
+7|Aparatos para elaborar aguas minerales
+7|Aparatos vulcanizadores de caucho
+7|Aplanadoras
+7|Arados de carbón
+7|Árboles de levas
+7|Árboles para máquinas
+7|Arrancapilotes
+7|Arranques de pedal para motocicletas
+7|Arranques para motores
+7|Aspiradoras
+7|Aspiradoras eléctricas
+7|Aspiradoras manuales
+7|Aspiradoras para uso comercial e industrial
+7|Aspiradoras para uso doméstico
+7|Aspiradoras para uso industrial
+7|Aspiradoras robóticas
+7|Aspiradores inalámbricos
+7|Astilladoras de madera
+7|Atadoras
+7|Aventadoras
+7|Bandas de rodadura de goma para su uso con orugas en maquinaria agrícola
+7|Bandas de rodadura de goma para su uso con orugas en maquinaria de construcción
+7|Bandas de rodadura de goma para su uso con orugas en maquinaria de minería
+7|Bandas de rodadura de goma para su uso con orugas en maquinaria quitanieves
+7|Barredoras autopropulsadas
+7|Barredoras de caminos autopropulsadas
+7|Barredoras inalámbricas
+7|Barrenas de tierra
+7|Bastidores de lavavajillas que son piezas de un lavavajillas
+7|Batidoras eléctricas de preparaciones alimenticias para bebés para uso doméstico
+7|Batidoras eléctricas manuales de uso doméstico
+7|Batidoras eléctricas para uso doméstico
+7|Bielas para máquinas y motores
+7|Bloques de motor para automóviles
+7|Bobinas automatizadas para mangueras de jardín
+7|Bobinas de encendido para motores de automóviles
+7|Bobinas para máquinas de coser
+7|Bolsas para aspiradoras
+7|Bombas como partes de máquinas y motores
+7|Bombas de alta presión para limpieza de instalaciones y aparatos
+7|Bombas de combustible a motor
+7|Bombas de combustible para motores de vehículos terrestres
+7|Bombas de succión
+7|Bombas de tornillo
+7|Bombas de tornillo de múltiples fases
+7|Bombas de vacío
+7|Bombas de vacío (máquinas)
+7|Bombas eléctricas
+7|Bombas hidráulicas
+7|Bombas lobulares rotatorias
+7|Bombas neumáticas
+7|Bombas para acuario
+7|Bombas para la industria de bebidas
+7|Bombas para máquinas
+7|Bombas que hacen olas para acuarios
+7|Bombas y compresores como partes de máquinas para máquinas y motores
+7|Brocas de centrado que sean partes de máquinas
+7|Brocas de corona
+7|Brocas para máquinas de minería
+7|Brocas para minería
+7|Brocas para taladrar roca
+7|Brocas para taladro eléctrico
+7|Bujías de encendido para motores de vehículos terrestres
+7|Bujías de precalentamiento para motores diésel
+7|Bulldozers
+7|Cabezales de corte para cortacéspedes
+7|Cables para ascensores
+7|Cabrestantes de arrastre
+7|Cabrias
+7|Cadenas de accionamiento que no sean para vehículos terrestres
+7|Cadenas de transmisión que no sean para vehículos terrestres
+7|Cadenas transportadoras
+7|Cajas de cambio que no sean para vehículos terrestres
+7|Cajas de eje (partes de máquinas)
+7|Cajas de hilatura para máquinas hiladoras de rotor de extremo abierto
+7|Calandrias de papel
+7|Calderas de máquinas
+7|Caminadores mecánicos para caballos
+7|Carburadores
+7|Cargadores con bandas de rodamiento de oruga
+7|Cargadores con deslizadera
+7|Cárteres para máquinas y motores
+7|Catenarias de goma para su uso con cintas transportadoras en máquinas y dispositivos de carga y descarga
+7|Centrifugadoras de aceite
+7|Centrífugas
+7|Cepilladoras eléctricas
+7|Cepilladoras para trabajar metales
+7|Cepillos eléctricos como partes de máquinas
+7|Cepillos para máquinas aspiradoras
+7|Cepillos que sean partes de máquinas
+7|Cestas de utensilios para máquinas lavavajillas (como partes de las mismas)
+7|Cierres eléctricos de puertas
+7|Cilindros de motor para automóviles
+7|Cinceladoras (máquinas herramientas)
+7|Cintas transportadoras
+7|Cintas transportadoras de malla metálica
+7|Cintas transportadoras para personas
+7|Cizallas eléctricas (máquinas)
+7|Cizallas mecánicas para metalistería
+7|Cizallas neumáticas
+7|Cojinetes de deslizamiento para máquinas
+7|Cojinetes para motores
+7|Colectores de admisión para motores de combustión interna
+7|Colectores de escape para motores
+7|Componentes de acoplamientos y transmisión de máquinas, excepto para vehículos terrestres, y sus piezas
+7|Compresores como partes de máquinas y motores
+7|Compresores de aire
+7|Compresores de aire para vehículos
+7|Compresores para aires acondicionados
+7|Compresores para máquinas
+7|Compresores para máquinas deshumidificadoras
+7|Compresores para recuperación y el reciclado de gases refrigerantes
+7|Compresores para refrigeradores
+7|Convertidores catalíticos
+7|Convertidores hidráulicos de par (elementos de máquinas que no sean para vehículos terrestres)
+7|Correas de distribución para máquinas
+7|Correas de máquinas
+7|Correas de motores
+7|Correas de tiempo para motores de vehículos terrestres
+7|Correas de transmisión eléctricas para máquinas y motores empleados en aplicaciones industriales
+7|Correas de transmisión que no sean para vehículos terrestres
+7|Correas para máquinas de vehículos agrícolas
+7|Corredores neumáticos de tuerca
+7|Cortacéspedes eléctricos
+7|Cortadoras de cepas de árboles
+7|Cortadoras de césped
+7|Cortadoras de césped a gasolina
+7|Cortadoras de césped mecánicas
+7|Cortadoras de forraje eléctricas
+7|Cortadoras de fresadoras de rosca (máquinas herramientas)
+7|Cortadoras de setos eléctricas
+7|Cortadoras de trincheras
+7|Cortadores eléctricos de alimentos
+7|Cosechadoras (máquinas agrícolas)
+7|Cuadernales eléctricos
+7|Cubos cargadores para excavadoras
+7|Cuchillos eléctricos
+7|Culatas de cilindros de motor
+7|Cultivadoras eléctricas
+7|Descascaradoras de cereales
+7|Descascarilladoras de arroz
+7|Descortezadoras de cereales
+7|Desintegradores para procesamiento químico
+7|Desmotadoras de algodón
+7|Destornilladores de aire comprimido
+7|Destornilladores eléctricos
+7|Destornilladores neumáticos
+7|Diafragmas de bombas
+7|Diamantes de vidriero como partes de máquinas
+7|Dínamos
+7|Dínamos para bicicleta
+7|Discos de aletas para rectificadoras eléctricas
+7|Dispositivos cierra puertas hidráulicos
+7|Dispositivos cierra puertas neumáticos
+7|Dispositivos de accionamiento para elevadores
+7|Dispositivos de corte que sean partes de máquinas
+7|Dispositivos de encendido para motores de vehículos terrestres
+7|Dispositivos eléctricos de apertura de puertas
+7|Dispositivos eléctricos para correr cortinas
+7|Distribuidores automáticos
+7|Distribuidores frigoríficos automáticos
+7|Elevadores
+7|Elevadores de escalera
+7|Elevadores mecánicos e hidráulicos
+7|Elevadores para coches
+7|Elevadores y partes de elevadores
+7|Elevadores y sus partes
+7|Embaladoras para uso agrícola
+7|Embaladoras para uso industrial
+7|Embragues para máquinas
+7|Embragues que no sean para vehículos terrestres
+7|Embutidoras de salchichas
+7|Empacadora
+7|Empaquetadoras al vacío
+7|Encendidos electrónicos para vehículos
+7|Enceradoras eléctricas para uso industrial
+7|Escaleras mecánicas
+7|Escariadores (máquinas herramientas)
+7|Escobas eléctricas
+7|Escobillas de dínamo
+7|Esmeril angular (herramientas de mano que no sean accionadas manualmente)
+7|Espumadores de leche eléctricos
+7|Estatores como piezas de máquinas
+7|Excavadoras hidráulicas
+7|Exprimidores de fruta eléctricos para uso doméstico
+7|Exprimidores eléctricos de zumo de frutas
+7|Exprimidores eléctricos para frutas y verduras
+7|Extractoras de miel (máquinas)
+7|Extractores de jugo
+7|Extractores de jugo de frutas eléctricos
+7|Fileteadoras
+7|Filtros de aceite para motores
+7|Filtros de aire para motores de vehículos
+7|Filtros de combustible para motores de vehículos
+7|Filtros para aceite
+7|Filtros para motores
+7|Filtros para polvo y bolsas para aspiradoras
+7|Flejadoras
+7|Fotocomponedoras
+7|Fregadores de suelo automáticos
+7|Frenos de cinta (elementos de máquinas que no sean para vehículos terrestres)
+7|Frenos para máquinas industriales
+7|Fresadoras
+7|Fresadoras de fieltro
+7|Fresadoras para madera
+7|Fresadoras para trabajar metales
+7|Fresas como partes de máquinas
+7|Fresas de módulo (máquinas herramientas)
+7|Fresas para máquinas fresadoras
+7|Fundidoras de caracteres de imprenta
+7|Gatos eléctricos
+7|Gatos hidráulicos
+7|Generador de alto voltaje
+7|Generador de energía operados por gas
+7|Generadores de corriente
+7|Generadores de corriente alterna (alternadores)
+7|Generadores de corriente directa
+7|Generadores de electricidad
+7|Generadores de electricidad móviles
+7|Generadores de electricidad que utilizan el calor residual
+7|Generadores de electricidad que utilizan energía geotérmica
+7|Generadores de energía eléctrica para barcos
+7|Generadores eléctricos accionados por vapor
+7|Generadores eléctricos para emergencias
+7|Generadores electrostáticos
+7|Generadores para turbinas de viento
+7|Gofradoras
+7|Grúa de pluma
+7|Grúas
+7|Grúas con mástil en celosía
+7|Grúas de cable
+7|Grúas de muelle móviles
+7|Grúas de torre
+7|Grúas fijas y móviles
+7|Grúas flotantes
+7|Grúas locomotoras
+7|Grúas móviles
+7|Grúas para camiones
+7|Grúas para descarga
+7|Grúas pórtico (grúas de puente)
+7|Grúas portuarias montadas
+7|Grúas sobre orugas
+7|Henificadoras
+7|Herramientas de afilado para máquinas rectificadoras
+7|Impresoras offset
+7|Impulsores de bomba
+7|Incubadoras de huevos
+7|Instalaciones de elevación para el transporte de personas y productos
+7|Instalaciones de lavado de vehículos
+7|Inyectores de motor
+7|Jaulas de cojinetes como partes de máquinas
+7|Juntas metálicas de motores para vehículos
+7|Laminadores para metalistería
+7|Lámparas para soldar
+7|Laves inglesas hidráulicas de torsión
+7|Lijadoras de suelos
+7|Lijadoras operadas manualmente
+7|Lijadoras para trabajar la madera
+7|Limpiadoras de vapor multiusos
+7|Líneas transportadoras
+7|Llaves de trinquete neumáticas
+7|Llaves de tuerca eléctricas
+7|Machos de roscar (máquinas-herramienta)
+7|Magnetos de encendido para motores
+7|Mandriles para taladros eléctricos
+7|Mangos eléctricos
+7|Mangueras para aspiradoras
+7|Máquina de pavimentación con asfalto
+7|Máquina de pavimentación con hormigón
+7|Maquinaria de aserradero portátil
+7|Maquinaria de coser
+7|Maquinaria de fundición
+7|Maquinaria de procesado de láminas de semiconductores
+7|Máquinas afiladoras
+7|Máquinas apiladoras
+7|Máquinas atomizadoras
+7|Máquinas automáticas para doblar ropa para uso industrial
+7|Máquinas batidoras para procesamiento químico
+7|Máquinas bobinadoras de hilo
+7|Máquinas capsuladoras de botellas
+7|Máquinas clasificadoras (alzadoras de imprenta)
+7|Máquinas clasificadoras de arena
+7|Máquinas clasificadoras de granos de arroz
+7|Máquinas clasificadoras para procesamiento químico
+7|Máquinas colectoras de polvo para procesamiento químico
+7|Máquinas colocadoras de hormigón
+7|Máquinas compactadoras de tierra
+7|Máquinas compactadoras y acabadoras para la superficie del suelo
+7|Máquinas compaginadoras automáticas
+7|Máquinas comprobadoras de cemento
+7|Máquinas cortacésped con asiento
+7|Máquinas cortadoras de alimentos para uso comercial
+7|Máquinas cortadoras de fibra
+7|Máquinas cortadoras de hojas de moreras
+7|Máquinas cortadoras de papel
+7|Máquinas cortadoras de piedras
+7|Máquinas de aire comprimido
+7|Máquinas de amolado de tornillo
+7|Máquinas de arado
+7|Máquinas de arqueado
+7|Máquinas de barrenado para trabajar el metal
+7|Máquinas de bobinado de hilo de seda
+7|Máquinas de bombeo para pozos petroleros
+7|Máquinas de bordar
+7|Máquinas de calcinado para el procesamiento químico
+7|Máquinas de cardar
+7|Máquinas de cardar fieltro
+7|Máquinas de clavar
+7|Máquinas de colada continua de metales
+7|Máquinas de compostaje de residuos orgánicos
+7|Máquinas de comprobación de materias plásticas
+7|Máquinas de comprobación de materias textiles
+7|Máquinas de comprobación para hormigón
+7|Máquinas de conformado de alambres
+7|Máquinas de conformado de metales
+7|Máquinas de conformado para metalistería
+7|Máquinas de corte de barras de refuerzo
+7|Máquinas de corte de fibra básica
+7|Máquinas de corte de forraje (cortadoras de piensos)
+7|Máquinas de corte de rastrojos
+7|Máquinas de corte para mecanizado de metales
+7|Máquinas de corte y soldadura con oxiacetileno
+7|Máquinas de coser
+7|Máquinas de costura para uso industrial
+7|Máquinas de descortezado de madera
+7|Máquinas de descortezar ramio
+7|Máquinas de dibujado de planos
+7|Máquinas de disolución para el procesamiento químico
+7|Máquinas de dragado
+7|Máquinas de elaboración de goma
+7|Máquinas de embalaje
+7|Máquinas de embalaje para alimentos
+7|Máquinas de enlatado
+7|Máquinas de enrollado para enrollar metales
+7|Máquinas de envasado al vacío
+7|Máquinas de envasado automático de comida
+7|Máquinas de escardar
+7|Máquinas de escariado para metalistería
+7|Máquinas de estampado automático
+7|Máquinas de extrusión de alambre
+7|Máquinas de extrusión para materias plástica
+7|Máquinas de fabricación de chips de memoria
+7|Máquinas de fabricación de pañales de papel
+7|Máquinas de fijación de dientes de sierra para trabajar la madera
+7|Máquinas de fijación de dientes de sierra para trabajos en madera y aserradura
+7|Máquinas de fotograbado
+7|Máquinas de fragüe
+7|Máquinas de fregado y blanqueado continuo
+7|Máquinas de fundición continua
+7|Máquinas de galvanización
+7|Máquinas de grabado computarizadas
+7|Máquinas de grabar con láser
+7|Máquinas de hacer fieltro
+7|Máquinas de hilatura de seda
+7|Máquinas de impresión flexográfica
+7|Máquinas de impresión intaglio
+7|Máquinas de impresión para materias textiles
+7|Máquinas de impresión para uso industrial
+7|Máquinas de impresión planográfica
+7|Máquinas de inserción de láminas
+7|Máquinas de insertar y llenar sobres (máquinas de empaquetado)
+7|Máquinas de labranza para jardín
+7|Máquinas de ladrillos
+7|Máquinas de lapeado
+7|Máquinas de lapeado para metalistería
+7|Máquinas de lavado a presión
+7|Máquinas de lavado de vehículos
+7|Máquinas de lavandería de secado
+7|Máquinas de limpieza de arena
+7|Máquinas de limpieza para estanques
+7|Máquinas de limpieza para motores de aviación
+7|Máquinas de moldeo por compresión
+7|Máquinas de moldeo por extrusión
+7|Máquinas de moldeo por inyección
+7|Máquinas de moldeo por inyección de plásticos
+7|Máquinas de molienda de alimentos
+7|Máquinas de movimiento de tierras
+7|Máquinas de perforación de madera
+7|Máquinas de procesado de obleas de semiconductores
+7|Máquinas de rebobinado de hilo de seda
+7|Máquinas de refinado de pasta de papel
+7|Máquinas de sacudido de madera
+7|Máquinas de satinado de textiles
+7|Máquinas de sinterización para procesamiento químico
+7|Máquinas de soldadura con gas
+7|Máquinas de soldadura de alambre
+7|Máquinas de soldadura eléctrica
+7|Máquinas de soldadura por láser
+7|Máquinas de teñido por inmersión
+7|Máquinas de trefilar
+7|Máquinas de trituración de madera
+7|Máquinas de vapor que no sean para vehículos terrestres
+7|Máquinas decatizadoras de humedad
+7|Máquinas desgranadoras
+7|Máquinas desmenuzadoras para uso industrial
+7|Máquinas elaboradoras de artículos de vidrio
+7|Máquinas elaboradoras de cajas de papel
+7|Máquinas elaboradoras de leche condensada
+7|Máquinas eléctricas de cortar con cizalla
+7|Máquinas eléctricas de planchado para ropa
+7|Máquinas eléctricas deshuesadoras de dátiles par uso doméstico
+7|Máquinas eléctricas deshuesadoras de dátiles par uso industrial
+7|Máquinas eléctricas para cortar y astillar troncos para leña
+7|Máquinas eléctricas para encerar de uso doméstico
+7|Máquinas eléctricas para lavar ventanas
+7|Máquinas eléctricas para triturar hielo
+7|Máquinas empaquetadoras
+7|Máquinas emulsionantes para el procesamiento químico
+7|Máquinas encuadernadoras de uso industrial
+7|Máquinas enrolladoras de papel
+7|Máquinas ensobretadoras
+7|Máquinas espigadoras
+7|Máquinas excavadoras
+7|Máquinas expendedoras de bolas de chicle
+7|Máquinas extractoras de café
+7|Máquinas extractoras para procesamiento químico
+7|Máquinas filtradoras de leche
+7|Máquinas filtradoras para procesamiento químico
+7|Máquinas fresadoras para el tratamiento de cerámicos y metales
+7|Máquinas fresadoras y rectificadoras para el tratamiento de cerámica y metal
+7|Máquinas fresadoras-perforadoras
+7|Máquinas gaseadoras de hilo
+7|Máquinas granuladoras para procesamiento químico
+7|Máquinas herramientas metalúrgicas
+7|Máquinas herramientas para eliminar material residual
+7|Máquinas herramientas para separar material superficial de carreteras
+7|Máquinas hiladoras
+7|Máquinas hiladoras de fibra química
+7|Máquinas homogeneizadoras de leche
+7|Máquinas industriales de prensado
+7|Máquinas lavadoras de huevos de gusanos de seda
+7|Máquinas lavadoras de materias textiles para uso industrial
+7|Máquinas lavadoras de ropa
+7|Máquinas lavadoras eléctricas para uso industrial
+7|Máquinas lavadoras para uso doméstico
+7|Máquinas lavaplatos
+7|Máquinas lavavajillas para uso doméstico
+7|Máquinas lavavajillas para uso industrial
+7|Máquinas lijadoras de cinta
+7|Máquinas lijadoras orbitales
+7|Máquinas limpiadoras de algodón
+7|Máquinas limpiadoras de pisos
+7|Máquinas mezcladoras
+7|Máquinas mezcladoras de caucho
+7|Máquinas mezcladoras de forraje (mezcladoras de pienso)
+7|Máquinas moldeadoras de zuecos de madera estilo japonés
+7|Máquinas neumáticas de encuadernación
+7|Máquinas ordeñadoras
+7|Máquinas para afilar taladros
+7|Máquinas para aplastar basura
+7|Máquinas para apretar balas de paja
+7|Máquinas para aserrar madera
+7|Máquinas para aserrar metales
+7|Máquinas para carga y descarga
+7|Máquinas para cepillar madera
+7|Máquinas para cepillar ramio
+7|Máquinas para construcción de hormigón
+7|Máquinas para copia de llaves
+7|Máquinas para cortar en copos carne de pescado (máquinas para preparar kezuri-bushi)
+7|Máquinas para cortar tela
+7|Máquinas para cortar y quitar azulejos
+7|Máquinas para curtir el cuero
+7|Máquinas para descortezar
+7|Máquinas para devanar hilo
+7|Máquinas para dispersar arena
+7|Máquinas para dragado del fango
+7|Máquinas para el acabado de cuerdas de paja
+7|Máquinas para el acabado de madera contrachapada
+7|Máquinas para el rameado de textiles
+7|Máquinas para el tratamiento (transformación) de materias plásticas
+7|Máquinas para elaborar bebidas gaseosas
+7|Máquinas para elaborar mantequilla
+7|Máquinas para embolsar
+7|Máquinas para embotellar
+7|Máquinas para empaquetar hilo de seda
+7|Máquinas para encolar madera contrachapada
+7|Máquinas para encordar raquetas
+7|Máquinas para enrollar alambres
+7|Máquinas para envolver
+7|Máquinas para espadillar textiles
+7|Máquinas para estampado en caliente
+7|Máquinas para extraer madera
+7|Máquinas para fabricar agujas
+7|Máquinas para fabricar bolsas de papel
+7|Máquinas para fabricar cartón ondulado
+7|Máquinas para fabricar cigarrillos
+7|Máquinas para fabricar cremalleras
+7|Máquinas para fabricar cuerdas de paja
+7|Máquinas para fabricar encajes y sus partes
+7|Máquinas para fabricar fósforos
+7|Máquinas para fabricar papel
+7|Máquinas para forjar formas libres
+7|Máquinas para forjar metales
+7|Máquinas para fregar los suelos
+7|Máquinas para hacer barras de filtro
+7|Máquinas para hacer bebidas gaseosas
+7|Máquinas para hacer bolas de masa cocida
+7|Máquinas para hacer fideos
+7|Máquinas para hacer leche en polvo
+7|Máquinas para hacer llaves
+7|Máquinas para hacer miso
+7|Máquinas para hacer pastas comestibles
+7|Máquinas para hacer salsa de soya
+7|Máquinas para la fabricación de cigarrillos de uso de fumadores
+7|Máquinas para la fabricación de pasta de pescado
+7|Máquinas para la fabricación de quesos
+7|Máquinas para la fabricación de semiconductores
+7|Máquinas para la industria azucarera
+7|Máquinas para lavar fruta
+7|Máquinas para lavar pelotas de golf
+7|Máquinas para limpiar billetes de banco
+7|Máquinas para limpieza en seco
+7|Máquinas para manipular mercancías
+7|Máquinas para marcar líneas de carretera
+7|Máquinas para peinar y torcer el hilo
+7|Máquinas para pintar
+7|Máquinas para procesar tabaco
+7|Máquinas para pulir cueros
+7|Máquinas para quitar la fibra del algodón
+7|Máquinas para rallar hortalizas
+7|Máquinas para recortar contrachapados
+7|Máquinas para revestimiento con papel
+7|Máquinas para separar materiales reciclables
+7|Máquinas para serigrafia
+7|Máquinas para soldadura autógena
+7|Máquinas para soldar operadas a gas
+7|Máquinas para tallar madera
+7|Máquinas para tallar y acabar engranajes
+7|Máquinas para teñir textiles
+7|Máquinas para trabajar la piedra
+7|Máquinas para trabajar materias plásticas
+7|Máquinas para trabajar metales
+7|Máquinas para trabajos de cimentaciones
+7|Máquinas para transportar sólidos
+7|Máquinas para tratar los alimentos
+7|Máquinas para unir madera contrachapada
+7|Máquinas peladoras de alimentos para uso comercial
+7|Máquinas perforadoras
+7|Máquinas perforadoras de pozos
+7|Máquinas perforadoras para metalistería
+7|Máquinas perforadoras para trabajar el metal
+7|Máquinas procesadoras de algas comestibles
+7|Máquinas procesadoras de bebidas
+7|Máquinas procesadoras de cereales
+7|Máquinas procesadoras de plástico
+7|Máquinas procesadoras de seda cruda
+7|Máquinas pulidoras de arroz
+7|Máquinas pulidoras de arroz o cebada
+7|Máquinas pulidoras de suelos
+7|Máquinas pulverizadoras humectantes para tratamiento de tejidos
+7|Máquinas rebanadoras de alimentos para uso comercial
+7|Máquinas rectificadoras con abrasivo para metalistería
+7|Máquinas rectificadoras con engranajes de bisel en espiral
+7|Máquinas rectificadoras evolventes
+7|Máquinas rectificadoras para el tratamiento de cerámica y metal
+7|Máquinas rectificadoras para metalistería
+7|Máquinas reparadoras de calzado
+7|Máquinas rotativas para materias textiles
+7|Máquinas secavajillas para uso industrial
+7|Máquinas secuenciadoras de continuidad de láminas
+7|Máquinas sembradoras de semillas agrícolas
+7|Máquinas separadoras de arroz con cáscara
+7|Máquinas separadoras para procesamiento químico
+7|Máquinas sopladoras
+7|Máquinas taladradoras de láser para trabajo en piedra
+7|Máquinas taponadoras
+7|Máquinas tejedoras
+7|Máquinas torcedoras de hilo
+7|Máquinas transportadoras de material de residuo
+7|Máquinas transportadoras para líneas de montaje
+7|Máquinas transportadores
+7|Máquinas trilladoras de cebada
+7|Máquinas trituradoras de forraje apelmazado (trituradoras de piensos)
+7|Máquinas trituradoras de tallos
+7|Máquinas urdidoras de hilo
+7|Máquinas y aparatos pulidores de suelos eléctricos
+7|Martillos eléctricos
+7|Martillos eléctricos (herramientas de mano)
+7|Martillos giratorios eléctricos
+7|Martillos hidráulicos
+7|Martillos neumáticos (herramientas de mano)
+7|Martinete
+7|Martinetes para hincado de pilotes
+7|Mástiles de carga
+7|Matrices de prensado para la conformación de metales
+7|Mecanismos de ascensores
+7|Mezcladores de asfalto
+7|Mini-cultivadores eléctricos
+7|Moldes de forja
+7|Moledores móviles para minería
+7|Molinillos de pimienta eléctricos
+7|Molinillos de pimientaeléctricos
+7|Molinillos de sal eléctricos
+7|Molinillos eléctricos para alimentación
+7|Molinos de café eléctricos
+7|Molinos de viento
+7|Molinos para el procesamiento químico
+7|Molinos para la fabricación de tubos para metalistería
+7|Montacargas
+7|Montacargas eléctricos de barcos
+7|Montacargas eléctricos o neumáticos
+7|Montacargas mecánicos
+7|Mopas eléctricas a vapor
+7|Motores a gasolina que no sean para vehículos terrestres
+7|Motores a reacción que no sean para vehículos terrestres
+7|Motores de aeronáutica
+7|Motores de arranque con retroceso para motores no destinados a vehículos
+7|Motores de avión
+7|Motores de barco
+7|Motores de cabrestante
+7|Motores de cohetes no para vehículos terrestres
+7|Motores de corriente directa
+7|Motores de elevador
+7|Motores de tracción
+7|Motores de vapor marinos que no sean para vehículos terrestres
+7|Motores de variación de la presión de vapor
+7|Motores diésel que no sean para vehículos terrestres
+7|Motores eléctricos para frigoríficos
+7|Motores eléctricos que no sean para vehículos terrestres
+7|Motores eléctricos y sus partes que no sean para vehículos terrestres
+7|Motores lineales
+7|Motores para aerostación
+7|Motores para afilado de fresas
+7|Motores para la producción de electricidad
+7|Motores para modelos a escala
+7|Motores para modelos a escala de vehículos, aviones y barcos
+7|Motores que no sean para vehículos terrestres
+7|Operadores de puerta hidráulicas
+7|Operadores de puertas eléctricas
+7|Palas mecánicas
+7|Partes de inyector de combustible para motores de vehículos terrestres y acuáticos
+7|Partes de máquinas, a saber, rodamientos
+7|Pasillos móviles
+7|Pastillas de freno que no sean para vehículos
+7|Pilones (máquinas)
+7|Pistolas de clavos eléctricas
+7|Pistolas grapadoras eléctricas
+7|Pistolas para pegar en caliente
+7|Pistolas pulverizadoras de revestimiento en polvo
+7|Pistolas pulverizadoras para pintura
+7|Placas de zinc para impresión en ófset
+7|Plataformas de trabajo elevadoras incluidas las móviles
+7|Polipastos de alambre
+7|Portaherramientas para máquinas de metalurgia (partes de máquinas)
+7|Prensas de embutir
+7|Prensas de extrusión de metales
+7|Prensas de imprenta de fotograbado
+7|Prensas hidráulicas de aceite para metalistería
+7|Prensas hidráulicas para metalistería
+7|Prensas mecánicas para metalistería
+7|Prensas para contrachapado
+7|Prensas para forraje
+7|Prensas para procesamiento químico
+7|Prensas punzonadoras
+7|Prensas punzonadoras para metalistería
+7|Prensas tipográficas
+7|Procesadores eléctricos de alimentos
+7|Puentes grúa
+7|Puertas de elevador
+7|Pulidoras para trabajar metales
+7|Pulverizadores automáticos para pintura electroestática
+7|Pulverizadores eléctricos para insecticidas
+7|Quitanieves
+7|Radiadores de enfriamiento para motores
+7|Radiadores para motores
+7|Radiadores para vehículos
+7|Ralladores eléctricos
+7|Ranuradoras para metalistería
+7|Recolector de hojas de té (máquinas)
+7|Recortadoras
+7|Recortadoras de jardín eléctricas
+7|Recortadoras de oxígeno
+7|Rectificadoras internas
+7|Reductores de presión como partes de máquinas
+7|Refrigeradores de aceite (piezas de motores de vehículos)
+7|Remachadoras eléctricas
+7|Revolvedoras de hormigón
+7|Robots de costura
+7|Robots para uso industrial
+7|Rodamientos como partes de máquinas
+7|Rodamientos de inserción para máquinas
+7|Rodamientos de rodillos para máquinas
+7|Rodillos de prensa de cebada
+7|Rodillos para máquinas de impresión rotativa
+7|Roscadoras
+7|Rozadoras de carbón
+7|Segadoras (máquinas agrícolas)
+7|Segadoras-trilladoras
+7|Selladores eléctricos de vacío para uso doméstico
+7|Sembradora para máquinas agrícolas
+7|Separadores ciclónicos
+7|Separadores de aceite
+7|Serradoras
+7|Servo motores de corriente alterna
+7|Servo-válvulas
+7|Servomotores
+7|Sierras caladoras eléctricas
+7|Sierras circulares para trabajar la madera
+7|Sierras de cadena
+7|Sierras de cinta
+7|Sierras de cinta para madera
+7|Sierras eléctricas
+7|Sierras eléctricas de cadena
+7|Sierras eléctricas de sable
+7|Sierras eléctricas para madera
+7|Sierras hidráulicas de alambre
+7|Silenciadores para motores
+7|Sistemas de inyección de combustible para motores
+7|Sistemas de tratamiento de gases de escape para motores diésel
+7|Soldadoras eléctricas para trabajar metales
+7|Sondas desatascadoras eléctricas para fontanería
+7|Sopladores de nieve
+7|Sopladores eléctricos
+7|Sopladores operados eléctricamente
+7|Sopletes a gas
+7|Sopletes de corte
+7|Sopletes de soldadura
+7|Soportes de cojinetes para máquinas
+7|Taladradoras eléctricas de mano
+7|Taladradoras radiales
+7|Taladros de minería
+7|Taladros eléctricos
+7|Taladros eléctricos (herramientas de mano)
+7|Taladros eléctricos para el hielo utilizados en la pesca en hielo
+7|Taladros neumáticos (herramientas de mano)
+7|Taladros para la industria minera
+7|Taladros para roca
+7|Telares automáticos
+7|Telares eléctricos
+7|Telares para calcetería
+7|Tijeras eléctricas para setos recargables
+7|Tornos (máquinas herramientas)
+7|Tornos de alfareros mecánicos
+7|Tornos de elevación eléctricos
+7|Tornos de madera
+7|Tornos de mano
+7|Tornos para trabajar metales
+7|Torres de perforación
+7|Transmisiones de máquinas
+7|Transmisiones para máquinas
+7|Transmisiones y mecanismos eléctricos para máquinas excepto vehículos de tierra
+7|Transportadoras por fases y segmentadas
+7|Transportadores
+7|Transportadores de cinta
+7|Transportadores de rodillo
+7|Transportadores hidráulicos
+7|Transportadores mecánicos de elevación con raíles
+7|Transportadores neumáticos
+7|Transportadores sinfín
+7|Trenes de transmisión de aviación
+7|Trilladoras
+7|Trituradoras (máquinas) para residuos
+7|Trituradoras de aspiración para eliminar escombros
+7|Trituradoras de basura
+7|Trituradoras de desechos
+7|Trituradoras de mandíbula (máquinas)
+7|Trituradoras para uso industrial
+7|Tubos de escape para vehículos terrestres
+7|Turbinas de aire que no sean para vehículos terrestres
+7|Turbinas de vapor que no sean para vehículos terrestres
+7|Turbinas hidráulicas
+7|Turbinas que no sean para vehículos terrestres
+7|Unidades convertidoras catalíticas para escapes de vehículos
+7|Válvulas como componente de máquina
+7|Válvulas componente partes de máquina
+7|Válvulas de control de bombas
+7|Válvulas de control termostáticas para máquinas
+7|Válvulas hidráulicas (partes de máquinas)
+7|Ventiladores eléctricos para aspiradoras
+7|Ventiladores para motores
+7|Vibradoras de hormigón
+7|Vibradores para concreto eléctricos

--- a/lib/seeds/class_8_terms.csv
+++ b/lib/seeds/class_8_terms.csv
@@ -1,326 +1,276 @@
-class,reference_id,name
-8,080002,instrumentos de mano abrasivos
-8,080003,piedras de afilar
-8,080005,limas de aguja
-8,080006,cuero para afilar
-8,080008,leznas
-8,080009,barras de mandrinado [herramientas de mano]
-8,080010,escariadores
-8,080011,manguitos de escariadores
-8,080012,alargadores de berbiquíes para machos de roscar
-8,080013,espátulas de pintor
-8,080014,espátulas [herramientas de mano]
-8,080015,puños americanos
-8,080015,manoplas [armas de defensa personal]
-8,080016,brocas [partes de herramientas de mano]
-8,080016,mechas [brocas] [partes de herramientas de mano]
-8,080017,escuadras [herramientas de mano]
-8,080019,aparatos e instrumentos para desollar animales
-8,080019,instrumentos y herramientas para desollar animales
-8,080020,terrajas anulares
-8,080021,sierras de arco
-8,080022,armas blancas
-8,080023,extractores de clavos accionados manualmente
-8,080023,sacaclavos accionados manualmente
-8,080024,gatos manuales
-8,080025,bayonetas
-8,080026,maquinillas para cortar la barba
-8,080026,cortabarbas [maquinillas para cortar la barba]
-8,080028,taladradoras de mano accionadas manualmente
-8,080029,escoplos
-8,080030,azuelas de dos filos
-8,080030,martillos de vidriero
-8,080031,instrumentos para marcar el ganado
-8,080031,instrumentos de hierra
-8,080033,esquiladoras para el ganado
-8,080034,pies de cabra [herramientas de mano]
-8,080034,arrancaclavos [herramientas de mano]
-8,080036,bujardas
-8,080036,escodas
-8,080037,chairas de afilar
-8,080038,buterolas [herramientas de mano]
-8,080038,martillos de remachar [herramientas de mano]
-8,080039,pujavantes [herramientas de mano]
-8,080040,tijeras*
-8,080042,pinzas pequeñas
-8,080043,buriles [herramientas de mano]
-8,080044,picos*
-8,080045,hierros de calafateo
-8,080046,navajas
-8,080046,cortaplumas
-8,080047,almádenas
-8,080048,sierras de vaivén
-8,080048,seguetas
-8,080049,garlopas
-8,080050,botadores
-8,080051,cachas [herramientas de mano]
-8,080052,batanes [herramientas de mano]
-8,080053,cuchillos de caza
-8,080054,mangos de serrucho
-8,080054,mangos de sierras de mano
-8,080055,sierras [herramientas de mano]
-8,080056,hormas para zapatos [herramientas de zapatero]
-8,080058,rizadores
-8,080058,tenacillas para rizar el cabello
-8,080059,cubiertos [cuchillos, tenedores y cucharas]
-8,080060,cizallas*
-8,080060,tijeras grandes
-8,080061,hojas de cizalla
-8,080062,perforadores [herramientas de mano]
-8,080063,aprietatuercas
-8,080063,giramachos
-8,080064,llaves [herramientas de mano]
-8,080065,trinquetes [herramientas de mano]
-8,080066,terrajas [herramientas de mano]
-8,080066,terrajas de cojinetes móviles [herramientas de mano]
-8,080067,perforadoras [herramientas de mano]
-8,080068,colodras
-8,080068,portapiedras de afilar
-8,080069,hachas
-8,080070,tenedores
-8,080071,cepillos de carpintero
-8,080072,herramientas de mano accionadas manualmente
-8,080073,cortadores de verduras y hortalizas accionados manualmente
-8,080073,cortaverduras accionados manualmente
-8,080074,alicates para uñas
-8,080075,cortatubos [herramientas de mano]
-8,080076,cortafríos
-8,080076,cortadores [herramientas de corte]
-8,080077,hachas de carnicero
-8,080078,artículos de cuchillería
-8,080079,recolectores de fruta [instrumentos de mano]
-8,080080,cucharas*
-8,080081,cucharas y cucharones [herramientas de mano]
-8,080082,suavizadores [cueros] de navajas de afeitar
-8,080083,pisones de pavimentación [herramientas de mano]
-8,080083,aplanaderas [herramientas de pavimentación]
-8,080084,troqueles [herramientas de mano]
-8,080084,estampas [punzones] [herramientas de mano]
-8,080085,fresas [herramientas de mano]
-8,080086,desplantadores
-8,080087,llanas
-8,080087,trullas
-8,080088,aparatos accionados manualmente para eliminar los parásitos de las plantas
-8,080089,diamantes de vidriero [partes de herramientas de mano]
-8,080090,mandriles [herramientas de mano]
-8,080090,mandriles de expansión [herramientas de mano]
-8,080091,afiladores
-8,080092,instrumentos de afilar
-8,080093,instrumentos para afilar hojas y cuchillas
-8,080095,cuchillos descamadores
-8,080095,cuchillos escamadores
-8,080096,escardas [herramientas de mano]
-8,080097,tijeras de podar
-8,080098,podaderas [tijeras de jardinero]
-8,080099,cuchillos para injertos de escudete
-8,080100,podaderas de árboles
-8,080101,alicates para cutículas
-8,080102,pinzas de depilar
-8,080103,pasadores de cabo
-8,080104,brocas de media caña
-8,080105,estampadores [troqueles] [herramientas de mano]
-8,080106,estuches de pedicura
-8,080107,estuches para navajas y maquinillas de afeitar
-8,080107,fundas de navajas y maquinillas de afeitar
-8,080108,vaciadores [partes de herramientas de mano]
-8,080109,rastrillos [herramientas de mano]
-8,080110,palas [herramientas de mano]
-8,080111,layas [palas] [herramientas de mano]
-8,080112,hocinos
-8,080113,guadañas
-8,080114,anillas de guadaña
-8,080115,piedras para amolar guadañas
-8,080115,muelas para afilar guadañas
-8,080116,hierros [herramientas no eléctricas]
-8,080117,planchas de gofrado
-8,080118,planchas de satinado
-8,080118,planchas de pulido
-8,080119,cuchillas de guillame
-8,080119,cuchillas de cepillo de carpintero
-8,080120,hierros para moldurar
-8,080121,tenacillas para encañonar
-8,080122,hierros para marcar a fuego
-8,080124,barrenas de carpintero [herramientas de mano]
-8,080124,brocas [herramientas de mano]
-8,080125,vainas de sable
-8,080126,aparatos de mano para rizar el cabello
-8,080127,cortacéspedes [instrumentos de mano]
-8,080128,picos para hielo [piolets]
-8,080128,piolets
-8,080129,gubias [herramientas de mano]
-8,080130,porras
-8,080130,bastones de policía
-8,080130,cachiporras
-8,080131,buriles*
-8,080132,cuchillas de herrador [legras]
-8,080132,legras
-8,080133,tranchetes [chairas, cuchillas de zapatero]
-8,080134,injertadores [herramientas de mano]
-8,080134,herramientas para injertar [herramientas de mano]
-8,080135,guillames
-8,080136,picadores de verduras y hortalizas
-8,080137,hachetas
-8,080138,cuchillos de picar
-8,080139,hachas de tonelero [herramientas de mano]
-8,080140,arpones
-8,080141,azuelas de carpintero [herramientas de mano]
-8,080142,azadillas
-8,080143,abreostras
-8,080144,pulverizadores para insecticidas [herramientas de mano]
-8,080144,atomizadores para insecticidas [herramientas de mano]
-8,080144,vaporizadores para insecticidas [herramientas de mano]
-8,080145,herramientas de jardinería accionadas manualmente
-8,080146,navajas de poda
-8,080147,cárceles de carpintero [gatos]
-8,080147,prensas de carpintero [sargentos]
-8,080148,hojas de afeitar
-8,080148,cuchillas de maquinillas de afeitar
-8,080149,hojas [herramientas de mano]
-8,080149,cuchillas [herramientas de mano]
-8,080150,cuchillas [armas]
-8,080151,hojas de sierra [partes de herramientas de mano]
-8,080153,palancas
-8,080154,machetes
-8,080155,mazas [herramientas de mano]
-8,080156,martillos [herramientas de mano]
-8,080157,mazos
-8,080158,macetas de albañil
-8,080159,cinceles*
-8,080159,retacadores
-8,080160,tensores de alambres y cintas metálicas [herramientas de mano]
-8,080161,trenzadoras [herramientas de mano]
-8,080162,recogemonedas
-8,080163,morteros [herramientas de mano]
-8,080164,cortamechas
-8,080164,cortapábilos
-8,080166,neceseres de afeitar
-8,080167,punzones para numerar
-8,080168,limas de uñas
-8,080169,abrelatas no eléctricos
-8,080170,arpones de pesca
-8,080171,picos [herramientas de mano]
-8,080172,pisones [herramientas de mano]
-8,080172,manos de mortero
-8,080174,pistolas [herramientas de mano]
-8,080175,punzones para marcar [herramientas de mano]
-8,080176,instrumentos de mano para transportar hierro colado
-8,080176,cazos de colada [herramientas de mano]
-8,080177,hierros de cepillo de carpintero
-8,080178,escofinas [herramientas de mano]
-8,080179,maquinillas de afeitar eléctricas o no
-8,080180,punzones botadores
-8,080181,atizadores
-8,080182,remachadoras [herramientas de mano]
-8,080183,zapas [guadañas pequeñas]
-8,080184,azadas [herramientas de mano]
-8,080185,escardaderas
-8,080186,portasierras
-8,080187,rastrillos para uso textil [herramientas de mano]
-8,080188,hocejos
-8,080189,hoces
-8,080191,instrumentos de mano para decantar
-8,080192,herramientas de corte
-8,080193,machos de roscar [herramientas de mano]
-8,080194,barrenos [herramientas de mano]
-8,080195,destornilladores no eléctricos
-8,080196,tajaderas [herramientas de mano]
-8,080197,barrenas [herramientas de mano]
-8,080198,instrumentos para cortar tubos
-8,080199,berbiquíes [herramientas]
-8,080200,instrumentos agrícolas accionados manualmente
-8,080201,muelas de afilar [herramientas de mano]
-8,080201,piedras de amolar [herramientas de mano]
-8,080202,jeringas para pulverizar insecticidas
-8,080203,cuberterías de plata [cuchillos, tenedores y cucharas]
-8,080204,arrancadoras [herramientas de mano]
-8,080205,cuchillos*
-8,080206,alicates
-8,080207,tenazas
-8,080207,pinzas*
-8,080208,espadas
-8,080209,sables
-8,080211,arietes [herramientas de mano]
-8,080212,instrumentos para picar billetes [tickets]
-8,080212,instrumentos para picar boletos
-8,080213,limas de uñas [eléctricas]
-8,080214,pulidores de uñas [eléctricos o no]
-8,080218,portabrocas*
-8,080219,maquinillas eléctricas o no para cortar el cabello
-8,080219,cortadoras de cabello eléctricas o no
-8,080220,horcas para uso agrícola [herramientas de mano]
-8,080221,cortaúñas eléctricos o no
-8,080222,esquiladoras [instrumentos de mano]
-8,080223,tundidoras [instrumentos de mano]
-8,080223,cortadoras de pelo [instrumentos de mano]
-8,080224,planchas de ropa
-8,080226,muelas de esmeril
-8,080227,limas [herramientas de mano]
-8,080228,sacabocados [herramientas de mano]
-8,080229,punzones [herramientas de mano]
-8,080230,recortadoras [herramientas de mano]
-8,080231,estuches de manicura
-8,080232,pistolas accionadas manualmente para extrudir masillas
-8,080234,zanjadoras [herramientas de mano]
-8,080235,rascadores [herramientas de mano]
-8,080236,picadores de carne [herramientas de mano]
-8,080236,cuchillos para picar carne [herramientas de mano]
-8,080237,rasquetas [herramientas de mano]
-8,080237,raederas [herramientas de mano]
-8,080237,raspadores [herramientas de mano]
-8,080241,aparatos para perforar las orejas
-8,080242,aparatos de depilación eléctricos o no
-8,080243,neceseres de instrumentos de manicura eléctricos
-8,080244,tornillos de banco
-8,080245,bombas de mano*
-8,080245,bombas accionadas a mano*
-8,080246,puñales
-8,080246,dagas
-8,080247,cinturones portaherramientas
-8,080248,cortadores de queso no eléctricos
-8,080249,cortadores de pizza no eléctricos
-8,080249,cortapizzas no eléctricos
-8,080250,barretas
-8,080251,cortadores de huevos no eléctricos
-8,080251,cortahuevos no eléctricos
-8,080252,rizadores de pestañas
-8,080253,cajas de ingletes
-8,080254,rastrillos de golf
-8,080255,fuelles de chimenea [instrumentos de mano]
-8,080256,aparatos de tatuaje
-8,080257,limas de esmeril
-8,080258,guías pasacables [herramientas de mano]
-8,080259,pinzas pelacables [herramientas de mano]
-8,080261,tornillos para bancos de trabajo [herramientas de mano]
-8,080262,pistolas para calafatear no eléctricas
-8,080263,tensores de hilos metálicos [herramientas de mano]
-8,080263,tensores de cables metálicos [herramientas de mano]
-8,080264,cuchillos para manualidades [escalpelos]
-8,080265,bombas de aire accionadas manualmente
-8,080266,cuchillos de cerámica
-8,080267,limas de cartón
-8,080268,herramientas para afilar cantos de esquís accionadas manualmente 
-8,080269,agujas de tatuaje
-8,080270,espátulas para artistas
-8,080271,cinceles de escultor
-8,080272,cucharas, tenedores y cuchillos de mesa de materias plásticas
-8,080273,cucharas, tenedores y cuchillos de mesa para bebés
-8,080274,rasquetas para esquís
-8,080275,mangos para herramientas de mano accionadas manualmente
-8,080276,mangos de cuchillo
-8,080277,mangos de guadaña
-8,080278,cortadores de verduras y hortalizas en espiral que funcionan manualmente
-8,080279,peladores de verduras y hortalizas accionados manualmente 
-8,080280,cortadores de cuchilla retráctil [cúteres]
-8,080281,trenzadores eléctricos para el cabello
-8,080282,palitos para mezclar la pintura
-8,080283,cortacápsulas de accionamiento manual para botellas de vino
-8,080284,cortadores de frutas en cuartos
-8,080285,descorazonadores de fruta
-8,080286,mandolinas de cocina
-8,080287,garras para carne
-8,080288,instrumentos estériles para perforaciones corporales
-8,080289,aparatos de depilación láser que no sean para uso médico
-8,080290,martillos de emergencia
-8,080291,cuchillos para verduras y hortalizas
-8,080292,tenedores de trinchar
-8,080293,cuchillos de trinchar
+class|name
+8|Abrelatas no eléctricos
+8|Abreostras
+8|Abridores de carcasas de reloj
+8|Afiladores de cuchillos
+8|Afiladores de hojas de afeitar accionadas manualmente
+8|Agujas para perforar orejas
+8|Aireadores de césped (herramientas de mano impulsadas manualmente)
+8|Alicates
+8|Alicates (herramientas de mano)
+8|Alicates de corte (alicates universales)
+8|Alicates de engastar
+8|Alicates de pesca
+8|Alicates japoneses (cortahílos japonés)
+8|Alicates para marbetes de oreja de ganado
+8|Aparatos de depilación
+8|Aparatos para doblar tubos (herramientas de mano)
+8|Aparatos para perforar las orejas
+8|Aparatos para tatuar
+8|Aprietatuercas (herramientas de mano)
+8|Avellanadoras (herramientas de mano)
+8|Barras sacaclavos para carpintería
+8|Barretas
+8|Bastones de policía
+8|Bastones espada
+8|Berbiquíes (herramientas manuales de perforación de madera)
+8|Bombas para líquidos accionadas manualmente
+8|Bujardas (martillos de piedra)
+8|Cavahoyos operados manualmente
+8|Cepillos de carpintero
+8|Cepillos que no sean eléctricos para descamar bloques de bonito desecado (cepillos katsuo-bushi)
+8|Chairas de afilar
+8|Cinceles (herramientas de mano)
+8|Cinturones portaherramientas
+8|Cizallas
+8|Cizallas de bolsillo
+8|Cizallas multipropósito
+8|Cizallas para lana
+8|Cizallas para papel
+8|Cizallas para uso doméstico
+8|Cizallas y tijeras de jardinería
+8|Cortadoras de alimentos no eléctricas
+8|Cortadoras de colchoneta de tatami
+8|Cortadoras de hojalata (operadas manualmente)
+8|Cortadores de alambre
+8|Cortadores de alambre (herramientas de mano)
+8|Cortadores de huevos no eléctricos
+8|Cortadores de pizza que no sean no eléctricos
+8|Cortadores de quesono eléctricos
+8|Cortadores de tartas
+8|Cortadores de vidrio
+8|Cortadores manuales para quitar los ojos de las piñas
+8|Cortadores no eléctricos para ajos
+8|Cortapelos eléctricos para las orejas
+8|Cortapelos eléctricos para nariz
+8|Cortapelos para bebés
+8|Cortaúñas
+8|Cortaúñas manuales para mascotas
+8|Cortaverduras
+8|Cucharas
+8|Cucharas de mesa
+8|Cucharas de metales preciosos
+8|Cucharas para pomelo
+8|Cuchillas de cepillado
+8|Cuchillo raya-fibras para chapas de madera
+8|Cuchillos
+8|Cuchillos biodegradables
+8|Cuchillos de buceo
+8|Cuchillos de carne
+8|Cuchillos de caza
+8|Cuchillos de cocina con hoja fina
+8|Cuchillos de cocina japoneses para picar
+8|Cuchillos de cocina para rebanar pescado
+8|Cuchillos de cocinero
+8|Cuchillos de mantequilla
+8|Cuchillos de mesa
+8|Cuchillos de pesca
+8|Cuchillos de tallar
+8|Cuchillos descamadores
+8|Cuchillos multiusos
+8|Cuchillos para ocio
+8|Cuchillos para pomelos
+8|Cuchillos para tallar frutas
+8|Cuchillos para uso doméstico
+8|Cuchillos plegables
+8|Cuchillos y cucharas
+8|Cuchillos, tenedores y cucharas
+8|Cueros para afilar navajas de afeitar
+8|Cultivadoras de mano accionadas manualmente
+8|Cultivadores de mano accionados manualmente para jardinería
+8|Cultivadores de tres dientes para jardinería (herramientas de mano)
+8|Descorazonador de manzanas
+8|Despepitadores de verduras y hortalizas
+8|Destornilladores
+8|Destornilladores (herramientas manuales)
+8|Desvenadores de camarones (herramientas de mano)
+8|Diamantes de cristalero como partes de herramientas de mano
+8|Empujadores de cutícula
+8|Encrespadores de pestañas eléctricos
+8|Escamadores para pescado
+8|Escardaderas (herramientas de mano)
+8|Escariadores (herramientas de mano)
+8|Espadas
+8|Espadas japonesas
+8|Espátulas de pintor
+8|Espátulas para enmasillar
+8|Estuches de instrumentos de manicura eléctricos
+8|Estuches de manicura
+8|Estuches de pedicura
+8|Estuches de utensilios de pedicura eléctricos
+8|Estuches para maquinillas de afeitar
+8|Fuelles de chimenea
+8|Ganchos
+8|Ganchos de mano
+8|Garlopas
+8|Gatos manuales
+8|Guadañas
+8|Hachas
+8|Hachas de cabeza grande
+8|Hachas de carnicero
+8|Hachetas
+8|Herramientas de afilar accionadas manualmente
+8|Herramientas de mano abrasivas
+8|Herramientas de mano operadas manualmente para hacer hielo raspado
+8|Herramientas de mano para plantar bulbos (operadas manualmente)
+8|Herramientas operadas manualmente para remover espaciadores de baldosas
+8|Herramientas remachadoras accionadas manualmente
+8|Hierros para marcar a fuego
+8|Hoces
+8|Hojas (herramientas de mano)
+8|Hojas de afeitar
+8|Hojas de cizallas
+8|Hojas de sierras de corte transversal
+8|Hojas de tijeras
+8|Hojas para maquinillas de afeitar eléctricas
+8|Hormas de calzado (herramientas de zapatero)
+8|Hormas para fabricación de calzado (sólo las accionadas manualmente)
+8|Horquillas antidisturbios
+8|Horquillas de cavar (horquillas de azada)
+8|Layas
+8|Limas accionadas manualmente
+8|Limas de uñas
+8|Llanas
+8|Llanas de albañilería
+8|Llanas de hormigón
+8|Llaves ajustables
+8|Llaves de ajuste dinamométricas
+8|Llaves de anillo
+8|Llaves de bujías
+8|Llaves de filtros de aceite
+8|Llaves de tornillos (llaves)
+8|Llaves de trinquete (herramientas de mano)
+8|Llaves de tubo
+8|Llaves de tubo (herramientas de mano)
+8|Llaves de tubos
+8|Llaves de tuercas
+8|Llaves de tuercas de cabezal flexible
+8|Llaves dinamométricas (accionadas manualmente)
+8|Llaves hexagonales
+8|Llaves inglesas
+8|Llaves para apretar clavos de zapatos de golf
+8|Llaves para clavijas hexagonales (herramientas de mano)
+8|Machetes
+8|Mangos de serrucho
+8|Mangos de trinquete
+8|Máquinas de afeitar no eléctricas
+8|Maquinillas de afeitar
+8|Maquinillas de afeitar desechables
+8|Maquinillas de afeitar eléctricas y maquinillas para cortar el cabello eléctricas
+8|Maquinillas de afeitar y hojas de afeitar
+8|Maquinillas para cortar el cabello accionadas manualmente
+8|Maquinillas para cortar el cabello eléctricas
+8|Maquinillas para cortar el pelo de los perros
+8|Maquinillas para cortar la barba
+8|Maquinillas para recortar el cabello eléctricas
+8|Martillos (herramientas de mano)
+8|Mazos
+8|Mortero de cerámica estilo japonés (suribachi)
+8|Morteros de madera estilo japonés (surikogi)
+8|Muelas de afilar para cuchillos y cuchillas
+8|Navajas
+8|Navajas de afeitar
+8|Navajas de afeitar japonesas
+8|Navajas de afeitar rectas
+8|Navajas de bolsillo
+8|Navajas de poda
+8|Neceseres de afeitar
+8|Onduladoras eléctricas para el cabello
+8|Palas
+8|Palas para fertilizante
+8|Palas para nieve
+8|Peladores de hortalizas no eléctricos
+8|Peladores de patatas (herramientas manuales)
+8|Peladores no eléctricos para ajos
+8|Picadores manuales
+8|Picos de montañismo (piolets)
+8|Picos para hielo (piolets)
+8|Picos y azadillas
+8|Piedras de afilar
+8|Pinzas
+8|Pinzas de pestañas artificiales
+8|Pinzas encrespadoras eléctricas
+8|Pinzas para leña
+8|Pinzas pelacables (herramientas de mano)
+8|Pinzas pequeñas
+8|Piolets
+8|Planchas alisadoras eléctricas
+8|Planchas de ropa
+8|Planchas de vapor eléctricas
+8|Planchas eléctricas para alisado de cabello
+8|Planchas eléctricas para peinar el cabello
+8|Plantadores manuales
+8|Portacuchillos de buceo
+8|Pujavantes
+8|Pulidoras de uñas eléctricas
+8|Pulidoras de uñas no eléctricas
+8|Pulidoras eléctricas para las uñas
+8|Puñales
+8|Punzones de ganado operados manualmente
+8|Punzones de mano
+8|Raspadores de pintura (herramientas de mano accionadas manualmente)
+8|Raspadores manuales para despellejar peces
+8|Raspadores manuales para quitar el hielo de las ventanillas de vehículos
+8|Raspadores para uso doméstico
+8|Rastrillos
+8|Rastrillos para césped accionados manualmente
+8|Recortadoras accionadas manualmente
+8|Recortadoras de barba eléctricas
+8|Recortadores de cejas no eléctricos
+8|Rizadores de cabello eléctricos
+8|Rizadores de pestañas
+8|Rizadores eléctricos para el cabello
+8|Sables (espadas)
+8|Sierras accionadas manualmente
+8|Sierras de aserradero
+8|Sierras de mano
+8|Sierras de vaivén accionadas manualmente
+8|Sierras para cortar metales
+8|Sierras para cortar ramas
+8|Suavizadores (cueros) de navajas de afeitar
+8|Tacos de lija (herramientas de mano)
+8|Taladros manuales
+8|Taladros manuales de hielo utilizados para la pesca en hielo
+8|Tenacillas (herramientas de mano)
+8|Tenazas de carpintero (arrancaclavos)
+8|Tenedores
+8|Tenedores (artículos de cuchillería)
+8|Tenedores de mesa
+8|Tenedores para caracoles
+8|Tensores (herramientas accionadas manualmente)
+8|Terrajas de roscar
+8|Tijeras
+8|Tijeras de bordado
+8|Tijeras de costura
+8|Tijeras de hojalatero accionadas manualmente
+8|Tijeras de podar
+8|Tijeras de sastre
+8|Tijeras dentadas
+8|Tijeras especiales para cortar hilos
+8|Tijeras manuales
+8|Tijeras manuales para chapa
+8|Tijeras para cortar el cabello
+8|Tijeras para cortar metales (cizallas para hojalata)
+8|Tijeras para cutícula
+8|Tijeras para ikebana
+8|Tijeras para niños
+8|Tijeras para recortar mechas de velas
+8|Tijeras para trinchar aves
+8|Tijeras para uso doméstico
+8|Tiradores de tabs de latas
+8|Tornillos de banco
+8|Tranchetes (chairas, cuchillas de zapatero)
+8|Troqueles de perforado
+8|Troqueles para su uso con herramientas manuales
+8|Vainas de cuchillo
+8|Varillas afiladoras

--- a/lib/seeds/class_9_terms.csv
+++ b/lib/seeds/class_9_terms.csv
@@ -1,911 +1,1658 @@
-class,reference_id,name
-9,090001,bobinas eléctricas
-9,090002,aceleradores de partículas
-9,090003,artículos reflectantes ponibles para prevenir accidentes
-9,090004,dispositivos de protección personal contra accidentes
-9,090005,ropa de protección contra los accidentes, las radiaciones y el fuego
-9,090007,acumuladores eléctricos para vehículos
-9,090007,baterías eléctricas para vehículos
-9,090008,vasos de acumuladores
-9,090008,vasos de baterías
-9,090009,cajas de acumuladores
-9,090009,cajas de baterías
-9,090010,acidímetros para acumuladores
-9,090010,acidímetros para baterías
-9,090011,hidrómetros
-9,090012,placas para acumuladores eléctricos
-9,090012,placas para baterías
-9,090013,silbatos de alarma
-9,090014,alarmas acústicas
-9,090014,alarmas sonoras
-9,090015,conductos acústicos
-9,090016,discos acústicos
-9,090016,discos fonográficos
-9,090017,tubos acústicos
-9,090017,bocinas*
-9,090018,actinómetros
-9,090019,máquinas de sumar
-9,090020,aerómetros
-9,090021,ampliadores [fotografía]
-9,090022,aparatos electrodinámicos para el control remoto de agujas de ferrocarril
-9,090023,imanes
-9,090024,bobinas electromagnéticas
-9,090025,aparatos analizadores de aire
-9,090026,instrumentos de alarma
-9,090027,alcoholímetros
-9,090028,alidadas
-9,090029,aparatos para analizar alimentos
-9,090030,dispositivos eléctricos de encendido a distancia
-9,090031,baterías de arranque
-9,090033,altímetros
-9,090034,guantes de amianto de protección contra accidentes
-9,090034,guantes de asbesto de protección con accidentes
-9,090035,ropa de amianto ignífuga
-9,090035,ropa de asbesto ignífuga
-9,090036,amperímetros
-9,090037,amplificadores
-9,090037,aparatos amplificadores de sonido
-9,090038,tubos amplificadores
-9,090038,válvulas amplificadoras
-9,090039,anemómetros
-9,090040,anillos de calibración
-9,090041,extintores
-9,090043,ánodos
-9,090044,baterías de ánodos
-9,090044,baterías de alta tensión
-9,090045,antenas
-9,090046,gafas antideslumbrantes
-9,090046,anteojos antirreflejo
-9,090047,viseras para cascos
-9,090048,dispositivos antiparásitos [electricidad]
-9,090049,transformadores eléctricos
-9,090050,apertómetros [óptica]
-9,090053,máquinas para contar y clasificar dinero
-9,090054,armarios de distribución [electricidad]
-9,090055,instrumentos de agrimensura
-9,090055,instrumentos para el levantamiento de planos
-9,090056,cadenas de agrimensura
-9,090059,objetivos de astrofotografía
-9,090060,válvulas termoiónicas
-9,090060,tubos de cátodo caliente
-9,090060,tubos termoiónicos
-9,090061,aparatos de enseñanza audiovisual
-9,090062,tocadiscos automáticos de previo pago
-9,090062,rocolas
-9,090063,mecanismos para aparatos que funcionan con monedas
-9,090064,mecanismos para aparatos que funcionan con fichas
-9,090066,calibres
-9,090067,comparadores
-9,090068,alarmas contra incendios
-9,090069,indicadores automáticos de pérdida de presión en los neumáticos de vehículos
-9,090070,trajes especiales de protección para aviadores
-9,090071,timbres de alarma eléctricos
-9,090072,varillas de zahorí
-9,090073,balsas salvavidas
-9,090074,balanzas
-9,090075,globos meteorológicos
-9,090076,aparatos desmagnetizadores de cintas magnéticas
-9,090077,grabadoras de cinta magnética
-9,090077,magnetófonos
-9,090078,cintas magnéticas
-9,090079,barómetros
-9,090080,máquinas de pesaje
-9,090081,básculas [aparatos de pesaje]
-9,090082,batefuegos
-9,090083,cargadores para acumuladores eléctricos
-9,090085,betatrones
-9,090086,distribuidores de billetes [tickets]
-9,090086,distribuidores de boletos
-9,090087,cajas de altavoces
-9,090087,cajas de altoparlantes
-9,090088,lentes de aproximación
-9,090089,bornes [electricidad]
-9,090090,tapones indicadores de presión para válvulas
-9,090092,galvanómetros
-9,090093,botones de timbre
-9,090094,cajas de derivación [electricidad]
-9,090095,brazos de tocadiscos
-9,090096,niveles de burbuja
-9,090097,máquinas de tarjetas perforadas para oficinas
-9,090098,fundas para cables eléctricos
-9,090099,marcos para diapositivas
-9,090101,reglas de cálculo circulares
-9,090102,reglas de cálculo
-9,090103,máquinas de calcular
-9,090103,máquinas aritméticas
-9,090103,calculadoras
-9,090104,compases de corredera
-9,090104,pies de rey
-9,090105,gálibos [instrumentos de medición]
-9,090106,aparatos para fotocalcos
-9,090107,cámaras cinematográficas
-9,090109,tubos capilares
-9,090111,soportes para grabaciones sonoras
-9,090112,cascos de protección
-9,090113,máscaras respiratorias que no sean para la respiración artificial
-9,090114,caretas para soldar
-9,090115,cadenas para gafas
-9,090115,cadenas para anteojos
-9,090116,aparatos de control térmico
-9,090116,aparatos termorreguladores
-9,090117,cuartos oscuros [fotografía]
-9,090120,instrumentos de control de calderas
-9,090122,estantes de secado [fotografía]
-9,090124,dispositivos para el montaje de películas cinematográficas
-9,090125,circuitos impresos
-9,090126,luces intermitentes [señales luminosas]
-9,090127,campanas de señalización
-9,090128,cajas para portaobjetos
-9,090129,colectores eléctricos
-9,090130,instalaciones eléctricas para el control remoto de operaciones industriales
-9,090131,cajas de distribución [electricidad]
-9,090132,conmutadores
-9,090133,brújulas marinas
-9,090134,oculares
-9,090136,cuentahilos
-9,090137,podómetros
-9,090137,cuentapasos
-9,090138,contadores
-9,090139,metrónomos
-9,090140,condensadores eléctricos
-9,090141,conductores eléctricos
-9,090142,conductos eléctricos
-9,090143,coyuntores
-9,090144,conectores [electricidad]
-9,090145,cajas de empalme [electricidad]
-9,090145,cajas de conexión
-9,090146,tableros de conexión
-9,090148,contactos eléctricos
-9,090149,aparatos de control del franqueo
-9,090150,aparatos eléctricos de control
-9,090150,aparatos eléctricos de regulación
-9,090151,aparatos de vigilancia que no sean para uso médico
-9,090152,aparatos de control de velocidad para vehículos
-9,090153,convertidores eléctricos
-9,090153,conmutatrices
-9,090154,fotocopiadoras
-9,090156,cordones para gafas
-9,090156,cordones para anteojos
-9,090157,retortas
-9,090158,soportes para retortas
-9,090159,lentes correctoras [óptica]
-9,090160,objetivos [óptica]
-9,090161,instrumentos de cosmografía
-9,090162,trajes de buceo
-9,090162,escafandras
-9,090162,trajes de submarinismo
-9,090163,aparatos eléctricos de conmutación
-9,090164,interruptores
-9,090164,peras eléctricas [interruptores]
-9,090165,limitadores [electricidad]
-9,090166,enchufes macho
-9,090166,clavijas eléctricas
-9,090167,rectificadores de corriente
-9,090168,reductores [electricidad]
-9,090169,cintas métricas de costura
-9,090170,crisoles
-9,090170,copelas
-9,090171,aparatos para medir el espesor del cuero
-9,090172,ciclotrones
-9,090173,detectores de moneda falsa
-9,090174,disparadores [fotografía]
-9,090175,densímetros
-9,090176,dibujos animados
-9,090177,bandejas de laboratorio
-9,090178,detectores de metales para uso industrial o militar
-9,090179,sonares
-9,090180,detectores
-9,090181,obturadores [fotografía]
-9,090182,diafragmas [acústica]
-9,090183,aparatos para enmarcar diapositivas
-9,090184,cámaras fotográficas
-9,090185,diapositivas
-9,090186,proyectores de diapositivas
-9,090187,aparatos medidores de distancias
-9,090187,distanciómetros
-9,090188,máquinas de dictar
-9,090188,dictáfonos
-9,090189,aparatos de difracción [microscopia]
-9,090190,altavoces
-9,090190,altoparlantes
-9,090191,disyuntores
-9,090191,cortacircuitos
-9,090192,tocadiscos
-9,090193,microscopios
-9,090194,aparatos registradores de distancias
-9,090195,telémetros
-9,090197,tableros de distribución [electricidad]
-9,090198,consolas de distribución [electricidad]
-9,090200,compases de medición
-9,090201,medidores
-9,090202,aparatos de medición
-9,090203,dinamómetros
-9,090204,indicadores del nivel de agua
-9,090205,escalas de salvamento
-9,090206,flashes [fotografía]
-9,090207,auriculares telefónicos
-9,090208,pantallas fluorescentes
-9,090209,pantallas de proyección
-9,090210,pantallas de protección facial para obreros
-9,090211,pantallas [fotografía]
-9,090212,escurridores para uso fotográfico
-9,090213,indicadores de pérdida eléctrica
-9,090214,aparatos eléctricos de medición
-9,090214,dispositivos eléctricos de medición
-9,090215,cables eléctricos
-9,090216,conducciones eléctricas
-9,090217,tableros de control [electricidad]
-9,090218,celdas galvánicas
-9,090218,elementos galvánicos
-9,090219,acometidas de líneas eléctricas
-9,090220,empalmes eléctricos
-9,090220,acoplamientos eléctricos
-9,090222,relés eléctricos
-9,090226,electrolizadores
-9,090227,emisores de señales electrónicas
-9,090228,emisores [telecomunicación]
-9,090230,dispositivos de limpieza para discos acústicos
-9,090230,dispositivos de limpieza para discos fonográficos
-9,090231,cintas para grabaciones sonoras
-9,090232,cuentakilómetros para vehículos
-9,090233,carretes [fotografía]
-9,090234,letreros mecánicos
-9,090235,epidiascopios
-9,090236,probetas
-9,090237,dispositivos de equilibrado
-9,090238,termostatos
-9,090239,ergómetros
-9,090240,instrumentos y máquinas para pruebas de materiales
-9,090241,ovoscopios
-9,090242,calibradores
-9,090243,indicadores de gasolina
-9,090245,parachispas*
-9,090246,estuches especiales para aparatos e instrumentos fotográficos
-9,090249,aparatos de análisis que no sean para uso médico
-9,090250,refractómetros
-9,090251,exposímetros
-9,090252,máquinas facturadoras
-9,090253,aparatos de fermentación [aparatos de laboratorio]
-9,090254,aparatos de seguridad para el tráfico ferroviario
-9,090255,hilos eléctricos
-9,090256,hilos magnéticos
-9,090257,plomos de plomada
-9,090258,plomadas
-9,090259,redes de protección contra accidentes
-9,090260,redes de seguridad
-9,090260,redes de salvamento
-9,090261,lonas de salvamento
-9,090262,aparatos para cortar películas
-9,090263,filtros para máscaras respiratorias
-9,090264,filtros fotográficos
-9,090266,cargadores de pilas y baterías
-9,090267,aparatos de alta frecuencia
-9,090268,frecuencímetros
-9,090269,fusibles
-9,090270,aparatos de radio
-9,090270,aparatos de T.S.H.
-9,090271,cristales de galena [detectores]
-9,090272,pilas galvánicas
-9,090274,guantes de protección contra accidentes
-9,090275,guantes de buceo
-9,090275,guantes de submarinismo
-9,090276,guantes de protección contra los rayos X para uso industrial
-9,090278,aparatos para analizar gases
-9,090279,gasómetros [instrumentos de medición]
-9,090280,aparatos e instrumentos geodésicos
-9,090281,jalones [instrumentos de agrimensura]
-9,090281,piquetes [instrumentos de agrimensura]
-9,090282,aparatos para secar impresiones fotográficas
-9,090283,aparatos para satinar impresiones fotográficas
-9,090284,reglas [instrumentos de medición]
-9,090285,recipientes de vidrio graduados
-9,090286,tramas de fotograbado
-9,090287,rejillas para acumuladores eléctricos
-9,090287,rejillas para baterías
-9,090288,ropa de protección contra el fuego
-9,090288,ropa ignífuga
-9,090289,receptores [audio y vídeo]
-9,090290,aparatos heliográficos
-9,090291,hologramas
-9,090292,higrómetros
-9,090293,bridas de identificación para hilos eléctricos
-9,090294,fundas de identificación para hilos eléctricos
-9,090295,aparatos y dispositivos de salvamento
-9,090295,aparatos y dispositivos de auxilio
-9,090296,lanzas para mangas de incendio
-9,090297,autobombas contra incendios
-9,090298,bombas contra incendios
-9,090299,indicadores de pendiente
-9,090299,clinómetros
-9,090299,inclinómetros
-9,090300,taxímetros
-9,090301,indicadores de cantidad
-9,090302,vacuómetros
-9,090302,indicadores de vacío
-9,090303,indicadores de velocidad
-9,090304,inductores [electricidad]
-9,090305,inducidos [electricidad]
-9,090306,aparatos de procesamiento de datos
-9,090307,espejos de inspección para obras
-9,090308,aparatos de intercomunicación
-9,090309,intermediarios [fotografía]
-9,090310,inversores [electricidad]
-9,090311,aparatos de ionización que no sean para el tratamiento del aire ni del agua
-9,090312,mirillas ópticas para puertas
-9,090313,marcadores de dobladillos
-9,090315,mobiliario especial de laboratorio
-9,090316,lactodensímetros
-9,090317,lactómetros
-9,090317,pesaleches
-9,090318,lámparas para cuartos oscuros [fotografía]
-9,090319,lámparas ópticas
-9,090319,linternas ópticas
-9,090321,linternas mágicas
-9,090322,linternas de señales
-9,090323,láseres que no sean para uso médico
-9,090324,lentes ópticas
-9,090324,lentillas ópticas
-9,090325,pesacartas
-9,090326,correderas*
-9,090327,sondalezas
-9,090328,lupas [óptica]
-9,090329,letreros luminosos
-9,090330,tubos luminosos [publicidad]
-9,090330,letreros de neón
-9,090331,gafas [óptica]
-9,090331,anteojos [óptica]
-9,090332,instrumentos con lentes oculares
-9,090333,niveles de anteojo
-9,090334,lentes para gafas
-9,090334,lentes para anteojos
-9,090335,artículos de óptica para la vista
-9,090336,manómetros
-9,090337,periscopios
-9,090338,máscaras de protección*
-9,090339,instrumentos matemáticos
-9,090340,mecanismos que funcionan con monedas para televisores
-9,090341,megáfonos
-9,090342,memorias de ordenador
-9,090342,memorias de computadora
-9,090343,reglas de carpintero [reglas de corredera]
-9,090344,niveles de mercurio
-9,090345,aparatos para medir la velocidad [fotografía]
-9,090346,aparatos para mediciones de precisión
-9,090347,instrumentos de medición
-9,090348,instrumentos meteorológicos
-9,090349,metros [instrumentos de medición]
-9,090350,tornillos micrométricos para instrumentos ópticos
-9,090351,micrófonos
-9,090352,microtomos
-9,090353,temporizadores que no sean artículos de relojería
-9,090354,espejos [óptica]
-9,090355,aparatos de respiración para la natación subacuática
-9,090356,aparatos e instrumentos náuticos
-9,090357,aparatos de señalización naval
-9,090358,instrumentos de navegación
-9,090359,monturas de gafas
-9,090359,monturas de anteojos
-9,090360,pilas eléctricas
-9,090360,baterías eléctricas
-9,090361,acumuladores eléctricos
-9,090362,niveles [instrumentos para determinar la horizontalidad]
-9,090363,instrumentos de nivelación
-9,090365,prismas [óptica]
-9,090366,instrumentos de observación
-9,090367,octantes
-9,090368,ohmímetros
-9,090369,ondámetros
-9,090370,aparatos e instrumentos ópticos
-9,090371,cristal óptico
-9,090371,vidrio óptico
-9,090372,ordenadores
-9,090372,computadoras
-9,090373,programas informáticos grabados
-9,090374,oscilógrafos
-9,090377,aparatos para trasvasar oxígeno
-9,090378,ozonizadores
-9,090379,micrómetros
-9,090379,palmers
-9,090380,paneles de señalización luminosos o mecánicos
-9,090381,pararrayos
-9,090383,parquímetros
-9,090384,aparatos e instrumentos de astronomía
-9,090386,aparatos para medir el espesor de las pieles
-9,090387,acidímetros
-9,090388,aparatos e instrumentos de pesaje
-9,090389,salinómetros
-9,090390,cubetas de lavado [fotografía]
-9,090391,pies para aparatos fotográficos
-9,090392,visores fotográficos
-9,090393,fotómetros
-9,090394,aparatos de telefotografía
-9,090395,aparatos e instrumentos de física
-9,090396,dispositivos de conducción automática para vehículos [pilotos automáticos]
-9,090396,pilotos automáticos
-9,090397,quevedos
-9,090398,pipetas de laboratorio
-9,090399,planchetas [instrumentos de agrimensura]
-9,090400,planímetros
-9,090401,tapones auditivos para buceo
-9,090401,tapones auditivos para submarinismo
-9,090402,timbres [aparatos de alarma]
-9,090403,pesas*
-9,090404,polarímetros
-9,090407,aparatos radiotelefónicos
-9,090408,aparatos radiotelegráficos
-9,090409,medidores de presión
-9,090410,indicadores de presión
-9,090411,aparatos de proyección
-9,090412,dispositivos catódicos de protección antioxidante
-9,090414,protectores bucales*
-9,090415,pirómetros
-9,090416,radares
-9,090417,aparatos de radio para vehículos
-9,090418,aparatos de radiología para uso industrial
-9,090419,transportadores [instrumentos de medición]
-9,090420,aparatos e instalaciones para generar rayos X que no sean para uso médico
-9,090421,tubos de rayos X que no sean para uso médico
-9,090422,dispositivos de protección contra los rayos X que no sean para uso médico
-9,090423,aparatos telefónicos
-9,090424,refractores
-9,090425,aparatos de rayos X que no sean para uso médico
-9,090426,espectroscopios
-9,090427,resistencias eléctricas
-9,090429,termómetros que no sean para uso médico
-9,090430,respiradores para filtrar el aire
-9,090431,aparatos de respiración que no sean para la respiración artificial
-9,090432,reóstatos
-9,090433,romanas [balanzas]
-9,090434,señales luminosas o mecánicas
-9,090435,sacarímetros
-9,090436,sondas para uso científico
-9,090437,satélites para uso científico
-9,090439,diafragmas para aparatos científicos
-9,090440,aparatos de enseñanza
-9,090440,aparatos didácticos
-9,090440,aparatos escolares
-9,090441,bobinas de reactancia [bobinas de impedancia]
-9,090442,bornes de presión [electricidad]
-9,090443,cerraduras eléctricas
-9,090444,sextantes
-9,090445,silbatos de señalización
-9,090446,triángulos de señalización de avería para vehículos
-9,090447,aparatos electrodinámicos para el control remoto de señales
-9,090448,simuladores de conducción y control de vehículos
-9,090449,sirenas
-9,090450,aparatos de transmisión de sonido
-9,090451,aparatos de grabación de sonido
-9,090452,aparatos de reproducción de sonido
-9,090453,aparatos y máquinas de sondeo
-9,090454,plomos de sondas
-9,090454,escandallos
-9,090455,sonómetros
-9,090457,espectrógrafos
-9,090458,esferómetros
-9,090460,estereoscopios
-9,090461,aparatos estereoscópicos
-9,090462,agujas de zafiro para tocadiscos
-9,090462,púas de zafiro para tocadiscos
-9,090463,sulfitómetros
-9,090464,teletipos
-9,090464,teleimpresores
-9,090465,tacómetros
-9,090465,taquímetros
-9,090466,calibres de roscado
-9,090467,telégrafos [aparatos]
-9,090468,televisores
-9,090469,hilos telegráficos
-9,090470,aparatos de control remoto*
-9,090471,postes de T.S.H.
-9,090471,postes para antenas inalámbricas
-9,090471,postes de telefonía inalámbrica
-9,090472,teleapuntadores
-9,090473,transmisores telefónicos
-9,090474,telerruptores
-9,090475,gemelos [óptica]
-9,090475,binoculares
-9,090476,telescopios
-9,090476,catalejos
-9,090477,indicadores de temperatura
-9,090478,aparatos para registrar el tiempo
-9,090479,teodolitos
-9,090481,termostatos para vehículos
-9,090484,totalizadores
-9,090485,cuentarrevoluciones
-9,090486,reguladores de velocidad para tocadiscos
-9,090488,transmisores [telecomunicación]
-9,090489,balanzas de precisión
-9,090490,gramiles
-9,090491,tubos de vacío [radio]
-9,090492,urómetros
-9,090493,variómetros
-9,090494,nonius
-9,090495,cintas de vídeo
-9,090495,videocintas
-9,090496,viscosímetros
-9,090497,instalaciones eléctricas antirrobo
-9,090498,reguladores de voltaje para vehículos
-9,090499,máquinas de votación
-9,090500,voltímetros
-9,090503,dispositivos para cambiar agujas de tocadiscos
-9,090503,dispositivos para cambiar púas de tocadiscos
-9,090504,alambiques de laboratorio
-9,090505,alambres fusibles
-9,090507,anticátodos
-9,090508,silbatos para perros
-9,090509,miras telescópicas para armas de fuego
-9,090511,alarmas antirrobo
-9,090512,instrumentos acimutales
-9,090513,balizas luminosas
-9,090514,soportes de bobinas eléctricas
-9,090515,películas expuestas
-9,090516,balizas luminosas o mecánicas para carreteras
-9,090517,aros salvavidas
-9,090517,salvavidas
-9,090518,boyas de señalización
-9,090522,zumbadores
-9,090523,brújulas
-9,090524,señales de niebla no explosivas
-9,090525,cajas registradoras
-9,090526,pantallas radiológicas para uso industrial
-9,090529,tarjetas magnéticas de identificación
-9,090531,células fotovoltaicas
-9,090532,densitómetros
-9,090533,discos magnéticos
-9,090534,disquetes
-9,090535,cintas para limpiar cabezales de lectura
-9,090536,grabadoras de vídeo
-9,090536,aparatos de vídeo
-9,090537,teclados de ordenador
-9,090537,teclados de computadora
-9,090538,circuitos integrados
-9,090539,semiconductores
-9,090540,chips [circuitos integrados]
-9,090543,cátodos
-9,090546,chalecos salvavidas
-9,090547,cinturones salvavidas
-9,090549,aparatos e instrumentos de química
-9,090550,películas cinematográficas expuestas
-9,090553,material para conducciones eléctricas [hilos, cables]
-9,090554,lentes de contacto
-9,090554,lentillas de contacto
-9,090555,estuches para lentes de contacto
-9,090555,estuches para lentillas de contacto
-9,090556,incubadoras para cultivos bacterianos
-9,090557,pilas solares
-9,090557,baterías solares
-9,090558,hilos de cobre aislados
-9,090559,tubos de descarga eléctrica que no sean para la iluminación
-9,090562,diafragmas [fotografía]
-9,090564,aparatos de destilación para uso científico
-9,090565,dosificadores
-9,090565,aparatos de dosificación
-9,090565,dosímetros
-9,090566,timbres de puerta eléctricos
-9,090567,estuches para gafas
-9,090567,estuches para anteojos
-9,090568,hornos de laboratorio
-9,090571,fibras ópticas [filamentos conductores de ondas luminosas]
-9,090571,filamentos conductores de ondas luminosas [fibras ópticas]
-9,090572,hilos telefónicos
-9,090573,películas de rayos X expuestas
-9,090573,películas radiográficas expuestas
-9,090574,filtros de rayos ultravioleta para la fotografía
-9,090575,pabellones [conos] de altavoces
-9,090577,trípodes para cámaras fotográficas
-9,090581,lectores de códigos de barras
-9,090582,chalecos antibalas
-9,090583,boyas de localización
-9,090583,boyas de referencia
-9,090584,obleas para circuitos integrados
-9,090585,aparatos de cromatografía para laboratorios
-9,090586,cronógrafos [aparatos para registrar el tiempo]
-9,090587,discos compactos [audio y vídeo]
-9,090588,discos ópticos compactos
-9,090588,discos compactos [memorias de sólo lectura]
-9,090589,programas de sistemas operativos informáticos grabados
-9,090590,periféricos informáticos
-9,090591,software [programas grabados]
-9,090592,condensadores ópticos
-9,090593,acopladores acústicos
-9,090594,acopladores [equipos de procesamiento de datos]
-9,090595,cámaras de descompresión
-9,090596,trazadores [plóters]
-9,090596,plóters [trazadores]
-9,090597,máscaras de buceo
-9,090597,máscaras de submarinismo
-9,090598,lápices electrónicos para unidades de visualización
-9,090599,tarjetas magnéticas codificadas
-9,090600,aparatos de fax
-9,090601,barcos-bomba contra incendios
-9,090603,interfaces [informática]
-9,090604,cambiadiscos [periféricos informáticos]
-9,090605,rodilleras para trabajadores
-9,090606,reguladores de luz eléctricos
-9,090606,variadores de luz eléctricos
-9,090607,soportes magnéticos de datos
-9,090608,codificadores magnéticos
-9,090609,unidades de cinta magnética [informática]
-9,090610,microprocesadores
-9,090611,módems
-9,090612,monitores [hardware]
-9,090613,monitores [programas informáticos]
-9,090614,ratones [periféricos informáticos]
-9,090615,lectores ópticos
-9,090616,soportes ópticos de datos
-9,090617,discos ópticos
-9,090618,impresoras de ordenador*
-9,090618,impresoras de computadora*
-9,090619,procesadores [unidades centrales de proceso]
-9,090619,unidades centrales de proceso [procesadores]
-9,090620,lectores [equipos de procesamiento de datos]
-9,090621,arneses de seguridad que no sean para asientos de vehículos ni equipos de deporte
-9,090622,escáneres [equipos de procesamiento de datos]
-9,090623,detectores de humo
-9,090624,transistores [electrónica]
-9,090625,radiografías que no sean para uso médico
-9,090626,manguitos de unión para cables eléctricos
-9,090627,ábacos
-9,090628,agendas electrónicas
-9,090629,contestadores telefónicos
-9,090629,contestadores automáticos
-9,090630,cámaras de vídeo
-9,090630,videocámaras
-9,090631,lectores de casetes
-9,090631,reproductores de casetes
-9,090632,lectores de discos compactos
-9,090632,reproductores de discos compactos
-9,090633,aparatos de diagnóstico que no sean para uso médico
-9,090634,mecanismos de arrastre de discos [informática]
-9,090634,unidades de disco [hardware]
-9,090635,raíles electrificados para montar proyectores
-9,090635,rieles electrificados para montar proyectores
-9,090636,traductores electrónicos de bolsillo
-9,090637,etiquetas electrónicas para mercancías
-9,090638,mantas ignífugas
-9,090639,bombillas de flash
-9,090640,tarjetas de circuitos integrados
-9,090640,tarjetas inteligentes
-9,090641,cucharas dosificadoras
-9,090642,ordenadores portátiles
-9,090642,computadoras portátiles
-9,090643,tablones de anuncios electrónicos
-9,090644,calculadoras de bolsillo
-9,090645,calzado de protección contra los accidentes, las radiaciones y el fuego
-9,090646,rociadores automáticos contra incendios
-9,090647,cables de arranque para motores
-9,090648,gafas de sol
-9,090648,anteojos de sol
-9,090649,relojes de fichar
-9,090649,relojes de control horario
-9,090650,casetes de vídeo
-9,090651,cartuchos de videojuegos
-9,090652,pantallas de vídeo
-9,090653,videoteléfonos
-9,090654,gafas de deporte
-9,090654,anteojos de deporte
-9,090655,pinzas nasales para submarinistas y nadadores
-9,090656,cascos protectores para deportes
-9,090657,publicaciones electrónicas descargables
-9,090658,programas informáticos descargables
-9,090659,aparatos de navegación para vehículos [ordenadores de a bordo]
-9,090660,imanes decorativos
-9,090661,teléfonos inalámbricos
-9,090662,alfombrillas de ratón
-9,090663,reproductores de sonido portátiles
-9,090664,reposamuñecas para utilizar con ordenadores
-9,090664,reposamuñecas para utilizar con computadoras
-9,090665,cables coaxiales
-9,090666,cables de fibra óptica
-9,090667,tapas de enchufe
-9,090667,tapas de toma de corriente
-9,090668,ecosondas hidrográficas
-9,090669,vallas electrificadas
-9,090670,software de juegos informáticos grabado
-9,090671,auriculares de diadema
-9,090671,cascos auriculares
-9,090672,balastos para aparatos de iluminación
-9,090673,aparatos de radiobúsqueda
-9,090674,aparatos de navegación por satélite
-9,090675,válvulas solenoides [interruptores electromagnéticos]
-9,090676,protectores de sobretensión
-9,090676,protectores de sobrevoltaje
-9,090677,radioteléfonos portátiles [walkie-talkies]
-9,090678,mangas catavientos
-9,090679,punteros electrónicos luminosos
-9,090680,maniquís para ejercicios de reanimación [aparatos de enseñanza]
-9,090682,reguladores de luces de escenario
-9,090683,relojes de arena
-9,090684,chips de ADN
-9,090685,lectores de DVD
-9,090685,reproductores de DVD
-9,090686,cajeros automáticos bancarios
-9,090687,semáforos [dispositivos de señalización]
-9,090688,kits manos libres para teléfonos
-9,090689,pantallas de amianto para bomberos
-9,090689,pantallas de asbesto para bomberos
-9,090690,cascos de equitación
-9,090691,ropa especial de laboratorio
-9,090692,pulseras de identificación codificadas magnéticas
-9,090693,transpondedores
-9,090694,tonos de llamada descargables para teléfonos móviles
-9,090694,melodías de llamada descargables para teléfonos móviles
-9,090695,archivos de música descargables
-9,090696,archivos de imagen descargables
-9,090697,maniquís para pruebas de colisión
-9,090697,maniquís para pruebas de choque
-9,090698,centrífugas de laboratorio
-9,090698,centrifugadoras de laboratorio
-9,090699,tarjetas de circuitos impresos
-9,090700,memorias USB
-9,090700,memorias flash
-9,090701,aparatos de GPS [sistema mundial de determinación de la posición]
-9,090702,reproductores multimedia portátiles
-9,090703,cordones para teléfonos celulares
-9,090703,cordones para teléfonos móviles
-9,090703,correas para teléfonos celulares
-9,090703,correas para teléfonos móviles
-9,090704,diodos electroluminiscentes [ledes]
-9,090705,triodos
-9,090706,transformadores elevadores
-9,090707,ordenadores de regazo
-9,090707,computadoras de regazo
-9,090708,mangueras contra incendios
-9,090709,bolsas especiales para ordenadores portátiles
-9,090709,bolsas especiales para computadoras portátiles
-9,090710,fundas para ordenadores portátiles
-9,090711,marcos para fotos digitales
-9,090712,cajas de Petri
-9,090713,tubos de Pitot
-9,090714,estroboscopios
-9,090715,conos de tráfico
-9,090716,etiquetas indicadoras de la temperatura que no sean para uso médico
-9,090717,aplicaciones informáticas descargables
-9,090718,lectores de libros electrónicos
-9,090719,teléfonos inteligentes
-9,090720,cartuchos de tóner vacíos para impresoras y fotocopiadoras
-9,090721,dispositivos de audio y vídeo para la vigilancia de bebés
-9,090721,vigilabebés
-9,090722,monitores de vídeo para la vigilancia de bebés
-9,090722,vigilabebés con cámara
-9,090723,parasoles para objetivos fotográficos
-9,090724,tabletas electrónicas
-9,090725,tarjetas de acceso codificadas
-9,090726,gafas 3D
-9,090726,anteojos 3D
-9,090727,tarjetas de memoria para máquinas de videojuegos
-9,090728,ropa antibalas
-9,090729,acelerómetros
-9,090730,adaptadores eléctricos
-9,090731,cápsulas de salvamento para desastres naturales
-9,090732,hardware
-9,090733,paneles solares para producir electricidad
-9,090734,teléfonos celulares
-9,090734,teléfonos móviles
-9,090735,miras telescópicas de artillería
-9,090736,letreros digitales
-9,090737,monitores de actividad física ponibles
-9,090738,cargadores para cigarrillos electrónicos
-9,090739,brazaletes conectados [instrumentos de medición]
-9,090740,carcasas para teléfonos inteligentes
-9,090741,estuches para teléfonos inteligentes
-9,090742,brazos extensibles para autofotos [monopies de mano]
-9,090743,calorímetros
-9,090744,caudalímetros
-9,090745,chalecos de seguridad reflectantes
-9,090746,collares electrónicos para el adiestramiento de animales
-9,090747,palancas de mando [joysticks] de ordenador, que no sean para videojuegos
-9,090747,palancas de mando [joysticks] de computadora, que no sean para videojuegos
-9,090748,gafas inteligentes
-9,090748,anteojos inteligentes
-9,090749,relojes inteligentes
-9,090750,aparatos de extinción de incendios
-9,090751,láminas protectoras especiales para pantallas de ordenador
-9,090751,láminas protectoras especiales para pantallas de computadora
-9,090752,protectores bucales para deportes
-9,090753,protectores de cabeza para deportes
-9,090754,agujas para brújulas topográficas
-9,090755,fichas de seguridad [dispositivos de cifrado]
-9,090756,detectores de infrarrojos
-9,090757,carcasas para organizadores personales digitales [PDA]
-9,090758,pesabebés
-9,090758,básculas de bebés
-9,090759,sistemas de control de acceso electrónicos para puertas interbloqueadas
-9,090760,cámaras termográficas
-9,090761,básculas con calculadora de masa corporal
-9,090762,carcasas para tabletas electrónicas
-9,090763,cajas negras [registradores de datos]
-9,090764,estaciones meteorológicas digitales
-9,090765,estaciones de recarga para vehículos eléctricos
-9,090766,terminales interactivos con pantalla táctil
-9,090767,anillos inteligentes
-9,090768,dispositivos eléctricos y electrónicos de efectos para instrumentos musicales
-9,090769,interfaces de audio
-9,090770,ecualizadores [aparatos de audio]
-9,090771,altavoces de frecuencias ultrabajas
-9,090772,básculas para cuartos de baño
-9,090773,termohigrómetros
-9,090774,biochips
-9,090775,películas de protección para teléfonos inteligentes
-9,090776,cascos de realidad virtual
-9,090777,pizarras interactivas electrónicas
-9,090777,pizarrones interactivos electrónicos
-9,090778,robots humanoides dotados de inteligencia artificial
-9,090779,mezcladores de audio
-9,090780,baterías de cigarrillos electrónicos
-9,090781,llaveros electrónicos en cuanto mandos a distancia
-9,090782,partituras electrónicas descargables
-9,090783,reglas T graduadas
-9,090784,escuadras graduadas
-9,090785,escuadras de medición
-9,090786,dispositivos electrónicos de visualización numérica
-9,090787,robots de laboratorio
-9,090788,robots pedagógicos
-9,090789,robots de vigilancia para la seguridad
-9,090790,organizadores personales digitales [PDA]
-9,090791,plataformas de software, grabado o descargable
-9,090792,buscadores de satélites
-9,090793,medidores de anillos
-9,090794,anilleros
-9,090795,clientes ligeros [ordenadores]
-9,090796,cámaras de marcha atrás para vehículos 
-9,090796,cámaras de reversa para vehículos
-9,090797,diccionarios electrónicos de bolsillo
-9,090798,simuladores para la formación en reanimación
-9,090799,arneses de cableado eléctrico para automóviles
-9,090799,haces de cables eléctricos para automóviles
-9,090800,tubos de buceo
-9,090801,silbatos de deporte
-9,090802,software salvapantallas para ordenadores, grabado o descargable
-9,090803,objetivos para autofotos
-9,090803,lentes para autofotos
-9,090804,elementos gráficos descargables para teléfonos móviles
-9,090805,aparatos de telecomunicaciones en forma de joyas
-9,090806,ordenadores ponibles
-9,090807,monitores de visualización de vídeo ponibles
-9,090808,aparatos de imagenología por resonancia magnética [IRM] que no sean para uso médico
-9,090809,punteros láser de señalización de emergencia
-9,090810,cartuchos de tinta vacíos para impresoras y fotocopiadoras
-9,090811,pedales wah-wah
-9,090812,instrumentos para medir la estatura
-9,090813,maniquís de peluquería [aparatos de enseñanza]
-9,090814,dispositivos para proyectar teclados virtuales
-9,090815,mantas de supervivencia
-9,090816,botes salvavidas
-9,090817,dispositivos para analizar el tamaño de nanopartículas
-9,090818,almohadillas para cascos auriculares
-9,090819,guantes de datos
-9,090820,bolas de seguimiento [periféricos de ordenador]
-9,090820,bolas de desplazamiento [periféricos de ordenador]
-9,090821,emoticonos descargables para teléfonos móviles
-9,090822,robots de telepresencia
-9,090823,termostatos digitales para la climatización
-9,090824,sensores piezoeléctricos
-9,090825,diodos electroluminiscentes orgánicos [OLED]
-9,090826,diodos electroluminiscentes de puntos cuánticos [QLED]
-9,090827,cuentagotas graduados que no sean para uso médico o doméstico
-9,090827,goteros graduados que no sean para uso médico o doméstico
-9,090828,enchufes hembra
-9,090828,tomacorrientes
-9,090829,software de juegos descargable
-9,090830,luces de emergencia no explosivas ni pirotécnicas
-9,090831,soportes especiales para ordenadores portátiles
-9,090832,chichoneras
-9,090832,cubrecabezas en cuanto cascos de protección
-9,090833,candados electrónicos
-9,090834,cinturones de lastre para bucear
-9,090835,auriculares para comunicación remota
-9,090836,sensores de estacionamiento para vehículos
-9,090837,impresoras de billetes [tickets]
-9,090837,impresoras de boletos
-9,090838,arneses de sujeción corporal para levantar cargas
-9,090839,sonajeros de señalización para dirigir el ganado 
-9,090840,proyectores de vídeo
-9,090841,claves criptográficas descargables para recibir y gastar criptomonedas
-9,090842,billeteras electrónicas descargables
-9,090842,monederos electrónicos descargables
-9,090843,datáfonos
-9,090843,terminales para tarjetas de crédito
-9,090844,pasaportes biométricos
-9,090844,pasaportes electrónicos 
-9,090845,tarjetas de identidad biométricas
+class|name
+9|Ábacos
+9|Abalorios para teléfonos móviles
+9|Aceleradores de gráficos
+9|Acelerómetros
+9|Acometidas de líneas eléctricas
+9|Acopladores ópticos
+9|Acoplamientos de fibra óptica
+9|Acumuladores (baterías)
+9|Acumuladores y baterías
+9|Adaptadores (electricidad)
+9|Adaptadores de corriente eléctrica
+9|Adaptadores de corriente para su uso en casquillos de encendedor de vehículos
+9|Adaptadores de enchufe
+9|Adaptadores de prueba para probar tableros de circuitos impresos
+9|Adaptadores de redes informáticas
+9|Adaptadores de tarjetas de memoria flash
+9|Adaptadores para enchufes
+9|Adaptadores para lentes de cámaras
+9|Afinadores de radiofrecuencia de vehículos
+9|Agendas electrónicas
+9|Agujas de zafiro para tocadiscos
+9|Aireadores para uso en laboratorio
+9|Alambre y cable eléctrico
+9|Alambres de resistencia
+9|Alambres eléctricos
+9|Alambres y cables eléctricos
+9|Alargadores
+9|Alarmas acústicas
+9|Alarmas antirrobo
+9|Alarmas antirrobo eléctricas y electrónicas
+9|Alarmas antirrobo y contra incendio
+9|Alarmas contra incendios
+9|Alarmas contra intrusiones
+9|Alarmas para la detección de gases inflamables
+9|Alfombrillas de ratón
+9|Alidadas
+9|Almohadillas de enfriamiento para computadores portátiles
+9|Almohadillas de mouse (periféricos computacionales)
+9|Almohadillas nasales de silicona para anteojos
+9|Altavoces
+9|Altavoces con amplificadores incorporados
+9|Altavoces de subgraves
+9|Altavoces inalámbricos
+9|Altavoces para automóviles
+9|Altímetros
+9|Amortiguadores de vibración para equipamiento de audio electrónico
+9|Amperímetros
+9|Amplificadores de guitarra
+9|Amplificadores de poder
+9|Amplificadores de sonido
+9|Amplificadores de tubo
+9|Amplificadores de válvula
+9|Amplificadores eléctricos para su uso con instrumentos musicales
+9|Amplificadores semiconductores ópticos
+9|Analizadores de acidez
+9|Analizadores de esperma animal para uso en laboratorio
+9|Analizadores de fluorescencia de rayos X
+9|Analizadores de gas de combustión
+9|Analizadores de grasa corporal para uso doméstico
+9|Analizadores de humedad de la piel, que no sean para uso médico
+9|Analizadores de inyectores diésel
+9|Analizadores de partículas de polvo
+9|Analizadores electroscópicos de fotoelectrones (que no sean para uso médico)
+9|Analizadores informatizados para motores de vehículos
+9|Anillos adaptadores de objetivos para cámaras
+9|Antenas
+9|Antenas de autos
+9|Antenas de microondas
+9|Antenas de placa de zona
+9|Antenas de radio y televisión
+9|Antenas de radiofrecuencia
+9|Antenas de recepción para la difusión vía satélite
+9|Antenas de satélite
+9|Antenas de transmisión de ondas de radio
+9|Antenas externas
+9|Antenas para aparatos de comunicación inalámbrica
+9|Antenas para radar
+9|Antenas parabólicas
+9|Antenas parabólicas de satélite
+9|Antenas parabólicas para transmisiones por satélite
+9|Anteojos antideslumbrantes
+9|Anteojos con revestimiento antireflectante
+9|Anteojos de deporte
+9|Anticátodos
+9|Antiparras de visión nocturna
+9|Aparato de medición de nivel de láser
+9|Aparatos acopladores acústicos
+9|Aparatos analizadores de aire
+9|Aparatos basados en computadores para diseñar planos de circuitos electrónicos
+9|Aparatos científicos para analizar el contenido de agua en productos de petróleo
+9|Aparatos de alarma e instalaciones de alarma
+9|Aparatos de cierre centralizado de puertas
+9|Aparatos de codificación y decodificación
+9|Aparatos de conmutación de audio
+9|Aparatos de control de flujo de gas
+9|Aparatos de control eléctrico para calefacción y manejo de energía
+9|Aparatos de control eléctricos
+9|Aparatos de control remoto para instalaciones de aire acondicionado
+9|Aparatos de cromatografía automática
+9|Aparatos de cromatografía automáticos de intercambio de iones para uso en laboratorio
+9|Aparatos de cromatografía de gases para uso en laboratorio
+9|Aparatos de cromatografía líquida para su uso en laboratorios
+9|Aparatos de cromatografía para laboratorios
+9|Aparatos de destilación para uso científico
+9|Aparatos de detección por infrarrojos
+9|Aparatos de doblaje de audio
+9|Aparatos de fax
+9|Aparatos de fotocopiado
+9|Aparatos de grabación de imágenes y sonido
+9|Aparatos de grabación y reproducción para transportadores de sonido e imagen
+9|Aparatos de guía para aterrizaje de aeronaves
+9|Aparatos de identificación animal electrónicos
+9|Aparatos de karaoke
+9|Aparatos de localización
+9|Aparatos de medición de polvo fino
+9|Aparatos de medición de radiactividad
+9|Aparatos de medición de temperatura y niveles de humedad en gases y sustancias sólidas
+9|Aparatos de medición del polvo
+9|Aparatos de medición y control para aparatos de tecnología de aire acondicionado
+9|Aparatos de medida de parámetros de antenas
+9|Aparatos de medida digitales
+9|Aparatos de montaje para cámaras y monitores
+9|Aparatos de monturas para diapositivas
+9|Aparatos de navegación para botes
+9|Aparatos de navegación para vehículos (computadoras de a bordo)
+9|Aparatos de pantallas de vídeo colocados en la cabeza
+9|Aparatos de proyección de diapositivas o fotografías
+9|Aparatos de proyección de fotografías
+9|Aparatos de pruebas para comprobar placas de circuitos impresos
+9|Aparatos de radio para vehículos
+9|Aparatos de reconocimiento ópticos de caracteres
+9|Aparatos de registro de películas
+9|Aparatos de reproducción de sonido
+9|Aparatos de respiración para la natación subacuática
+9|Aparatos de respiración subacuática
+9|Aparatos de telefonía celular
+9|Aparatos de telefonía inalámbrica
+9|Aparatos de telefotografía
+9|Aparatos de telemetría por control remoto
+9|Aparatos de televisión para proyección
+9|Aparatos de transmisión de microondas para programas de radio y mensajes
+9|Aparatos de transmisión de sonido
+9|Aparatos de transmisión de telecomunicaciones
+9|Aparatos de transmisión de video
+9|Aparatos de transmisión telegráfica
+9|Aparatos de transmisión y recepción de fax
+9|Aparatos de video
+9|Aparatos de visualización de puntuación (electrónicos)
+9|Aparatos e instrumentos de codificación y decodificación
+9|Aparatos e instrumentos de grabación de sonido (aparatos cinematográficos)
+9|Aparatos e instrumentos de grabación y reproducción de sonido
+9|Aparatos e instrumentos de navegación y posicionamiento
+9|Aparatos e instrumentos de pesaje
+9|Aparatos e instrumentos para transportar, distribuir, transformar, almacenar, regular o controlar la corriente eléctrica
+9|Aparatos e instrumentos tocadiscos
+9|Aparatos e instrumentos xerográficos
+9|Aparatos eléctricos para la modificación genética de células para uso en investigación científica
+9|Aparatos electrónicos utilizados para localizar artículos perdidos utilizando sistemas de posicionamiento globales o redes de comunicaciones celulares
+9|Aparatos evaluadores para acumuladores
+9|Aparatos extintores de incendio para vehículos
+9|Aparatos extintores de incendios
+9|Aparatos identificadores biométricos
+9|Aparatos interruptores automáticos (para telecomunicaciones)
+9|Aparatos medidores de distancias
+9|Aparatos multifuncionales que incorporan copiadoras y funciones de facsímiles en modo autónomo
+9|Aparatos para análisis de gases, líquidos y sólidos
+9|Aparatos para analizar gases
+9|Aparatos para control de parámetros de vuelo
+9|Aparatos para difusión, grabación, transmisión o reproducción de sonido o imágenes
+9|Aparatos para el control de la iluminación
+9|Aparatos para grabación, transmisión o reproducción de imágenes
+9|Aparatos para grabación, transmisión o reproducción de sonido e imágenes
+9|Aparatos para grabación, transmisión y reproducción de imágenes
+9|Aparatos para grabación, transmisión y reproducción de sonido e imágenes
+9|Aparatos para grabación, transmisión, procesamiento y reproducción de sonido, imágenes o datos
+9|Aparatos para grabar y reproducir voz
+9|Aparatos para interferir radares
+9|Aparatos para la grabación, transmisión y reproducción de sonido e imágenes
+9|Aparatos para la reproducción de películas
+9|Aparatos para limpiar cabezales de lectura magnéticos
+9|Aparatos para medir la alineación de las ruedas
+9|Aparatos para medir la velocidad del swing en golf
+9|Aparatos para prueba de frenos de vehículos
+9|Aparatos para prueba de transmisiones de vehículos
+9|Aparatos para pruebas de alcohol
+9|Aparatos para registrar el tiempo
+9|Aparatos para secar impresiones fotográficas
+9|Aparatos para transmisión de comunicaciones
+9|Aparatos para transmisión inalámbrica de información acústica
+9|Aparatos para transmisión y reproducción de sonido o imágenes
+9|Aparatos para transmitir programas de radio y mensajes de radio
+9|Aparatos periféricos informáticos
+9|Aparatos portátiles para la reproducción de sonido
+9|Aparatos radiotelefónicos
+9|Aparatos radiotelegráficos
+9|Aparatos receptores de televisión por satélite
+9|Aparatos resonadores
+9|Aparatos telefónicos
+9|Aparatos telefónicos con pantalla y teclado incorporados
+9|Aparatos telefónicos inalámbricos
+9|Aparatos telefónicos móviles con sistemas de fax incorporados
+9|Aparatos telegráficos automáticos
+9|Aparatos telegráficos manuales
+9|Aparatos transmisores y receptores para emisiones de radio y televisión y para transmisiones de larga distancia
+9|Aparatos video grabadores y video reproductores
+9|Aparatos y receptores telefónicos
+9|Archivos de música descargables
+9|Armazones de altavoces
+9|Arranques de batería
+9|Asistentes personales digitales
+9|Atenuadores
+9|Atenuadores de luces
+9|Atriles de soporte para micrófonos
+9|Audio casetes de audio vírgenes
+9|Audio cintas con música
+9|Audio cintas pregrabadas con música
+9|Audio cintas vírgenes
+9|Audio receptores y video receptores
+9|Auriculares
+9|Auriculares de botón
+9|Auriculares de conducción ósea
+9|Auriculares de supresión de ruidos
+9|Auriculares estéreo
+9|Auriculares manos libres para celulares
+9|Auriculares para juegos de realidad virtual
+9|Auriculares para música
+9|Auriculares para teléfonos
+9|Auriculares para teléfonos móviles
+9|Auriculares personales para aparatos de transmisión de sonido
+9|Auriculares personales para su uso con sistemas de transmisión de sonido
+9|Auriculares telefónicos
+9|Autobombas contra incendios
+9|Autocolimadores
+9|Autotemporizadores para cámaras
+9|Autotransformadores
+9|Balanzas de bolsillo
+9|Balanzas de refrigerante
+9|Balanzas digitales portátiles para pesar maletas
+9|Balanzas electrónicas de cocina
+9|Balanzas electrónicas de mano
+9|Balanzas electrónicas digitales portátiles
+9|Balizas para carreteras luminosas o mecánicas
+9|Balsas salvavidas
+9|Barcos-bomba contra incendios
+9|Barras de sonido
+9|Barreras y puertas de previo pago para estacionamientos de coches
+9|Báscula de baño
+9|Básculas
+9|Básculas digitales de cuarto de baño
+9|Básculas para bebés
+9|Básculas parlantes
+9|Bases de datos (electrónicas)
+9|Bases de datos electrónicas
+9|Bases de microscopios quirúrgicos
+9|Baterías
+9|Baterías de almacenamiento eléctrico
+9|Baterías de almacenamiento níquel-cadmio
+9|Baterías de ánodos
+9|Baterías de ion litio
+9|Baterías de litio secundarias
+9|Baterías eléctricas
+9|Baterías eléctricas para vehículos
+9|Baterías eléctricas recargables
+9|Baterías para coches
+9|Baterías para linternas
+9|Baterías para teléfonos móviles
+9|Baterías para uso con ayudas auditivas
+9|Baterías para vehículos
+9|Baterías recargables
+9|Baterías y cargadores de baterías
+9|Binoculares para la caza
+9|Biomicroscopios
+9|Biorreactores de uso en laboratorio
+9|Blancos de lente ópticos
+9|Bloques de bornes eléctricos
+9|Bloques de distribución de energía eléctrica
+9|Bobinas electromagnéticas
+9|Bobinas magnéticas y electromagnéticas
+9|Bocinas, auriculares, micrófonos y lectores de CD
+9|Bolígrafos con punta conductora para dispositivos con pantalla táctil
+9|Bolígrafos para pantallas táctiles
+9|Bolsas para cámaras y equipo fotográfico
+9|Bolsos especiales para ordenadores (computadoras) portátiles
+9|Bombillas de flash
+9|Bombillas de flash para uso en fotografía
+9|Borradores de cintas magnéticas
+9|Boyas de marcación y señalización
+9|Boyas de radio
+9|Boyas salvavidas
+9|Brazaletes de identificación magnéticamente codificados
+9|Brazos de tocadiscos
+9|Brújulas direccionales
+9|Brújulas giroscópicas magnéticas
+9|Brújulas magnéticas
+9|Brújulas magnéticas para agrimensura
+9|Brújulas marinas
+9|Cabezales basculantes para cámaras
+9|Cabezales de impresión para impresoras y trazadores (aparatos de medición)
+9|Cable de telecomunicación
+9|Cables adaptadores eléctricos
+9|Cables adaptadores para auriculares
+9|Cables aéreos de alta tensión
+9|Cables alargadores
+9|Cables conectores eléctricos
+9|Cables de alimentación eléctrica submarinos
+9|Cables de arranque
+9|Cables de arranque de batería
+9|Cables de audio
+9|Cables de batería
+9|Cables de carga eléctrica
+9|Cables de conexión
+9|Cables de corriente
+9|Cables de extensión telefónicos
+9|Cables de fibra óptica
+9|Cables de micrófonos
+9|Cables de relé de radio
+9|Cables de telecomunicaciones
+9|Cables eléctricos
+9|Cables eléctricos de aislamiento mineral
+9|Cables eléctricos para uso en conexiones
+9|Cables eléctricos y ópticos
+9|Cables eléctricos, conductores y partes de los mismos
+9|Cables ópticos
+9|Cables para guitarras
+9|Cables para ordenadores
+9|Cables para sistemas de transmisión de señal eléctrica y óptica
+9|Cables para transmisión de señal eléctrica u óptica
+9|Cables para transmisión de señal óptica
+9|Cables pasa corriente
+9|Cables USB
+9|Cables USB para teléfonos celulares
+9|Cables y alambres eléctricos
+9|Cables y fibras para la transmisión de sonidos e imágenes
+9|Cadenas de agrimensura
+9|Cadenas para gafas
+9|Cadenas para gafas y gafas de sol
+9|Cadenas para quevedos
+9|Cadenas y cordones para gafas
+9|Cadenas y cordones para gafas de sol
+9|Cajas de acumuladores
+9|Cajas de conexión eléctricas
+9|Cajas de distribución de electricidad
+9|Cajas de distribución para energía eléctrica
+9|Cajas de empalme
+9|Cajas de Petri
+9|Cajas de protección para discos magnéticos
+9|Cajas para altavoces
+9|Cajas para diapositivas
+9|Cajas registradoras
+9|Cajas registradoras automáticas
+9|Cajas registradoras, máquinas calculadoras, equipo de procesamiento de datos y computadoras
+9|Cajeros automáticos
+9|Calculadoras de bolsillo
+9|Calculadoras electrónicas
+9|Calculadoras electrónicas de bolsillo
+9|Calculadoras electrónicas de escritorio
+9|Calculadoras y máquinas calculadoras
+9|Calibrador angular
+9|Calibradores de la profundidad de travesaños
+9|Calibradores de la profundidad del dibujo de los neumáticos
+9|Calibradores pasa - no pasa
+9|Calibres anulares
+9|Calibres de herradura
+9|Calibres digitales de torsión
+9|Calibres electrónicos de corredera
+9|Calibres para agujeros
+9|Calibres para medir la longitud
+9|Calibres para medir la proporción aire/combustible
+9|Calorímetros
+9|Cámaras
+9|Cámaras cinematográficas
+9|Cámaras de ángulo ciego para vehículos
+9|Cámaras de caza
+9|Cámaras de monitorización e inspección de equipo en una estación de energía nuclear
+9|Cámaras de oxígeno hiperbárico que no sean para uso médico
+9|Cámaras de película fotográfica
+9|Cámaras de películas de auto-revelado
+9|Cámaras de placa
+9|Cámaras de televisión
+9|Cámaras de video portables con grabadoras de cassettes de video incluidas
+9|Cámaras desechables
+9|Cámaras digitales
+9|Cámaras digitales para uso industrial
+9|Cámaras endoscópicas para uso industrial
+9|Cámaras fotográficas
+9|Cámaras fotográficas de revelado instantáneo
+9|Cámaras infrarrojas
+9|Cámaras para películas de autorrevelado
+9|Cámaras para usos múltiples
+9|Cámaras que contienen un sensor de imagen lineal
+9|Cámaras réflex digitales (DSLR)
+9|Cámaras sin espejo
+9|Cámaras subacuáticas
+9|Cambiadiscos (periféricos informáticos)
+9|Cambiadores automáticos para teléfonos
+9|Cambiadores de monedas
+9|Campanas de flujo laminar para laboratorios
+9|Carcasas para diskettes y discos compactos
+9|Caretas para soldar
+9|Cargadores de baterías
+9|Cargadores de baterías de teléfonos móviles para su uso en vehículos
+9|Cargadores de baterías para ordenadores portátiles
+9|Cargadores de baterías para su uso con teléfonos
+9|Cargadores de pilas solares
+9|Cargadores inalámbricos
+9|Cargadores inalámbricos para teléfonos inteligentes
+9|Cargadores para acumuladores eléctricos
+9|Cargadores para baterías de tabletas
+9|Cargadores para equipamiento recargable
+9|Cargadores por USB
+9|Cargadores USB adaptados para tomas de encendedores de cigarrillos de automóviles
+9|Carretes para cámaras
+9|Carros de bomberos
+9|Cartuchos para juegos de computador
+9|Cartuchos y casetes de videojuegos
+9|Cascos con auriculares para su uso con ordenadores
+9|Cascos de bateador
+9|Cascos de ciclismo
+9|Cascos de equitación
+9|Cascos de fútbol
+9|Cascos de hockey sobre hielo
+9|Cascos de protección
+9|Cascos de seguridad para bicicleta
+9|Cascos de snowboard
+9|Cascos para fútbol americano
+9|Cascos para soldar
+9|Cascos protectores para deportes
+9|Cascos protectores para motociclista
+9|Casquillos móviles
+9|Catalejos
+9|Cátodos
+9|Caudalímetros
+9|Caudalímetros para gas
+9|Celdas y baterías eléctricas
+9|Celostatos
+9|Células de energía solar de silicio cristalino
+9|Células fotoeléctricas
+9|Células fotovoltaicas
+9|Células solares
+9|Células y módulos fotovoltaicos
+9|Centrales telefónicas automáticas
+9|Centralitas automáticas
+9|Centralitas de telecomunicaciones
+9|Cerraduras de seguridad eléctricas
+9|Cerraduras eléctricas para vehículos
+9|Cerraduras electromagnéticas
+9|Chalecos antibalas
+9|Chalecos salvavidas
+9|Chalecos salvavidas para animales de compañía
+9|Chalecos salvavidas para perros
+9|Chips de ADN
+9|Chips de ordenador
+9|Chips electrónicos para la manufactura de circuitos integrados
+9|Chips multiprocesadores
+9|Ciclocomputadoras
+9|Cierres controlados por radiofrecuencia
+9|Cierres de circuito eléctrico
+9|Cintas magnéticas vírgenes para lectoras de cinta
+9|Cintas métricas
+9|Cintas para limpiar cabezales de video grabadoras
+9|Cinturones de pesos para buceo
+9|Cinturones salvavidas
+9|Circuito electrónicos impresos para aparatos y tarjetas con circuitos integrados
+9|Circuitos de interface para cámaras de video
+9|Circuitos electrónicos
+9|Circuitos electrónicos integrados
+9|Circuitos impresos flexibles
+9|Circuitos impresos para ordenadores
+9|Circuitos integrados
+9|Circuitos lógicos
+9|Circuitos para alta tensión
+9|Clavijas de ensayo para comprobar placas de circuitos impresos
+9|Clavijas eléctricas
+9|Clinómetros
+9|Codificadores giratorios
+9|Codificadores magnéticos
+9|Colimadores
+9|Colorímetros
+9|Columnas de cromatografía para uso en laboratorio
+9|Columnas de destilación para uso en laboratorio
+9|Combinadores de antenas
+9|Comparadores
+9|Compases de corredera
+9|Compensadores de amplificador doble
+9|Compresores eléctricos
+9|Comprobadores de emisiones para motores diésel
+9|Comprobadores de graduación (comprobadores de calibración)
+9|Comprobadores de velocímetros
+9|Comprobadores de voltaje
+9|Computadora para gestión de dispositivos de control para aviones
+9|Computadoras
+9|Computadoras de bolsillo para toma de notas
+9|Computadoras de comunicaciones
+9|Computadoras de escritorio
+9|Computadoras electrónicas
+9|Computadoras para uso en la gestión de datos
+9|Computadoras personales
+9|Computadoras portátiles
+9|Computadoras y hardware informático
+9|Computadoras y periféricos informáticos
+9|Computadores miniatura que no utilizan monitor (stick PC)
+9|Computadores notebook
+9|Computadores portátiles
+9|Computadores tablet
+9|Concentradores (hubs) USB
+9|Condensadores cerámicos monolíticos
+9|Condensadores eléctricos
+9|Condensadores eléctricos para aparatos de telecomunicación
+9|Condensadores para microscopios
+9|Conducciones para cables eléctricos
+9|Conductores eléctricos
+9|Conductores LED
+9|Conductos acústicos
+9|Conector de enchufe
+9|Conectores de alimentación (eléctricos)
+9|Conectores de cabezal eléctricos
+9|Conectores de cables
+9|Conectores de enchufes
+9|Conectores de enchufes circulares
+9|Conectores de fibra óptica
+9|Conectores eléctricos
+9|Conectores eléctricos y electrónicos
+9|Conectores para aparatos telecomunicacionales
+9|Conectores para circuitos electrónicos
+9|Conectores telefónicos
+9|Conmutador de energía
+9|Conmutadores automáticos (para las telecomunicaciones)
+9|Conmutadores de ethernet
+9|Conmutadores eléctricos de intermitentes
+9|Conos de seguridad de tránsito
+9|Contactos eléctricos
+9|Contador de horas para motores
+9|Contadores de amperios-hora
+9|Contadores de centelleos
+9|Contadores de resistencia de aislamiento
+9|Contestador automático telefónico
+9|Contestadores telefónicos
+9|Contestadores telefónicos automáticos
+9|Controladores eléctricos
+9|Controladores electrónicos de la velocidad
+9|Controladores lógicos programables
+9|Controles remotos para proyectores
+9|Controles remotos para televisores
+9|Convertidores de corriente
+9|Convertidores de digital a analógico
+9|Convertidores de electricidad
+9|Convertidores de frecuencia
+9|Convertidores de frecuencia electrónicos para electromotores de alta velocidad
+9|Convertidores de frecuencia para accionadores
+9|Convertidores de moneda electrónicos
+9|Convertidores eléctricos
+9|Convertidores giratorios
+9|Convertidores para enchufes eléctricos
+9|Copiadoras digitales a color
+9|Cordones para gafas
+9|Cordones para quevedos
+9|Cordones para teléfonos celulares
+9|Correas para teléfonos celulares
+9|Correas para teléfonos móviles
+9|Crisoles para uso en laboratorio
+9|Cristales ópticos
+9|Cristales para gafas de sol
+9|Cuadros indicadores electrónicos
+9|Cubiertas de teclas para teclados de ordenador
+9|Cucharas dosificadoras
+9|Cupones electrónicos descargables
+9|Decodificador para televisión
+9|Demoduladores
+9|Demultiplexores
+9|Densímetros
+9|Densímetros para anticongelantes
+9|Densitómetros para café
+9|Descodificadores de televisión
+9|Desfasadores ópticos
+9|Detectores de billetes falsos
+9|Detectores de captura de electrones
+9|Detectores de cristal de galena para uso en electrónica
+9|Detectores de dióxido de carbono
+9|Detectores de fallas por ultrasonido
+9|Detectores de gas
+9|Detectores de humo y de incendios
+9|Detectores de metales
+9|Detectores de metales portátiles para controles de seguridad
+9|Detectores de monóxido de carbono
+9|Detectores de movimiento
+9|Detectores de movimiento para luces de seguridad
+9|Detectores de objetos magnéticos
+9|Detectores de radar
+9|Detectores de radiación
+9|Detectores magnéticos de vigas verticales
+9|Detectores pasivos de infrarrojos
+9|Diacs (diodos para corriente alterna)
+9|Diapositivas
+9|Diapositivas fotográficas
+9|Diarios personales electrónicos
+9|Diccionarios electrónicos de mano
+9|Dictáfono
+9|Dinamómetros
+9|Diodos
+9|Diodos de carburo de silicio
+9|Diodos de láser
+9|Diodos eléctricos
+9|Diodos electroluminiscentes orgánicos
+9|Diodos emisores de luz (leds)
+9|Diodos láser superluminiscentes
+9|Diodos luminosos
+9|Discos compactos con música
+9|Discos compactos de memoria de lectura (CD-ROM)
+9|Discos compactos de sólo lectura (CD ROM)
+9|Discos compactos vírgenes
+9|Discos de audio vírgenes
+9|Discos de ordenador vírgenes
+9|Discos duros
+9|Discos duros externos
+9|Discos fonográficos con música
+9|Discos fonográficos de larga duración (LP)
+9|Discos magnéticos vírgenes
+9|Discos ópticos vírgenes
+9|Discos versátiles digitales (DVDs) de ejercicios pregrabados
+9|Discos versátiles digitales (DVDs) que contienen música pre-grabada
+9|Discos vírgenes para grabar
+9|Disipadores de calor para ordenadores
+9|Diskettes (para computadores)
+9|Dispensadores electrónicos de boletos para estacionamientos
+9|Dispositivos de entrada para ordenadores
+9|Dispositivos de fax
+9|Dispositivos de iluminación para la realización de fotografías
+9|Dispositivos de iluminación para microscopios
+9|Dispositivos de laboratorio para detectar secuencias genéticas
+9|Dispositivos de manos libres para teléfonos móviles
+9|Dispositivos de medida del diámetro de cables
+9|Dispositivos de montaje cinematográfico
+9|Dispositivos de navegación por sistema de posicionamiento global
+9|Dispositivos disyuntores termomagnéticos
+9|Dispositivos generadores de imágenes de huellas digitales
+9|Dispositivos ópticos de metrología de frecuencia
+9|Dispositivos para analizar la secuencia de proteínas utilizados como aparatos de laboratorio
+9|Dispositivos para transmisiones de radio inalámbrica
+9|Dispositivos para uso en manos libres de teléfonos móviles
+9|Dispositivos semiconductores
+9|Disyuntores
+9|Duplexores
+9|DVDs pregrabados que contienen música
+9|Electrodos
+9|Electrodos de grafito
+9|Electrodos para investigación en laboratorios
+9|Electroimanes
+9|Electrolizadores
+9|Electrolizadores (células electrolíticas)
+9|Elementos semiconductores de energía
+9|Emisores de señales electrónicas
+9|Emisores de televisión
+9|Empalmadoras para películas
+9|Empalmes eléctricos
+9|Empalmes para transmisión de líneas eléctricas
+9|Enchufes de banana
+9|Enchufes de contacto de seguridad
+9|Enchufes de salida múltiples
+9|Enchufes eléctricos
+9|Enrutadores de red
+9|Enrutadores de redes informáticas
+9|Enrutadores USB inalámbricos
+9|Ensamblajes de cerraduras electrónicas
+9|Equipo de procesamiento de textos
+9|Equipo electrónico para detección de minas
+9|Equipo endoscópico para uso industrial
+9|Equipo periférico informático
+9|Equipos de localización
+9|Equipos de música (estéreos) para coches
+9|Equipos de radio para el control del tráfico aéreo
+9|Equipos lectores de tarjetas
+9|Equipos pararrayos
+9|Escafandras autónomas
+9|Escáner de imágenes
+9|Escáneres 3D
+9|Escáneres biométricos del iris
+9|Escáneres de documentos portátiles
+9|Escáneres de huellas dactilares
+9|Escáneres de mano
+9|Escáneres de rayos X de cuerpo completo para fines de seguridad
+9|Escáneres digitales de entrada y salida
+9|Escáneres gráficos digitales
+9|Escáneres ópticos
+9|Escáneres para códigos de barra
+9|Escáneres para control automático de superficies
+9|Escáneres tridimensionales portátiles
+9|Escudos de protección de la cara
+9|Escudos de protección personal antibalas en la forma de mochilas
+9|Escudos protectores para policías
+9|Esferómetros
+9|Espectrógrafos
+9|Espectrógrafos astronómicos
+9|Espejos de inspección
+9|Estabilizadores de frecuencia
+9|Estabilizadores de tensión
+9|Estantes de secado (fotografía)
+9|Estereoscopios
+9|Estiletes capacitivos para su uso con dispositivos de pantalla táctil
+9|Estroboscopios
+9|Estuches adaptados para instrumentos de disección no para uso médico
+9|Estuches de baterías
+9|Estuches de gafas
+9|Estuches de teclado para teléfonos inteligentes
+9|Estuches de transporte de computadores notebook
+9|Estuches de transporte y contenedores para lentes de contacto
+9|Estuches especialmente adaptados para artículos de óptica
+9|Estuches especialmente adaptados para cámaras a prueba de agua
+9|Estuches impermeables para cámaras de vídeo
+9|Estuches para aparatos fotográficos
+9|Estuches para calculadoras de bolsillo
+9|Estuches para cámaras
+9|Estuches para gafas
+9|Estuches para gafas (anteojos)
+9|Estuches para gafas para niños
+9|Estuches para gafas y gafas de sol
+9|Estuches para gafas, quevedos y lentes de contacto
+9|Estuches para lentes de contacto
+9|Estuches para llevar lentes de contacto
+9|Estuches para ordenadores tipo tablilla
+9|Estuches para teléfonos
+9|Estuches para teléfonos móviles
+9|Etiquetas con información grabada o codificada de forma magnética, óptica o electrónica
+9|Etiquetas de identificación por radiofrecuencia (RFID)
+9|Etiquetas electrónicas para mercancías
+9|Etiquetas indicadoras de la temperatura que no sean para uso médico
+9|Extintores
+9|Extintores de fuego
+9|Fibras ópticas
+9|Fibras ópticas no lineales
+9|Fibroscopios, que no sean para uso médico
+9|Filamentos conductores de luz
+9|Filtros antiparasitarios para radio
+9|Filtros antirreflejo para televisores
+9|Filtros fotográficos
+9|Filtros fotográficos para cámaras
+9|Filtros ópticos para pantallas
+9|Filtros para dispositivos ópticos
+9|Filtros para laboratorios
+9|Flashes para cámaras
+9|Fonocaptores electrónicos para guitarras y bajos
+9|Fonocaptores para aparatos de telecomunicación
+9|Fonógrafos eléctricos
+9|Fotodiodos
+9|Fotómetros
+9|Fotorresistencias
+9|Frascos de laboratorio
+9|Frecuencímetros
+9|Fuentes de alimentación de conmutación de alta frecuencia
+9|Fuentes de alimentación para estabilizar el voltaje
+9|Fundas especialmente adaptadas para reproductores multimedia portátiles
+9|Fundas impermeables para teléfonos inteligentes
+9|Fundas para agendas electrónicas
+9|Fundas para cables eléctricos
+9|Fundas para ordenadores (computadoras) portátiles
+9|Fundas para teclados de ordenador
+9|Fundas para teléfonos inteligentes
+9|Fundas para teléfonos móviles
+9|Fundas y estuches especialmente adaptados para transportar teléfonos portátiles y equipamiento telefónico
+9|Fusibles eléctricos
+9|Fusibles para aparatos de telecomunicación
+9|Fusibles para corriente eléctrica
+9|Gafas
+9|Gafas (anteojos o antiparras)
+9|Gafas (anteojos) de deporte
+9|Gafas (óptica)
+9|Gafas antideslumbrantes
+9|Gafas correctoras para daltónicos
+9|Gafas de buceo
+9|Gafas de deporte
+9|Gafas de esquí
+9|Gafas de natación
+9|Gafas de niños
+9|Gafas de protección
+9|Gafas de realidad virtual
+9|Gafas de seguridad anti vaho
+9|Gafas de sol
+9|Gafas de sol para mascotas
+9|Gafas de sol y gafas
+9|Gafas de soldadura
+9|Gafas para glaciares
+9|Gafas para leer
+9|Gafas polarizadas
+9|Gafas y gafas de sol
+9|Gafas y máscaras de protección contra el polvo
+9|Galgas de deformación
+9|Galgas de espesores
+9|Galgas de separación para bujías
+9|Gasómetros (instrumentos de medición)
+9|Gemelos (óptica)
+9|Gemelos de opera
+9|Gemelos de teatro
+9|Generadores de reloj para ordenadores
+9|Girocompases
+9|Girómetros
+9|Giróscopos
+9|Globos meteorológicos
+9|Grabaciones de audio y video descargables
+9|Grabaciones de sonido musical descargables
+9|Grabaciones de vídeos musicales descargables
+9|Grabaciones descargables de video y audio con música e interpretaciones artísticas
+9|Grabaciones musicales descargables
+9|Grabadoras de audio cintas
+9|Grabadoras de casetes
+9|Grabadoras de CD-ROM
+9|Grabadoras de cinta magnética
+9|Grabadoras de discos compactos
+9|Grabadoras de DVD
+9|Grabadoras de teléfonos
+9|Grabadoras de televisión y video
+9|Grabadoras de vídeo
+9|Grabadoras de video casete
+9|Grabadoras de videocinta
+9|Grabadoras personales de video (PVRs)
+9|Grabadoras y lectores de cinta magnética
+9|Grabadores de vídeo digitales
+9|Grabadores de voz digitales
+9|Gráficos computacionales descargables
+9|Gráficos descargables para teléfonos móviles
+9|Gramiles de ebanista
+9|Gramófonos
+9|Gravímetros
+9|Guantes de protección contra accidentes
+9|Guantes resistentes al fuego
+9|Hardware de almacenamiento conectado en red (NAS)
+9|Hardware informático para telecomunicaciones
+9|Hardware informático y dispositivos periféricos
+9|Hardware informático y dispositivos periféricos informáticos
+9|Hardware informático y periféricos
+9|Hardware informático y periféricos informáticos
+9|Hardware informático y sus dispositivos periféricos
+9|Hardware para ordenadores
+9|Hardware para puesta en red de ordenadores
+9|Higrómetros
+9|Hilos de aleaciones metálicas (fusibles)
+9|Hilos de bobinado (electricidad)
+9|Hilos telefónicos
+9|Hilos telefónicos magnéticos
+9|Hilos telegráficos
+9|Hisopos de laboratorio (instrumentos de laboratorio)
+9|Hornos de laboratorio
+9|Hubs (concentradores) de redes informáticas
+9|Imanes decorativos
+9|Imanes decorativos para refrigeradores
+9|Imanes para uso industrial
+9|Impresora de computadora
+9|Impresoras a color
+9|Impresoras de documentos para computadoras
+9|Impresoras de inyección de tinta
+9|Impresoras de inyección de tinta a color
+9|Impresoras de vídeo
+9|Impresoras digitales a color
+9|Impresoras fotográficas
+9|Impresoras láser [de ordenador]
+9|Impresoras térmicas
+9|Incubadoras para cultivos bacterianos
+9|Indicadores automáticos de baja presión en neumáticos
+9|Indicadores de altitud automáticos
+9|Indicadores de fase
+9|Indicadores de nivel
+9|Indicadores de nivel (niveles de burbuja)
+9|Indicadores de pendiente
+9|Indicadores de presión de gas
+9|Indicadores de presión de neumáticos
+9|Indicadores de sobrealimentación
+9|Indicadores de temperatura
+9|Indicadores de temperatura de agua
+9|Indicadores de temperatura de los gases de escape
+9|Indicadores de velocidad
+9|Indicadores del nivel de agua
+9|Indicadores luminosos de salida
+9|Indicadores luminosos para aparatos de telecomunicación
+9|Inducidos para uso en Aparatos eléctricos
+9|Instalaciones eléctricas para el control remoto de operaciones industriales
+9|Instalaciones eléctricas y electrónicas para vigilancia por vídeo
+9|Instrucciones de uso y funcionamiento almacenadas en formato digital para ordenadores y software informático, en particular en disquetes o discos compactos
+9|Instrumentos de agrimensura
+9|Instrumentos de análisis para fotogrametría
+9|Instrumentos de control de calderas
+9|Instrumentos de detección de radiación
+9|Instrumentos de disección para fines científicos o de investigación
+9|Instrumentos de medición de resistencia
+9|Instrumentos de medida de nivel y nivel de llenado
+9|Instrumentos de medida del flujo
+9|Instrumentos de navegación eléctricos
+9|Instrumentos meteorológicos
+9|Instrumentos para la medición de parámetros de calidad de la leche
+9|Instrumentos para medir longitudes
+9|Intensificadores de imagen
+9|Intercomunicadores
+9|Intercomunicadores de emergencia portátiles
+9|Interfaces (informática)
+9|Interfaces para detectores
+9|Interfaces y dispositivos periféricos informáticos
+9|Interferómetros
+9|Interruptores
+9|Interruptores de alta frecuencia
+9|Interruptores de cambio para aparatos telefónicos
+9|Interruptores de corriente eléctrica
+9|Interruptores de luz
+9|Interruptores de mercurio
+9|Interruptores de redes computacionales
+9|Interruptores diferenciales
+9|Interruptores eléctricos
+9|Interruptores locales
+9|Interruptores para lámparas fluorescentes
+9|Interruptores piezoeléctricos
+9|Interruptores temporizados
+9|Inversores
+9|Inversores fotovoltaicos
+9|Inversores para fuentes de alimentación
+9|Jarras de medir
+9|Jirafas para micrófonos
+9|Láminas semiconductoras
+9|Lámparas de señalización de avería para vehículos
+9|Lanzas para mangas de incendio
+9|Lapiceras ópticas-magnéticas
+9|Lápices comprobadores de voltaje eléctrico
+9|Lápices ópticos
+9|Láseres para tomar medidas
+9|Láseres que no sean para uso médico
+9|LCDs (pantallas de cristal líquido)
+9|Lector de disco versátil digital
+9|Lectores biométricos
+9|Lectores biométricos de retina
+9|Lectores de audio casetes
+9|Lectores de audio casetes y discos compactos
+9|Lectores de audio y video casete
+9|Lectores de bandas magnéticas
+9|Lectores de casetes
+9|Lectores de casetes para coches
+9|Lectores de CD
+9|Lectores de cintas y videocintas
+9|Lectores de códigos de barras
+9|Lectores de códigos ópticos
+9|Lectores de discos compactos
+9|Lectores de discos ópticos
+9|Lectores de DVD
+9|Lectores de identificación por radiofrecuencia (RFID)
+9|Lectores de libros digitales
+9|Lectores de microfilmes
+9|Lectores de microplacas
+9|Lectores de tarjeta de memoria
+9|Lectores de tarjetas con chip
+9|Lectores de tarjetas de crédito
+9|Lectores de tarjetas de memoria flash
+9|Lectores de tarjetas electrónicas
+9|Lectores de tarjetas inteligentes
+9|Lectores de tarjetas magnéticas codificadas
+9|Lectores de videodiscos
+9|Lectores MP3
+9|Lectores ópticos
+9|Lectores para discos compactos digitales
+9|Lectores y grabadoras de audio y video digital
+9|Lectores y grabadoras de video combinados
+9|Lente circular
+9|Lentes antirreflectantes
+9|Lentes con clips magnéticos para gafas de sol
+9|Lentes correctoras
+9|Lentes de cámara de teléfonos inteligentes
+9|Lentes de contacto
+9|Lentes ojo de pez para cámaras
+9|Lentes para caretas de protección facial
+9|Lentes para gafas
+9|Lentes para gafas (anteojos)
+9|Lentes semiterminadas para gafas
+9|Libretas digitales
+9|Libros electrónicos descargables en el ámbito de la enseñanza del golf
+9|Limitadores de potencia
+9|Limpiadores de cinta magnética
+9|Luces de seguridad parpadeantes
+9|Luces de señalización de emergencia
+9|Luces giratorias (señalización)
+9|Luminómetros
+9|Lupas
+9|Lupas de joyeros
+9|Lupas de relojeros
+9|Magnetómetros
+9|Magnetos de borrar
+9|Magnetos de refrigerador
+9|Mangas catavientos (indicadores de dirección del viento)
+9|Mangas catavientos (indicadores del viento)
+9|Mangueras de fuego
+9|Manguitos de unión para cables eléctricos
+9|Manguitos de unión para fibra óptica
+9|Maniquíes para pruebas de colisión
+9|Manómetros
+9|Manómetros de alta presión
+9|Mantas extintoras de fuego
+9|Mantas ignífugas
+9|Mantas ignífugas y extintores de fuego
+9|Mapas de carreteras descargables
+9|Máquinas calculadoras y equipo de procesamiento de datos
+9|Máquinas calculadoras, equipos de procesamiento de datos y computadoras
+9|Máquinas codificadoras para tarjetas de crédito (periféricos informáticos)
+9|Máquinas copiadoras electroestáticas
+9|Máquinas de calcular
+9|Máquinas de contabilidad
+9|Máquinas de cribado de seguridad por rayos X
+9|Máquinas de dictar
+9|Máquinas de edición de películas
+9|Máquinas de ensayo de compresión para metales
+9|Máquinas de fax móviles o portátiles
+9|Máquinas de fotocopiado
+9|Máquinas de grabación y reproducción de imágenes y sonido
+9|Máquinas de medida de nivel para agrimensura
+9|Máquinas de navegación de larga distancia (LORAN)
+9|Máquinas de pesaje
+9|Máquinas de procesamiento de textos
+9|Máquinas de sumar
+9|Máquinas de transmisión de fax
+9|Máquinas de votación
+9|Máquinas e instrumentos automáticos de control de fluidos
+9|Máquinas e instrumentos automáticos de control de flujo de líquidos
+9|Máquinas e instrumentos automáticos de control de nivel de líquidos
+9|Máquinas e instrumentos automáticos de control de presión
+9|Máquinas e instrumentos de control de combustión automáticos.
+9|Máquinas e instrumentos de medición astrométrica
+9|Máquinas e instrumentos de medición de roscas de tornillo
+9|Máquinas electrónicas de comprobación de tickets
+9|Máquinas electrónicas para lectura de tarjetas de crédito y grabación de operaciones financieras
+9|Máquinas fotocopiadoras
+9|Máquinas para contar y clasificar dinero
+9|Máquinas parlantes
+9|Máquinas y aparatos cinematográficos
+9|Máquinas y aparatos de comunicaciones de un canal para estaciones fijas
+9|Máquinas y aparatos de radar
+9|Máquinas y aparatos de radio comunicación marítima
+9|Máquinas y aparatos de radiocomunicación para la aeronáutica
+9|Máquinas y aparatos de radiofaros
+9|Marcadores automáticos de teléfono
+9|Marcos monoculares
+9|Marcos para fotos digitales
+9|Máscaras antipolvo
+9|Máscaras de buceo
+9|Máscaras de gas
+9|Máscaras de protección
+9|Mascarillas de buzo
+9|Material volumétrico graduado de vidrio
+9|Mecanismos de previo pago para televisores
+9|Mecanismos para aparatos accionados con monedas
+9|Medidores acústicos
+9|Medidores de acidez
+9|Medidores de agua
+9|Medidores de bebidas espirituosas
+9|Medidores de concentración
+9|Medidores de electricidad
+9|Medidores de exposición para aparatos fotográficos
+9|Medidores de flujos luminosos
+9|Medidores de grosor ultrasónicos
+9|Medidores de juntas
+9|Medidores de presión del viento
+9|Medidores de presión para neumáticos
+9|Medidores de refrigerante
+9|Medidores de vibración
+9|Medidores de vibración electrotécnicos
+9|Medidores del nivel de sonido
+9|Medidores del ruido
+9|Megáfonos
+9|Memorias de disco
+9|Memorias electrónicas
+9|Memorias para equipo de procesamiento de datos
+9|Memorias para uso en computadoras
+9|Memorias semiconductoras
+9|Memorias USB en blanco
+9|Mensáfono
+9|Mesas de mezcla para video
+9|Metrónomos
+9|Metrónomos electrónicos
+9|Mezcladoras de sonido
+9|Mezcladoras de sonido con amplificadores integrados
+9|Mezcladores de gases para laboratorio
+9|Microchips
+9|Microchips (hardware)
+9|Microcomprobadores de dureza
+9|Microcomputadora
+9|Microcomputadoras
+9|Microcontroladores
+9|Microfilmes sensibilizados, expuestos
+9|Micrófonos
+9|Micrófonos binaurales
+9|Micrófonos para aparatos de telecomunicación
+9|Micrófonos para dispositivos de comunicación
+9|Micromatrices de ADN
+9|Microprocesadores
+9|Microprocesadores y semiconductores
+9|Microscopios
+9|Microscopios biológicos
+9|Microscopios con LEDs
+9|Microscopios de electrones
+9|Microscopios de fluorescencia
+9|Microscopios de sonda de barrido
+9|Microscopios electrónico de barrido
+9|Microscopios electrónicos de transmisión
+9|Microscopios incluidos los estereoscópicos
+9|Microscopios metalúrgicos
+9|Microscopios polarizantes
+9|Microscopios y sus partes
+9|Microtomos
+9|Miniproyectores
+9|Miras de arco telescópicas
+9|Miras telescópicas
+9|Miras telescópicas para armas de fuego
+9|Mirillas ópticas para puertas
+9|Módems
+9|Módems de comunicación
+9|Módems externos
+9|Módems internos
+9|Módulo de circuito integrado
+9|Módulos de circuito integrado
+9|Módulos de expansión de memoria
+9|Módulos de memoria
+9|Módulos de monitoreo de tensión
+9|Módulos de rectificador
+9|Monitores de bebés
+9|Monitores de oxígeno atmosférico
+9|Monitores de televisión
+9|Monitores de video
+9|Monitores electrónicos de dióxido de carbono (que no sean para uso médico)
+9|Monitores LCD
+9|Monitores LED
+9|Monitores para la señalización digital
+9|Monóculos
+9|Montaduras de gafas
+9|Montaduras de gafas y gafas de sol
+9|Montaduras de gafas y quevedos
+9|Monturas de gafas
+9|Monturas de gafas (anteojos)
+9|Monturas de gafas metálicas y de material sintético
+9|Monturas de quevedos
+9|Monturas para diapositivas
+9|Monturas para gafas hechas de metal o combinación de metal y plástico
+9|Monturas para objetivos de cámaras
+9|Multiplexor de video
+9|Multiplexores
+9|Multiplexores de telecomunicaciones
+9|Multiplicadores
+9|Música digital descargable de la Internet
+9|Niveles de burbuja
+9|Núcleos magnéticos
+9|Objetivos de astrofotografía
+9|Objetivos de microscopios
+9|Obleas para circuitos integrados
+9|Obleas semiconductoras estructuradas
+9|Obleas solares
+9|Obturadores (para camaras)
+9|Obturadores de cámara
+9|Obturadores de lentes
+9|Obturadores ópticos
+9|Obturadores para cámaras
+9|Odómetros
+9|Ondámetros
+9|Opacímetro
+9|Ordenadores cuánticos
+9|Ordenadores de bolsillo
+9|Ordenadores de navegación para coches
+9|Ordenadores para buceo subacuático
+9|Organizadores personales electrónicos
+9|Osciladores
+9|Oscilógrafos
+9|Oscilógrafos (osciloscopios)
+9|Osciloscopios
+9|Ovoscopios
+9|Ozonizadores
+9|Pabellones (conos) de altavoces
+9|Palancas de mando (joysticks) para ordenadores
+9|Palmers
+9|Paneles de alarma
+9|Paneles de circuitos que contienen circuitos integrados
+9|Paneles de control eléctricos
+9|Paneles de LCD
+9|Paneles digitales electrónicos
+9|Paneles táctiles
+9|Pantalla de cristal líquido de transistores de película fina (TFT-LCD)
+9|Pantalla electroforética
+9|Pantallas de computadora
+9|Pantallas de ordenador
+9|Pantallas de protección de asbesto para bomberos
+9|Pantallas de protección facial para cascos de protección
+9|Pantallas de proyección para películas cinematográficas
+9|Pantallas de radar
+9|Pantallas fluorescentes
+9|Pantallas grandes de LCD
+9|Pantallas para teléfonos inteligentes
+9|Pantallas táctiles
+9|Pararrayos
+9|Parasoles para cámaras
+9|Parasoles para objetivos de cámaras
+9|Partes metálicas de protección para zapatos y botas
+9|Patas de reemplazo para mouse de computador
+9|Patillas de gafas
+9|Película cinematográfica impresionada
+9|Películas cinematográficas expuestas
+9|Películas de cámara expuestas
+9|Películas de diapositivas impresionadas
+9|Periféricos informáticos
+9|Periféricos informáticos inalámbricos
+9|Periscopios
+9|Pértigas (jirafas) de brazo móvil para aparatos de transmisión de sonido
+9|Pesas de prueba (medición)
+9|Pesas para balanzas
+9|Pies para aparatos fotográficos
+9|Piezas para protección de los ojos
+9|Pilas de combustible
+9|Pilas galvánicas
+9|Pilas húmedas
+9|Pilas secas
+9|Pilas secas y baterías
+9|Pilas solares
+9|Pinzas nasales para natación
+9|Pizarras interactivas para ordenador
+9|Placa de circuitos electrónicos
+9|Placas de circuitos
+9|Placas de circuitos de vídeo
+9|Placas de memoria
+9|Placas de Petri para uso en investigaciones de laboratorio
+9|Placas madre
+9|Placas para acumuladores eléctricos
+9|Planetarios
+9|Planímetros
+9|Plantillas de diseño gráfico descargables
+9|Platos giratorios para tocadiscos
+9|Pletinas de grabación
+9|Plumas electrónicas
+9|Plumas magnéticas
+9|Portagafas
+9|Portapipetas para laboratorios
+9|Prendas aislantes para protección contra accidentes o lesiones
+9|Prismas para microscopios
+9|Prismas para telescopios
+9|Prismas para uso en óptica
+9|Prismáticos
+9|Probadores de circuitos
+9|Probadores de tubos al vacío
+9|Procesadores de datos y textos
+9|Procesadores de efectos para guitarras
+9|Procesadores de imágenes de trama
+9|Procesadores de señal digital
+9|Procesadores de señales de voces digitales
+9|Procesadores de vídeo
+9|Procesadores digitales de sonido
+9|Programas computacionales legibles por maquina para uso en la reproducción musical
+9|Programas computacionales para búsqueda remota de contenido en computadores y redes de computadores
+9|Programas computacionales para juegos de video y computador
+9|Programas computacionales para uso con internet y world wide web
+9|Programas computacionales para uso en diseño de interfaces
+9|Programas de computación grabados en medios de datos (software) diseñados para su uso en construcción y manufacturaautomática
+9|Programas de computación para habilitar el acceso o control de entrada
+9|Programas de computación para juegos pre-grabados
+9|Programas de computación para la búsqueda de contenidos en redes de computadores por control remoto
+9|Programas de computación utilizados para sistemas de cajas registradoras electrónicas
+9|Programas de computadora para conexión remota a computadoras o a redes informáticas
+9|Programas de computadora para la edición de imágenes, sonido y video
+9|Programas de grabación de circuitos electrónicos para aparatos de entretenimiento para uso con pantallas de cristal liquido
+9|Programas de juegos de ordenador descargables
+9|Programas de juegos de ordenador grabados
+9|Programas de juegos informáticos
+9|Programas de juegos informáticos descargables desde la Internet
+9|Programas de juegos informáticos descargables desde una red informática mundial
+9|Programas de juegos informáticos multimedia interactivos
+9|Programas de juegos informáticos para uso en teléfonos móviles
+9|Programas de juegos informáticos y videojuegos
+9|Programas de ordenador para la gestión de redes
+9|Programas de sistema operativo
+9|Programas de software para la gestión de hojas de cálculo
+9|Programas de videojuegos descargables
+9|Programas informáticos para cifrado
+9|Programas informáticos para el reconocimiento óptico de caracteres
+9|Programas informáticos para gestión de documentos
+9|Programas informáticos para la producción de modelos financieros
+9|Programas informáticos para su uso en el control de acceso a ordenadores
+9|Protecciones laterales para anteojos
+9|Protectores bucales de uso atlético
+9|Protectores bucales para el boxeo
+9|Protectores de sobrevoltaje
+9|Proyectores cinematográficos
+9|Proyectores de diapositivas
+9|Proyectores de enfoque automáticos
+9|Proyectores de imagen
+9|Proyectores de películas
+9|Proyectores de perfiles
+9|Proyectores de sonido y amplificadores
+9|Proyectores de video
+9|Proyectores digitales
+9|Proyectores en particular proyectores para la industria del entretenimiento
+9|Proyectores LCD
+9|Proyectores multimedia
+9|Proyectores para la edición de películas
+9|Proyectores planetarios
+9|Puertos paralelos de ordenador
+9|Punteros láser
+9|Punteros luminosos
+9|Quevedos
+9|Radar para patrullaje marítimo
+9|Radares
+9|Radio receptores
+9|Radio receptores y monitores para reproducción de sonido y señales
+9|Radio receptores y sintonizadores de señales de radio
+9|Radio transceptores
+9|Radio transmisores
+9|Radio transmisores y receptores para mandos a distancia y controles de radio
+9|Radiogoniómetros
+9|Radiografías que no sean para uso médico
+9|Radios bidireccionales
+9|Radios de corto alcance
+9|Radios inalámbricos de banda ancha
+9|Radios portátiles
+9|Ratones de bola
+9|Ratones de bola (dispositivos de entrada)
+9|Ratones de computadora
+9|Ratones de computadora inalámbricos
+9|Reactores de alta tensión
+9|Reactores fotoquímicos de laboratorio
+9|Reactores químicos de laboratorio
+9|Recargadores para acumuladores eléctricos
+9|Receptores audiovisuales
+9|Receptores de audio y video
+9|Receptores de radiofrecuencia
+9|Receptores de televisión (televisores)
+9|Receptores de televisión por cable
+9|Receptores de video
+9|Receptores para GPS
+9|Receptores para recepción de televisión por cable
+9|Receptores para satélites
+9|Receptores satelitales
+9|Recipientes de vidrio graduados
+9|Recipientes de vidrio para experimentos científicos en laboratorios
+9|Rectificadores de corriente
+9|Redes de protección contra accidentes
+9|Redes de seguridad
+9|Reflectores ópticos
+9|Reflectores para microscopios
+9|Reflectores para señales de tráfico
+9|Reflectores para telescopios
+9|Refractómetros
+9|Registradores de presión
+9|Reglas de cálculo
+9|Reglas de carpintero (reglas de corredera)
+9|Reglas graduadas
+9|Reglas para medir
+9|Reglas plegables de carpintero
+9|Reguladores de iluminación
+9|Reguladores de intensidad de luz
+9|Reguladores de tensión
+9|Reguladores de tensión (voltaje) para vehículos
+9|Reguladores de tensión para líneas eléctricas
+9|Reguladores de voltaje de inducción
+9|Rejillas para acumuladores eléctricos
+9|Relés coaxiales
+9|Relés de enclavamiento accionados por impulsos
+9|Relés de protección de sobretensión
+9|Relés de sobrecarga
+9|Relojes de arena
+9|Relojes de fichar
+9|Relojes de fichar informatizados con función de reconocimiento dactilar
+9|Repetidor eléctrico
+9|Repetidor eléctricos y transformadores
+9|Repetidoras para estaciones de radio y televisión
+9|Reposamuñecas para utilizar con computadoras
+9|Reproductores de discos compactos para su uso con ordenadores
+9|Reproductores mp4
+9|Reproductores multimedia portátiles
+9|Resistencias eléctricas
+9|Resistencias eléctricas (para aparatos de telecomunicaciones)
+9|Resonadores
+9|Rociadores automáticos contra incendios
+9|Ropa de protección contra accidentes
+9|Ropa de protección contra el fuego
+9|Ropa de vestir para protección contra químicos y la radiación
+9|Ropa y vestimenta para protección contra el fuego
+9|Satélites
+9|Satélites transmisores-receptores
+9|Secadores de vidrio para uso en laboratorio
+9|Semáforos (dispositivos de señalización)
+9|Semiconductores
+9|Semiconductores electrónicos
+9|Semiconductores ópticos
+9|Señales ferroviarias
+9|Sensores automáticos de seguimiento solar
+9|Sensores de aceleración
+9|Sensores de alarma
+9|Sensores de contaminantes
+9|Sensores de nivel de aceite
+9|Sensores de nivel de líquidos
+9|Sensores de pantalla táctil
+9|Sensores de posición ópticos
+9|Sensores de posición por LED
+9|Sensores de presión
+9|Sensores de proximidad
+9|Sensores de sincronización
+9|Sensores de temperatura
+9|Sensores de temperatura de refrigerantes
+9|Sensores de vibración
+9|Sensores de vibración para instalación en las carcasas de los molinos de viento
+9|Sensores eléctricos
+9|Sensores electrónicos para medir la radiación solar
+9|Sensores fotoeléctricos
+9|Sensores ópticos
+9|Sensores para determinar la posición, velocidad, aceleración y temperatura
+9|Sensores para la determinación de temperaturas, posiciones y distancias
+9|Sensores ultrasónicos
+9|Separadores magnéticos para uso científico
+9|Series de libros infantiles descargables
+9|Servidor de red
+9|Servidores de Internet
+9|Servidores de Intranet
+9|Servidores de redes informáticas
+9|Servidores informáticos
+9|Servidores para alojamiento de sitios web
+9|Sextantes
+9|Simuladores de conducción de vehículos para la enseñanza
+9|Simuladores de vuelo
+9|Simuladores de vuelo para aviones
+9|Simuladores electrónicos de entrenamiento deportivo
+9|Simuladores para manejar o controlar vehículos
+9|Sintetizadores de frecuencia
+9|Sintonizadores de modulación de amplitud
+9|Sintonizadores estéreo
+9|Sismógrafos
+9|Sistemas de control electrónicos para máquinas
+9|Sistemas de medición por láser
+9|Sistemas de megafonía
+9|Sistemas de navegación asistido por ordenador
+9|Sistemas de sonar y sus partes
+9|Software compilador
+9|Software computacional para uso en el procesamiento de obleas semiconductoras
+9|Software con una finalidad de dosimetría en el campo de la radioterapia
+9|Software de bot conversacional para simular conversaciones
+9|Software de compresión de datos
+9|Software de computación para realzar las capacidades audio visuales de aplicaciones multimedia, específicamente para la integración de texto, audio, gráficos, imágenes sin movimiento y con movimiento
+9|Software de control y mejora de la calidad sonora de equipos de audio
+9|Software de conversión de datos
+9|Software de conversión de imágenes de documentos a formato electrónico.
+9|Software de gestión de bases de datos
+9|Software de juegos de computador descargable a través de redes de computación global y dispositivos inalámbricos
+9|Software de juegos de computadora
+9|Software de juegos de realidad virtual
+9|Software de seguridad de correo electrónico
+9|Software de sistemas operativos informáticos
+9|Software descargable de juegos informáticos
+9|Software informático descargable para su uso como monedero electrónico
+9|Software informático para conservación y operación de sistemas informáticos
+9|Software informático para controlar la operación de dispositivos de audio y video
+9|Software informático para controlar y gestionar aplicaciones de servidor de acceso
+9|Software informático para crear y editar música y sonidos
+9|Software informático para el control de terminales de autoservicio
+9|Software informático para el procesamiento de archivos de música digital
+9|Software informático para el procesamiento de imágenes digitales
+9|Software informático para entrega inalámbrica de contenidos
+9|Software informático para organizar y visualizar imágenes digitales y fotografías
+9|Software informático para permitir la transmisión de fotografías a teléfonos móviles
+9|Software informático para programación de máquinas de fax
+9|Software informático para uso en relación a animación digital y efectos especiales de imágenes
+9|Software informático salvapantallas
+9|Software para el manejo operacional de tarjetas portátiles electrónicas y magnéticas
+9|Software para juegos de computador (programas grabados)
+9|Software para la autorización de acceso a bases de datos
+9|Software para la composición de música
+9|Software para procesamiento de imágenes, gráficos y texto
+9|Software para sistemas de evaluación de créditos
+9|Sonares de espera inalámbricos (timbres)
+9|Sondas de avalancha con sensores para medir la profundidad de la nieve
+9|Sondas para comprobar semiconductores
+9|Soportes de bobinas eléctricas
+9|Soportes de montaje para monitores de ordenador
+9|Soportes de montaje para ordenadores
+9|Soportes para datos magnéticos vírgenes
+9|Soportes telefónicos para automóviles
+9|Supresores de picos de tensión
+9|Supresores de sobrecargas
+9|Tableros de anuncios electrónicos
+9|Tableros de conexión
+9|Tableros de enchufe
+9|Tabletas gráficas
+9|Tablones de anuncios electrónicos
+9|Tacómetros
+9|Tanques de aire para el buceo
+9|Tapas para cámaras
+9|Tapones auditivos para buceo
+9|Tarjeta de memoria flash
+9|Tarjetas codificadas con funciones de seguridad destinadas a la identificación
+9|Tarjetas con chip
+9|Tarjetas con circuitos integrados
+9|Tarjetas con microchip
+9|Tarjetas de acceso electrónicas
+9|Tarjetas de ampliación de memoria
+9|Tarjetas de circuitos electrónicos
+9|Tarjetas de circuitos impresos
+9|Tarjetas de computador LAN (local área network) para conectar aparatos computacionales portátiles a redes computacionales
+9|Tarjetas de crédito magnéticamente codificadas
+9|Tarjetas de débito magnéticamente codificadas
+9|Tarjetas de identidad codificadas
+9|Tarjetas de identificación electrónicas y magnéticas para uso en conexión con servicios de pago
+9|Tarjetas de interfaz para equipos de tratamiento de datos en forma de circuitos impresos
+9|Tarjetas de memoria
+9|Tarjetas de memoria SD
+9|Tarjetas electrónicas para procesamiento de imágenes
+9|Tarjetas inteligentes SIM [módulo de identificación de abonado]
+9|Tarjetas magnéticas de identificación
+9|Tarjetas vírgenes de circuitos integrados
+9|Tarjetas y microprocesadores para computadoras
+9|Tazas medidoras de polietileno
+9|Teclados
+9|Teclados multifuncionales
+9|Teclados para teléfonos inteligentes
+9|Teclados para teléfonos móviles
+9|Teleapuntadores
+9|Telecámaras
+9|Teléfonos
+9|Teléfonos celulares
+9|Teléfonos con sistemas de intercomunicación
+9|Teléfonos de Internet
+9|Teléfonos de línea fija
+9|Teléfonos de voz sobre protocolo de Internet (VOIP)
+9|Teléfonos digitales
+9|Teléfonos inalámbricos
+9|Teléfonos inteligentes con pantalla expandible
+9|Teléfonos inteligentes que pueden llevarse puestos
+9|Teléfonos móviles
+9|Teléfonos móviles en braille
+9|Teléfonos para conferencias
+9|Teléfonos públicos
+9|Teleimpresores
+9|Telémetros
+9|Telémetros de cámara
+9|Telémetros de golf
+9|Telescopios
+9|Telescopios (para vigilancia)
+9|Telescopios cenitales
+9|Telescopios de circulo meridiano
+9|Telescopios ecuatoriales
+9|Telescopios reflectores
+9|Televisiones para coche
+9|Televisores
+9|Televisores de panel de plasma (PDP)
+9|Televisores de pantallas de cristal líquido (LCD)
+9|Televisores de plasma
+9|Televisores y monitores
+9|Temporizadores de cocina, no eléctricos
+9|Temporizadores electrónicos de cocina
+9|Teodolitos de precisión
+9|Terminadores eléctricos
+9|Terminal telefónica
+9|Terminales de batería
+9|Terminales de pago electrónico
+9|Terminales de punto de venta
+9|Terminales electrónicos para el cobro de peajes
+9|Terminales informáticas, teclados e impresoras
+9|Terminales informáticos con una finalidad bancaria
+9|Terminales para radioteléfonos
+9|Terminales telefónicas
+9|Terminales transacciones electrónicas segura
+9|Termistores
+9|Termómetros
+9|Termómetros infrarrojos
+9|Timbres de aviso electrónicos
+9|Tiras de cómic descargables
+9|Tiras termosensibles indicadoras de temperatura
+9|Tiristores
+9|Tocadiscos
+9|Tomas de corriente eléctricas
+9|Tonos de llamada descargables para teléfonos móviles
+9|Tornamesas
+9|Traductores de bolsillo
+9|Traductores eléctricos de bolsillo
+9|Traductores electrónicos de bolsillo
+9|Trajes de amianto ignífugos
+9|Trajes de protección contra los accidentes, las radiaciones y el fuego
+9|Trajes de supervivencia
+9|Trajes de vuelo resistentes al fuego
+9|Trajes especiales de protección para aviadores
+9|Trajes ignífugos
+9|Transductores eléctricos
+9|Transductores electro-ópticos
+9|Transductores electroacústicos
+9|Transformadores
+9|Transformadores alta tensión
+9|Transformadores de corriente
+9|Transformadores de corriente continua
+9|Transformadores de distribución
+9|Transformadores de electricidad para amplificación
+9|Transformadores de refuerzo
+9|Transformadores de salida horizontal
+9|Transformadores de voltaje eléctrico
+9|Transformadores eléctricos
+9|Transformadores eléctricos para aparatos eléctricos
+9|Transformadores reductores
+9|Transistores
+9|Transmisores de audio
+9|Transmisores de radiofrecuencia
+9|Transmisores de señales de emergencia
+9|Transmisores de telecomunicaciones
+9|Transmisores de televisión por cable
+9|Transmisores telefónicos
+9|Transmisores y receptores inalámbricos
+9|Transmisores y receptores satelitales
+9|Transparencias fotográficas
+9|Transpondedores
+9|Transportadores de datos que contienen fuentes (tipos de letra) tipográficas guardadas
+9|Trazadores digitales
+9|Trazadores electrónicos
+9|Triángulos de señalización
+9|Triángulos de señalización de avería para vehículos
+9|Trípodes para cámaras
+9|Trípodes para máquinas de agrimensura
+9|Trípodes para telescopios
+9|Tubos de descarga eléctrica que no sean para la iluminación
+9|Tubos de microscopio
+9|Tubos de Pitot
+9|Tubos de rayos catódicos
+9|Tubos de rectificadores
+9|Tubos de telescopio
+9|Tubos de vacío para radios
+9|Tubos fotomultiplicadores
+9|Tubos intensificadores de imagen
+9|Tubos termoiónicos
+9|Ultracapacitadores para almacenamiento de energía
+9|Unidad de estado sólido (SSD)
+9|Unidades centrales de alarmas
+9|Unidades centrales de procesamiento de información, datos, sonidos e imágenes
+9|Unidades de cinta magnética (informática)
+9|Unidades de codificación electrónicas
+9|Unidades de disco
+9|Unidades de disco digitales
+9|Unidades de disco ópticas
+9|Unidades de discos compactos (CD) para computadoras
+9|Unidades de memoria de semiconductores
+9|Unidades de procesamiento central de computadores
+9|Unidades de procesamiento de gráficos (GPU)
+9|Urómetros que no sean de uso médico
+9|Vallas publicitarias electrónicas
+9|Válvulas termoiónicas
+9|Varillas de nivelación (instrumentos de agrimensura)
+9|Varillas medidoras de nivel para vehículos
+9|Variómetros
+9|Vatímetros
+9|Velocímetros para bicicleta
+9|Ventiladores de refrigeración internos para ordenadores
+9|Video casetes pregrabados con música
+9|Video casetes vírgenes
+9|Video grabadoras
+9|Video grabadoras para coches
+9|Videocámaras (cámaras de video)
+9|Videocintas pregrabadas con música
+9|Videodiscos y videocintas con dibujos animados
+9|Videodiscos y videocintas grabados con animaciones
+9|Videoteléfonos
+9|Vinilos (discos con música pregrabada)
+9|Viscosímetros
+9|Visor angular
+9|Visor de puntería para rifles (telescópicos)
+9|Visores fotográficos
+9|Visores para cámaras
+9|Voltímetros
+9|Webcams
+9|Zapatillas eléctricas con enchufes movibles
+9|Zapatos para protección contra accidentes e incendios
+9|Zumbadores eléctricos

--- a/spec/factories/terms.rb
+++ b/spec/factories/terms.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :term do
-    reference_id { 1 }
     name { "MyString" }
     nice_class
   end

--- a/spec/jobs/load_terms_from_csv_job_spec.rb
+++ b/spec/jobs/load_terms_from_csv_job_spec.rb
@@ -3,18 +3,18 @@ require 'rails_helper'
 RSpec.describe LoadTermsFromCsvJob, type: :job do
   let(:csv_content) do
     <<~CSV
-      reference_id,name
-      1,Term 1
-      2,Term 2
+      name
+      Term 1
+      Term 2
     CSV
+  end
+
+  def perform
+    described_class.perform_now(csv_content, nice_class.id)
   end
 
   context 'with valid nice class and csv file' do
     let(:nice_class) { create(:nice_class) }
-
-    def perform
-      described_class.perform_now(csv_content, nice_class.id)
-    end
 
     it 'creates terms' do
       expect { perform }.to change { nice_class.terms.count }.by(2)
@@ -23,12 +23,11 @@ RSpec.describe LoadTermsFromCsvJob, type: :job do
     it 'creates terms with correct attributes' do
       perform
 
-      expect(nice_class.terms.first.reference_id).to eq(1)
       expect(nice_class.terms.first.name).to eq('Term 1')
     end
 
     describe 'when term already exists' do
-      let!(:term) { create(:term, nice_class: nice_class, reference_id: 1) }
+      let!(:term) { create(:term, nice_class: nice_class, name: 'Term 1') }
 
       it 'does not create term' do
         expect { perform }.to change { nice_class.terms.count }.by(1)


### PR DESCRIPTION
### Contexto
​En Rnovo se quiere ayudar a los usuarios a clasificar y registrar sus marcas. El proceso de clasificación consiste en distinguir a cual/cuales de las 45 categorías de niza corresponde su marca. Para ello tenemos actualmente un listado de ~10.000 términos pero que son traducciones de la clasificación de niza original que está en inglés. Estas traducciones están en un español de españa (por lo que palabras como computador no están en la base de datos pero sí ordenador).


### Qué se esta haciendo
Encontramos un dataset de términos que se utilizan en el INAPI (instituto nacional de propiedad industrial), que están en un español "latinificado", por lo que reemplazamos los datos anteriores con los nuevos.

En el orden de los commits:
- Se actualizan los csv con las seeds
- Se modifica la forma en que se cargan los datos desde LoadTermsFromCsvJob
- Se elimina el atributo reference_id del modelo Term (era algo de los datos anteriores que no existe en estos nuevos datos).
​
#### En particular hay que revisar
​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
