### PR TITLE
feat(term-search): group results by niceClass

### DIFF
--- a/app/javascript/locales/es.ts
+++ b/app/javascript/locales/es.ts
@@ -5,6 +5,7 @@ export const esLocale = {
   },
   termSearch: {
     classNumber: 'Clase n°',
+    numberOfTerms: 'Número de coincidencias',
     error: 'Hubo un error inesperado, inténtalo nuevamente.',
     results: 'Resultados',
     search: 'Buscar',


### PR DESCRIPTION
### Contexto
En Rnovo se quiere ayudar a los usuarios a clasificar y registrar sus marcas. El proceso de clasificación consiste en distinguir a cual/cuales de las 45 categorías de niza corresponde su marca. Para ello tenemos actualmente un listado de ~16.000 términos, y un buscador de términos.

### Qué se esta haciendo
​Hacemos que los resultados de la búsqueda se agrupen en el front por las clases a las que corresponde cada término, para mostrar de forma más ordenada las recomendaciones y la cantidad de matches que hay.

#### En particular hay que revisar
No hay diseño aun de esta parte porque aun no sabemos cómo/en qué se va a usar, por eso se ve feito​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)

https://user-images.githubusercontent.com/20784646/223454976-2b0daaed-5d63-4e3a-b3bd-a6b22469a1e3.mov


