### PR TITLE
feat(term): add full text search to scope

### DIFF
--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -3,7 +3,13 @@ class Term < ApplicationRecord
 
   belongs_to :nice_class
 
-  pg_search_scope :search_by_name, against: :name, using: :trigram, ignoring: :accents
+  pg_search_scope :search_by_name,
+                  against: :name,
+                  using: {
+                    tsearch: { prefix: true },
+                    trigram: {}
+                  },
+                  ignoring: :accents
 end
 
 # == Schema Information


### PR DESCRIPTION
### Contexto
Estábamos haciendo una búsqueda por trigrams pero los términos muy largos​ no estaban siendo retornados al buscar palabras cortas.

Para obtener esos términos necesitamos además obtener resultados usando full text search.

### Qué se esta haciendo
Se agrega el `tsearch:`​ a los algoritmos de búsqueda del `pg_search_scope`


#### En particular hay que revisar
​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
