### PR TITLE
feat(TmviewClient): remove default offices

### DIFF
--- a/app/clients/tmview_client.rb
+++ b/app/clients/tmview_client.rb
@@ -6,8 +6,8 @@ class TmviewClient
   def initialize(
     nice_classes: [],
     page_size: 50,
-    offices: ['CL', 'WO'],
-    territories: ['CL'],
+    offices: [],
+    territories: [],
     fields: nil
   )
     @nice_classes_numbers = nice_classes.pluck(:number)


### PR DESCRIPTION
### Contexto
Rnovo es una plataforma que permite realizar búsquedas marcarías con el objetivo de ofrecer un flujo de registro de marcas y propiedad intelectual. En dicho contexto, una de las funcionalidades clave es el poder buscar marcas en el registro marcario internacional y para comparar fonéticamente.

Como proveedor de búsqueda fonética sobre base de datos marcaría se seleccionó a la NGO tmdn.org. Donde se utiliza su buscador TmView. Para testear en staging se dejo la region de busqueda por defecto en "Chile"; sin embargo, se desea buscar en todo el mundo, por lo que se arregla eso

### Qué se esta haciendo
​
#### En particular hay que revisar
​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
