### PR TITLE
feat(term-search): allow searching with multiple terms

### DIFF
--- a/app/javascript/locales/es.ts
+++ b/app/javascript/locales/es.ts
@@ -8,8 +8,8 @@ export const esLocale = {
     numberOfTerms: 'Número de coincidencias',
     error: 'Hubo un error inesperado, inténtalo nuevamente.',
     results: 'Resultados',
-    search: 'Buscar',
-    searchLabel: 'Buscar término',
+    search: 'Buscar términos',
+    addSearchParam: 'Agregar parámetro de búsqueda',
     showDetails: 'Ver más',
   },
   trademarkSearch: {


### PR DESCRIPTION
### Contexto
En Rnovo se quiere ayudar a los usuarios a clasificar y registrar sus marcas. El proceso de clasificación consiste en distinguir a cual/cuales de las 45 categorías de niza corresponde su marca. Para ello tenemos actualmente un listado de ~16.000 términos, y un buscador de términos.

### Qué se esta haciendo
​En un futuro cercano estaremos implementando un flujo para pedirle al usuario que liste los productos o servicios que ofrece. Por ello, necesitamos consultar por múltiples términos de búsqueda, por esto, estamos implementando una búsqueda con múltiples términos en el buscador que tenemos actualmente.

#### En particular hay que revisar
​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
![image](https://user-images.githubusercontent.com/20784646/224150083-83ebf2ae-e579-49a3-b47a-2ac0c2e230b3.png)
